### PR TITLE
Ensure columns keep their position in sortInfo

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -574,7 +574,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             var i = self.config.sortInfo.fields.indexOf(c.field);
             if (i != -1) {
                 c.sortDirection = self.config.sortInfo.directions[i] || 'asc';
-                self.config.sortInfo.columns.push(c);
+                self.config.sortInfo.columns[i] = c;
             }
             return false;
         });


### PR DESCRIPTION
This problem only affect external sorting via setting the sortInfo
ojbect.
