### PR TITLE
Added updateOnCellChange to options.

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -117,6 +117,9 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
         //Set this to false if you only want one item selected at a time
         multiSelect: true,
 
+        //Set to true to watch for changes on cell data. This is more costly, so only use when needed.
+        updateOnCellDataChange: false,
+
         // pagingOptions -
         pagingOptions: {
             // pageSizes: list of available page sizes.

--- a/src/directives/ng-grid.js
+++ b/src/directives/ng-grid.js
@@ -71,7 +71,7 @@
                                 }
                                 $scope.$emit("ngGridEventData", grid.gridId);
                             };
-                            $scope.$parent.$watch(options.data, dataWatcher);
+                            $scope.$parent.$watch(options.data, dataWatcher, options.updateOnCellDataChange);
                             $scope.$parent.$watch(options.data + '.length', function() {
                                 dataWatcher($scope.$eval(options.data));
 								$scope.adjustScrollTop(grid.$viewport.scrollTop(), true);


### PR DESCRIPTION
Added the option to watch for object equality changes on grid data. This is needed to trigger the dataWatcher listener function when the value of a row changes. The new option is called updateOnCellDataChange (and could perhaps need a better name) and defaults to false as to not affect the current implementation or performance.
