### PR TITLE
Make ng-grid use scope.$eval for options

### DIFF
--- a/src/directives/ng-grid.js
+++ b/src/directives/ng-grid.js
@@ -5,7 +5,7 @@
             return {
                 pre: function ($scope, iElement, iAttrs) {
                     var $element = $(iElement);
-                    var options = $scope[iAttrs.ngGrid];
+                    var options = $scope.$eval(iAttrs.ngGrid);
                     var gridDim = new ng.Dimension({ outerHeight: $($element).height(), outerWidth: $($element).width() });
                     var grid = new ng.Grid($scope, options, gridDim, SortService);
                     var htmlText = ng.defaultGridTemplate(grid.config);


### PR DESCRIPTION
Allows me to do for example:

``` html
<div ng-grid="foo.bar.myOptions"></div>
```
