### PR TITLE
Fix unknown column width issue

### DIFF
--- a/build/ng-grid.js
+++ b/build/ng-grid.js
@@ -1284,7 +1284,8 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
         $utils.forIn(item, function (prop, propName) {
             if (self.config.excludeProperties.indexOf(propName) == -1) {
                 self.config.columnDefs.push({
-                    field: propName
+                    field: propName,
+                    width:120
                 });
             }
         });


### PR DESCRIPTION
This allows the column definitions to have a default value for their width. I found some difficulties in loading large objects that had an unknown number of fields, so setting their widths
