### PR TITLE
template was modified to search first in the $templateCache.

### DIFF
--- a/src/classes/column.js
+++ b/src/classes/column.js
@@ -54,21 +54,21 @@
         self.editableCellTemplate = colDef.editableCellTemplate || $templateCache.get('editableCellTemplate.html');
     }
     if (colDef.cellTemplate && !TEMPLATE_REGEXP.test(colDef.cellTemplate)) {
-        self.cellTemplate = $.ajax({
+        self.cellTemplate = $templateCache.get(colDef.cellTemplate) || $.ajax({
             type: "GET",
             url: colDef.cellTemplate,
             async: false
         }).responseText;
     }
     if (self.enableCellEdit && colDef.editableCellTemplate && !TEMPLATE_REGEXP.test(colDef.editableCellTemplate)) {
-        self.editableCellTemplate = $.ajax({
+        self.editableCellTemplate = $templateCache.get(colDef.editableCellTemplate) || $.ajax({
             type: "GET",
             url: colDef.editableCellTemplate,
             async: false
         }).responseText;
     }
     if (colDef.headerCellTemplate && !TEMPLATE_REGEXP.test(colDef.headerCellTemplate)) {
-        self.headerCellTemplate = $.ajax({
+        self.headerCellTemplate = $templateCache.get(colDef.headerCellTemplate) || $.ajax({
             type: "GET",
             url: colDef.headerCellTemplate,
             async: false


### PR DESCRIPTION
some template use to preload from markup

```
    <script type="text/ng-template" id="cell-thumbnail.html">
        <img src="{{row.getProperty('thumbnail')}}" width="30px" height="30px"><span>{{row.getProperty('from')}}</span>
    </script>

```

text/ng-template load into $templateCache.
so i changed to search first in the $templateCache.
