### PR TITLE
Fix column sorting when called via options.sortBy API

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -500,7 +500,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
         $scope.$emit('ngGridEventChangeOrder', self.rowCache);
     };
     self.sortData = function(col, evt) {
-        if (evt.shiftKey && self.config.sortInfo) {
+        if (evt && evt.shiftKey && self.config.sortInfo) {
             var indx = self.config.sortInfo.columns.indexOf(col);
             if (indx === -1) {
                 if (self.config.sortInfo.columns.length == 1) {


### PR DESCRIPTION
I tried using the sortBy() API via $scope.gridOptions.sortBy() and ran into an error with 'evt' not being defined.  This adds the check.
