### PR TITLE
Undefined columns in sortInfo

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -392,7 +392,7 @@ ng.Grid = function($scope, options, sortService, domUtilityService, $filter) {
             ng.utils.seti18n($scope, newLang);
         });
         self.maxCanvasHt = self.calcMaxCanvasHeight();
-        if (self.config.sortInfo) {
+        if (self.config.sortInfo && $scope.columns.length) {
             self.config.sortInfo.column = $scope.columns.filter(function(c) {
                 return c.field == self.config.sortInfo.field;
             })[0];


### PR DESCRIPTION
When using server side sorting, the init() method attempts to set sortInfo.columns before $scope.columns is defined (before the buildColumns method has executed). It throws an error, and the grid is not displayed on the page.

See this plunker to show my point: http://plnkr.co/edit/7pbZp4. I have attached a custom ng-grid.debug.js, and compared it to the one in the main repo. Also, please note that the sorting won't work because in the plunker I used a static json file.
