### PR TITLE
scroll down not rendered rows as expected

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -706,7 +706,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             $scope.$emit('ngGridEventScroll');
         }
         var rowIndex = Math.floor(scrollTop / self.config.rowHeight);
-    	var viewPortHeightInRow = Math.ceil(self.$viewport[0].offsetHeight / self.config.rowHeight);
+        var viewPortHeightInRow = Math.ceil(self.$viewport[0].offsetHeight / self.config.rowHeight);
         var newRange;
         if (self.filteredRows.length > self.config.virtualizationThreshold) {
             // Have we hit the threshold going down?


### PR DESCRIPTION
when you scroll down, there was empty space because row generator condition didn't calculate with viewPort height.
