### PR TITLE
inlineAggregate support

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -261,6 +261,9 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
     }
     self.calcMaxCanvasHeight = function() {
         return (self.config.groups.length > 0) ? (self.rowFactory.parsedData.filter(function(e) {
+            if (self.config.inlineAggregate && e.isAggRow && !e.collapsed) {
+                return false;
+            }
             return !e[NG_HIDDEN];
         }).length * self.config.rowHeight) : (self.filteredRows.length * self.config.rowHeight);
     };
@@ -427,9 +430,10 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
         if (asterisksArray.length > 0) {
             self.config.maintainColumnRatios === false ? angular.noop() : self.config.maintainColumnRatios = true;
             // get the remaining width
-            var remainigWidth = self.rootDim.outerWidth - totalWidth;
+            var remainingWidth = self.rootDim.outerWidth - totalWidth;
+            remainingWidth -= self.config.groups.length * (self.config.inlineAggregate ? 125 : 25)
             // calculate the weight of each asterisk rounded down
-            var asteriskVal = Math.floor(remainigWidth / asteriskNum);
+            var asteriskVal = Math.floor(remainingWidth / asteriskNum);
             // set the width of each column based on the number of stars
             angular.forEach(asterisksArray, function(col) {
                 var t = col.width.length;

--- a/src/classes/rowFactory.js
+++ b/src/classes/rowFactory.js
@@ -73,11 +73,13 @@
         self.wasGrouped = true;
         self.parentCache = [];
         var x = 0;
-        var temp = self.parsedData.filter(function (e) {
+        var aggHeader = 0;
+        var visible = self.parsedData.filter(function (e) {
             if (e.isAggRow) {
                 if (e.parent && e.parent.collapsed) {
                     return false;
                 }
+                ++aggHeader;
                 return true;
             }
             if (!e[NG_HIDDEN]) {
@@ -85,12 +87,17 @@
             }
             return !e[NG_HIDDEN];
         });
-        self.totalRows = temp.length;
+        self.totalRows = visible.length;
         var rowArr = [];
+        var inplace = grid.config.inlineAggregate;
+        var aggCount = 0;
         for (var i = self.renderedRange.topRow; i < self.renderedRange.bottomRow; i++) {
-            if (temp[i]) {
-                temp[i].offsetTop = i * grid.config.rowHeight;
-                rowArr.push(temp[i]);
+            if (visible[i]) {
+                visible[i].offsetTop = (i - aggCount) * grid.config.rowHeight;
+                if (inplace && visible[i].isAggRow && !visible[i].collapsed) {
+                    ++aggCount
+                }
+                rowArr.push(visible[i]);
             }
         }
         grid.setRenderedRows(rowArr);
@@ -212,7 +219,7 @@
                 cols.splice(0, 0, new ngColumn({
                     colDef: {
                         field: '',
-                        width: 25,
+                        width: grid.config.inlineAggregate? 0 : 25,
                         sortable: false,
                         resizable: false,
                         headerCellTemplate: '<div class="ngAggHeader"></div>',

--- a/src/services/DomUtilityService.js
+++ b/src/services/DomUtilityService.js
@@ -73,6 +73,11 @@
             cols = $scope.columns,
             sumWidth = 0;
 
+        var groupPadding = 0;
+        if (grid.config.inlineAggregate) {
+            groupPadding = grid.config.groups.length * 125;
+        }
+
         if (!$style) {
             $style = $('#' + gridId);
             if (!$style[0]) {
@@ -82,9 +87,9 @@
         $style.empty();
         var trw = $scope.totalRowWidth();
         css = "." + gridId + " .ngCanvas { width: " + trw + "px; }" +
-            "." + gridId + " .ngRow { width: " + trw + "px; }" +
+            "." + gridId + " .ngRow { width: " + trw + "px; left: " + groupPadding + "px; }" +
             "." + gridId + " .ngCanvas { width: " + trw + "px; }" +
-            "." + gridId + " .ngHeaderScroller { width: " + (trw + domUtilityService.ScrollH) + "px}";
+            "." + gridId + " .ngHeaderScroller { width: " + (trw + domUtilityService.ScrollH) + "px; left: " + groupPadding + "px; }";
         for (var i = 0; i < cols.length; i++) {
             var col = cols[i];
             if (col.visible !== false) {


### PR DESCRIPTION
First cut of inline aggregate for #194.

When enabled, the aggregate header rows do not increment the row counter, causing the content rows to overlap with the header rows.  The content rows are then shifted with left: in .ngRow so the header arrows can still be clicked.

There are still things to be adjusted for things like the second grouping header, but it's a start.  To make the aggregate headers vertically aligned like the original issue, one can use aggregateTemplate to set top: or something similar.

![2013-05-01 11 23 53](https://f.cloud.github.com/assets/69736/449458/30cd9788-b273-11e2-90d0-adb1404de94b.png)
