### PR TITLE
Fix column resets to colDef width on data update

### DIFF
--- a/src/classes/column.js
+++ b/src/classes/column.js
@@ -135,7 +135,7 @@
     self.onMouseMove = function(event) {
         var diff = event.clientX - self.startMousePosition;
         var newWidth = diff + self.origWidth;
-        self.width = (newWidth < self.minWidth ? self.minWidth : (newWidth > self.maxWidth ? self.maxWidth : newWidth));
+        self.width = config.colDef.width = (newWidth < self.minWidth ? self.minWidth : (newWidth > self.maxWidth ? self.maxWidth : newWidth));
         domUtilityService.BuildStyles($scope, grid);
         return false;
     };


### PR DESCRIPTION
There was an issue where if a column was resized and then the data updated causing the watch event to fire, the width of the column would be reset to the width of the columnDef which makes for a poor user experience.  This simple fix also sets the width in the columnDef allowing it to maintain the same width
