### PR TITLE
CSS input selectors too broad.

### DIFF
--- a/ng-grid.css
+++ b/ng-grid.css
@@ -232,11 +232,11 @@
     top: 11px; 
     left: 6px;
 }
-input[type="checkbox"] {
+.ngGrid input[type="checkbox"] {
 	margin: 0;
 	padding: 0;
 }
-input {
+.ngGrid input {
 	vertical-align:top;
 }
 .ngSelectionCell{


### PR DESCRIPTION
I've narrowed down the input selectors by prefixing them with the .ngGrid class.  This should now prevent any conflicts with other UI libraries, such as Bootstrap.
