### PR TITLE
Reset sortInfo when grid columns change

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -691,6 +691,9 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 c.sortPriority = null;
             });
             self.lastSortedColumns = [];
+			self.config.sortInfo.columns = [];
+			self.config.sortInfo.fields = [];
+			self.config.sortInfo.directions = [];
         } else {
             angular.forEach(self.lastSortedColumns, function (c) {
                 if (col.index !== c.index) {

--- a/src/directives/ng-grid.js
+++ b/src/directives/ng-grid.js
@@ -19,6 +19,7 @@
                                     return;
                                 }
                                 // we have to set this to false in case we want to autogenerate columns with no initial data.
+								grid.clearSortingData();
                                 grid.lateBoundColumns = false;
                                 $scope.columns = [];
                                 grid.config.columnDefs = a;


### PR DESCRIPTION
This fixes an error when sorting columns and then changing the grid columns. 
