### PR TITLE
Fix - Generating lots of "Object 4 has no method 'setAttribute'" errors

### DIFF
--- a/src/classes/eventProvider.js
+++ b/src/classes/eventProvider.js
@@ -37,7 +37,7 @@
     self.setDraggables = function() {
         if (!grid.config.jqueryUIDraggable) {
             //Fix for FireFox. Instead of using jQuery on('dragstart', function) on find, we have to use addEventListeners for each column.
-            var columns = grid.$root.find('.ngHeaderSortColumn'); //have to iterate if using addEventListener
+            var columns = $.makeArray(grid.$root.find('.ngHeaderSortColumn')); //have to iterate if using addEventListener
             angular.forEach(columns, function(col){
                 col.setAttribute('draggable', 'true');
                 //jQuery 'on' function doesn't have  dataTransfer as part of event in handler unless added to event props, which is not recommended


### PR DESCRIPTION
This is my first pull request, so I'm not sure if I did everything correctly. 

Calls makeArray on results of find('.ngHearderSortColumn') so the call to forEach will not throw.
