### PR TITLE
Fixed issue where clearing the filter is slow after a sort operation.  T...

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -803,7 +803,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             newRange = new ngRange(Math.max(0, rowIndex - EXCESS_ROWS), rowIndex + self.minRowsToRender() + EXCESS_ROWS);
         } else {
             var maxLen = $scope.configGroups.length > 0 ? self.rowFactory.parsedData.length : self.data.length;
-            newRange = new ngRange(0, Math.max(maxLen, self.minRowsToRender() + EXCESS_ROWS));
+            newRange = new ngRange(0, Math.min(maxLen, self.minRowsToRender() + EXCESS_ROWS));
         }
         self.prevScrollTop = scrollTop;
         self.rowFactory.UpdateViewableRange(newRange);

--- a/src/directives/ng-grid.js
+++ b/src/directives/ng-grid.js
@@ -74,6 +74,7 @@
                             $scope.$parent.$watch(options.data, dataWatcher);
                             $scope.$parent.$watch(options.data + '.length', function() {
                                 dataWatcher($scope.$eval(options.data));
+								$scope.adjustScrollTop(grid.$viewport.scrollTop(), true);
                             });
                         }
                         


### PR DESCRIPTION
Fixed issue #777 where clearing the filter is slow after a sort operation. The renderedRange was incorrectly being set to the whole of the source data.
