### PR TITLE
Fix for #572 (broken drag&drop reordering in ng-grid-reorderable plugin)

### DIFF
--- a/plugins/ng-grid-reorderable.js
+++ b/plugins/ng-grid-reorderable.js
@@ -47,7 +47,7 @@ function ngGridReorderable () {
                 return;
             }
             self.changeRowOrder(prevRow.scope.row, rowScope.row);
-            grid.searchProvider.evalFilter();
+            self.myGrid.searchProvider.evalFilter();
             // clear out the rowToMove object
             self.services.DomUtilityService.eventStorage.rowToMove = undefined;
             // if there isn't an apply already in progress lets start one
@@ -55,12 +55,16 @@ function ngGridReorderable () {
         }
     };
     self.changeRowOrder = function (prevRow, targetRow) {
+        var i = prevRow.rowIndex;
+        var j = targetRow.rowIndex;
+        var cl = prevRow.copy();
+        // remove current row (prevRow) from it's current position
         // Splice the Rows via the actual datasource
-        var i = self.rowCache.indexOf(prevRow);
-        var j = self.rowCache.indexOf(targetRow);
         self.myGrid.rowCache.splice(i, 1);
-        self.myGrid.rowCache.splice(j, 0, prevRow);
-        self.$scope.$emit('ngGridEventChangeOrder', self.rowCache);
+        // place current row in new place
+        // placing prevRow here won't work, object must be copied
+        self.myGrid.rowCache.splice(j, 0, cl);
+        self.$scope.$emit('ngGridEventChangeOrder', self.myGrid.rowCache);
     };
     self.dragOver = function(evt) {
         evt.preventDefault();


### PR DESCRIPTION
Drag & drop wasn't working, so I've create a fix (see issue #572)
