### PR TITLE
Second attempt to fix #777, still ensuring the rendering row count is sensible

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -802,8 +802,8 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             }
             newRange = new ngRange(Math.max(0, rowIndex - EXCESS_ROWS), rowIndex + self.minRowsToRender() + EXCESS_ROWS);
         } else {
-            var maxLen = $scope.configGroups.length > 0 ? self.rowFactory.parsedData.length : self.data.length;
-            newRange = new ngRange(0, Math.min(maxLen, self.minRowsToRender() + EXCESS_ROWS));
+            var maxLen = $scope.configGroups.length > 0 ? self.rowFactory.parsedData.length : self.filteredRows.length;
+            newRange = new ngRange(0, Math.max(maxLen, self.minRowsToRender() + EXCESS_ROWS));
         }
         self.prevScrollTop = scrollTop;
         self.rowFactory.UpdateViewableRange(newRange);


### PR DESCRIPTION
The original issue was that when filtering dropped the filtered row count to under the virtualisation limit the formula used gave the total data source length as a result, leading to potentially very large numbers of rendered rows.

The first attempt to fix misinterpreted the role of various variables, and was incorrect.  This led to parts of the grid not rendering under some circumstances.

This fix corrects that misunderstanding, and reverts the original formula but substituting `filteredRows.length` for `data.length` still avoiding the rendering of the data source length number of rows. 
