### PR TITLE
Fix issue #397 - Disable outline around ngViewport when focused on some browsers.

### DIFF
--- a/ng-grid.css
+++ b/ng-grid.css
@@ -186,6 +186,9 @@
 	overflow: auto;
     min-height: 20px;
 }
+.ngViewport:focus {
+    outline: none;
+}
 
 .ngCanvas{
     position: relative;


### PR DESCRIPTION
Chrome adds by default an outline to focused text/input boxes and modal divs.

This is how all the demos at http://angular-ui.github.io/ng-grid/ looks like on Chrome without this fix:

![930d9cf4-b7fa-11e2-865f-00bd53cf9c61](https://f.cloud.github.com/assets/93081/489176/6883c360-b993-11e2-9fba-5990f15f789d.png)
