### PR TITLE
Dynamically change multiSelect

### DIFF
--- a/src/classes/selectionProvider.js
+++ b/src/classes/selectionProvider.js
@@ -7,6 +7,16 @@ var ngSelectionProvider = function (grid, $scope, $parse) {
     self.ignoreSelectedItemChanges = false; // flag to prevent circular event loops keeping single-select var in sync
     self.pKeyParser = $parse(grid.config.primaryKey);
 
+    // If multiSelect value is a string, bind it to the corresponding variable, as with data.
+    // This way we can watch for updates and therefore dynamically toggle multiSelect.
+    if(typeof grid.config.multiSelect === 'string') {
+        $scope.$parent.$watch(grid.config.multiSelect, function (newMultiSelectValue) {
+            self.multi = newMultiSelectValue;
+        });
+    } else {
+        self.multi = grid.config.multiSelect;
+    }
+
     // function to manage the selection action of a data item (entity)
     self.ChangeSelection = function (rowItem, evt) {
         // ctrl-click + shift-click multi-selections


### PR DESCRIPTION
I have two views with ng-grid and they're almost the same except the fact that one should allow multiSelect and another shouldn't.
I can render it two times with different options but since the grid is quite huge it takes long time.
It would be better to be able to dynamically change its behavior; however now configuration is read just once — before rendering — and it's impossible to change it afterwards.

I made some changes, so now it behaves exactly like the data parameter: you can either pass a value or a string. In  case of the string we simply bind and watch it.
