### PR TITLE
fix for searching object properties that are not lowercase

### DIFF
--- a/src/classes/searchProvider.js
+++ b/src/classes/searchProvider.js
@@ -8,6 +8,17 @@
 
     self.fieldMap = {};
 
+    var convertToFieldMap = function(obj) {
+
+        var fieldMap = {};
+        for (var prop in obj) {
+            if (obj.hasOwnProperty(prop)) {
+                fieldMap[prop.toLowerCase()] = obj[prop];
+            }
+        }
+        return fieldMap;
+    };
+
     var searchEntireRow = function(condition, item, fieldMap){
         var result;
         for (var prop in item) {
@@ -18,7 +29,8 @@
                 }
                 var pVal = item[prop];
                 if(typeof pVal === 'object'){
-                    return searchEntireRow(condition, pVal, c);
+                    var objectFieldMap = convertToFieldMap(c);
+                    return searchEntireRow(condition, pVal, objectFieldMap);
                 } else {
                     var f = null,
                         s = null;


### PR DESCRIPTION
This is a pull request for issue #634.

This attempts to fix an issue where the filter does not apply to properties defined on an object (in a column definintion).
