### PR TITLE
Added InterpolateUpdateService for easy updating of the interpolation symbols in templates

### DIFF
--- a/src/services/InterpolateUpdateService.js
+++ b/src/services/InterpolateUpdateService.js
@@ -21,10 +21,10 @@
         for (var i = 0; i < templates.length; i++){
             var template = templates[i];
             var curTemplate = $templateCache.get(template);
-            if (start != "}}"){
+            if (start !== "}}"){
                 curTemplate = curTemplate.replace(/\{\{/g, start);
             }
-            if (end != "}}"){
+            if (end !== "}}"){
                 curTemplate = curTemplate.replace(/\}\}/g, end);
             }
             $templateCache.put(template, curTemplate);


### PR DESCRIPTION
I'm currently working on a Django project and was having some issues with the Angular string interpolation since I changed the default symbols to not collide with Django's template symbols.  I've added a new service to update the interpolation symbols for the templates in $templateCache.   This service can be used like so (after setting up your custom interpolation symbols):

```
    angular.module("ngGrid").run(["$InterpolateUpdateService", function($InterpolateUpdateService){
        $InterpolateUpdateService.changeGridInterpolate();
    }]);
```

This is my first Angular project, so please review this commit carefully if you are considering accepting it.  I haven't gotten a chance to write tests for it yet, but I am willing to do so, if you think this is a good patch.
