### PR TITLE
added padding on UL and removed relative position on LI in column menu

### DIFF
--- a/src/less/menu.less
+++ b/src/less/menu.less
@@ -19,12 +19,11 @@
 
 .ngColList {
     list-style-type: none;
+    margin-top:2px;
+    margin-left:8px;
 }
 
 .ngColListItem {
-    position: relative;
-    right: 17px;
-    top: 2px;
     white-space:nowrap;
 }
 


### PR DESCRIPTION
Hello.
I was just having trouble with the relative position on LI if we already have a CSS design for LI that remove list-style and padding:  the relative position make the checkbox go out of the frame of the column menu.

But we don't need the relative position i we remove the padding, and it does not interfere with other design.
Could you take a look of that very small modification (and it is also my first pull request and i hope it respect the needed standards)
