### PR TITLE
Fix for #668 - Default header template ngSorted style should only be applied during an active sort

### DIFF
--- a/src/templates/headerCellTemplate.html
+++ b/src/templates/headerCellTemplate.html
@@ -1,4 +1,4 @@
-<div class="ngHeaderSortColumn {{col.headerClass}}" ng-style="{'cursor': col.cursor}" ng-class="{ 'ngSorted': !noSortVisible }">
+<div class="ngHeaderSortColumn {{col.headerClass}}" ng-style="{'cursor': col.cursor}" ng-class="{ 'ngSorted': !col.noSortVisible() }">
     <div ng-click="col.sort($event)" ng-class="'colt' + col.index" class="ngHeaderText">{{col.displayName}}</div>
     <div class="ngSortButtonDown" ng-show="col.showSortButtonDown()"></div>
     <div class="ngSortButtonUp" ng-show="col.showSortButtonUp()"></div>


### PR DESCRIPTION
The issue is located in headerCell Template, line 1:

ng-class="{ 'ngSorted': !noSortVisible }"

This is only testing for the existence of the noSortVisible function, not actually invoking the method.  Pull request correctly invokes the method.

BEFORE: http://plnkr.co/edit/IVbkGFAKGATKgyitdrrD?p=preview

AFTER: http://plnkr.co/edit/ZbRQZHTL0XMx1jyShdb1?p=preview
