### PR TITLE
pass $utils to ngColumn instantiation

### DIFF
--- a/src/classes/column.js
+++ b/src/classes/column.js
@@ -150,7 +150,7 @@
         return false;
     };
     self.copy = function() {
-        var ret = new ngColumn(config, $scope, grid, domUtilityService, $templateCache);
+        var ret = new ngColumn(config, $scope, grid, domUtilityService, $templateCache, $utils);
         ret.isClone = true;
         ret.orig = self;
         return ret;


### PR DESCRIPTION
heavy column virtualization fails with below trace without this change.

TypeError: Cannot call method 'isNullOrUndefined' of undefined
    at new C (http://localhost:8080/vendor/ng-grid/ng-grid-2.0.7.min.js:1:11351)
    at c.copy (http://localhost:8080/vendor/ng-grid/ng-grid-2.0.7.min.js:1:14134)
    at c (http://localhost:8080/vendor/ng-grid/ng-grid-2.0.7.min.js:1:31772)
    at Scope.i.adjustScrollLeft (http://localhost:8080/vendor/ng-grid/ng-grid-2.0.7.min.js:1:31954)
    at Object.n.RebuildGrid (http://localhost:8080/vendor/ng-grid/ng-grid-2.0.7.min.js:1:5922)
    at Object.fn (http://localhost:8080/vendor/ng-grid/ng-grid-2.0.7.min.js:2:16537)
    at Scope.$digest (http://localhost:8080/vendor/angular/angular.js:10569:27)
    at Scope.$apply (http://localhost:8080/vendor/angular/angular.js:10802:24)
    at done (http://localhost:8080/vendor/angular/angular.js:6937:45)
    at completeRequest (http://localhost:8080/vendor/angular/angular.js:7102:7) 
