### PR TITLE
Allow Float column width percentage and float column pixel width

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -467,8 +467,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             angular.forEach(percentArray, function(colDef) {
                 // Get the ngColumn that matches the current column from columnDefs
                 var ngColumn = $scope.columns[indexMap[colDef.index]];
-                var t = colDef.width;
-                var percent = parseInt(t.slice(0, -1), 10) / 100;
+                var percent = parseFloat(colDef.width) / 100;
                 percentWidth += percent;
 
                 if (!ngColumn.visible) {
@@ -483,8 +482,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 var ngColumn = $scope.columns[indexMap[colDef.index]];
                 
                 // Calc the % relative to the amount of % reserved for the visible columns (that use % based widths)
-                var t = colDef.width;
-                var percent = parseInt(t.slice(0, -1), 10) / 100;
+                var percent = parseFloat(colDef.width) / 100;
                 if (hiddenPercent > 0) {
                     percent = percent / percentWidthUsed;
                 }
@@ -493,7 +491,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 }
 
                 var pixelsForPercentBasedWidth = self.rootDim.outerWidth * percentWidth;
-                ngColumn.width = Math.floor(pixelsForPercentBasedWidth * percent);
+                ngColumn.width = pixelsForPercentBasedWidth * percent;
                 totalWidth += ngColumn.width;
             });
         }


### PR DESCRIPTION
Pixel width of columns was parsed to Int, eg 2.35% became 0.02 not 0.0235. The resulting pixelWidth was also floored to int, 60.6 became 60 resulting in whitespace in my grid.
