### PR TITLE
Removed non printable character from ng-grid.css

### DIFF
--- a/ng-grid.css
+++ b/ng-grid.css
@@ -1,4 +1,4 @@
-﻿
+
 /******** Grid Global ********/
 .nglabel {
     display: block;


### PR DESCRIPTION
Removed non printable character from ng-grid.css
The non-printable character was reintroduced by
change 3145f562e672030fd7614a41db9390e9fc2b5f0f by @timothyswt
