### PR TITLE
Update multi-select grid key navigation behavior

### DIFF
--- a/src/classes/selectionProvider.js
+++ b/src/classes/selectionProvider.js
@@ -9,7 +9,10 @@ var ngSelectionProvider = function (grid, $scope, $parse) {
     // function to manage the selection action of a data item (entity)
     self.ChangeSelection = function (rowItem, evt) {
         // ctrl-click + shift-click multi-selections
-        if (evt && !evt.keyCode && !evt.ctrlKey && !evt.shiftKey) {
+		// up/down key navigation in multi-selections
+		var charCode = evt.which || evt.keyCode;
+		var isUpDownKeyPress = (charCode === 40 || charCode === 38);
+        if (evt && (!evt.keyCode || isUpDownKeyPress) && !evt.ctrlKey && !evt.shiftKey) {
             self.toggleSelectAll(false, true);
         }
         if (evt && evt.shiftKey && !evt.keyCode && self.multi && grid.config.enableRowSelection) {
@@ -68,7 +71,7 @@ var ngSelectionProvider = function (grid, $scope, $parse) {
                 }
                 self.setSelection(rowItem, !rowItem.selected);
             }
-        } else if (!evt.keyCode) {
+        } else if (!evt.keyCode || isUpDownKeyPress) {
             self.setSelection(rowItem, !rowItem.selected);
         }
 		self.lastClickedRow = rowItem;


### PR DESCRIPTION
Updated selectionProvider to allow the use of up/down arrow keys for
navigation and selection in multi-selection grids. If ctrl or shift use the multi-select behavior, else single selection navigation.
