### PR TITLE
Update searchProvider to look for values in properties that come after the first object

### DIFF
--- a/src/classes/searchProvider.js
+++ b/src/classes/searchProvider.js
@@ -18,7 +18,10 @@
                 }
                 var pVal = item[prop];
                 if(typeof pVal === 'object'){
-                    return searchEntireRow(condition, pVal, c);
+                    result = searchEntireRow(condition, pVal, c);
+                    if (result) {
+                        return true;
+                    }
                 } else {
                     var f = null,
                         s = null;

--- a/test/unit/directivesSpec.js
+++ b/test/unit/directivesSpec.js
@@ -414,8 +414,49 @@ describe('directives', function () {
                 });
             });
             describe('searchProvider', function () {
-                it('should do something', function () {
-                    //add work here
+                beforeEach(inject(function ($rootScope, $domUtilityService, $templateCache, $compile) {
+                    $scope = $rootScope.$new();
+                    $dUtils = $domUtilityService;
+                    $linker = $compile;
+                    $cache = $templateCache;
+
+                    elm = angular.element(
+                        '<div ng-grid="gridOptions" style="width: 1000px; height: 1000px"></div>'
+                    );
+                    scope = $rootScope;
+
+                    scope.filterOptions = {
+                    filterText: ''
+                    };
+
+                    scope.myData = [{name: "Moroni", obj1: {age: 50}, obj2: {grade: 'one'} },
+                                    {name: "Tiancum", obj1: {age: 43}, obj2: {grade: 'two'} },
+                                    {name: "Jacob", obj1: {age: 27}, obj2: {grade: 'three'} },
+                                    {name: "Nephi", obj1: {age: 29}, obj2: {grade: 'four'} },
+                                    {name: "Enos", obj1: {age: 34}, obj2: {grade: 'five'} }];
+
+                    scope.gridOptions = {
+                    data: 'myData',
+                    filterOptions: scope.filterOptions,
+                    showFooter: true,
+                    columnDefs: [
+                                 { field: 'name' },
+                                 { field: 'obj1.age' },
+                                 { field: 'obj2.grade' }
+                                 ]
+                    };
+					
+                    $compile(elm)(scope);
+                    scope.$digest();
+                }));
+
+                it('should find values in properties that come after the first object', function() {
+                    expect(elm.find('.ngFooterTotalItems').text()).toContain(5);
+                    
+                    // Enter search text
+                    scope.filterOptions.filterText = 'two';
+                    scope.$digest();
+                    expect(elm.find('.ngFooterTotalItems').text()).toContain('Showing Items: 1');
                 });
             });
             describe('selectionProvider', function () {


### PR DESCRIPTION
Filtering doesn't look at all properties of an object before returning the result. It just returns the result of filtering in the first object and the rest of the properties are ignored.
