### PR TITLE
Don't detach all mousemove and mouseup events from document when resizing a column. 

### DIFF
--- a/src/classes/column.js
+++ b/src/classes/column.js
@@ -105,8 +105,8 @@
         return false;
     };
     self.gripOnMouseUp = function() {
-        $(document).off('mousemove');
-        $(document).off('mouseup');
+        $(document).off('mousemove', self.onMouseMove);
+        $(document).off('mouseup', self.gripOnMouseUp);
         event.target.parentElement.style.cursor = 'default';
         domUtilityService.digest($scope);
         return false;


### PR DESCRIPTION
ng-grid was removing all of my mouse move events which was causing bugs in my app that depended on these events. Specifying the handler in the the off call fixes this.
