### PR TITLE
Add a new option - noTabInterference.

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -184,7 +184,10 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
         i18n: 'en',
         
         //the threshold in rows to force virtualization on
-        virtualizationThreshold: 50
+        virtualizationThreshold: 50,
+
+	// Don't handle tabs, so they can be used to navigate between controls.
+	noTabInterference: false
     },
         self = this;
     self.maxCanvasHt = 0;

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -16,7 +16,7 @@ var ngMoveSelectionHandler = function($scope, elm, evt, grid) {
         newColumnIndex = visibleCols.indexOf($scope.col);
     }
 
-    if (charCode !== 37 && charCode !== 38 && charCode !== 39 && charCode !== 40 && charCode !== 9 && charCode !== 13) {
+    if (charCode !== 37 && charCode !== 38 && charCode !== 39 && charCode !== 40 && (grid.config.noTabInterference || charCode !== 9) && charCode !== 13) {
         return true;
     }
     


### PR DESCRIPTION
Setting this option prevents tabs from being processed by the control,
and are instead used to switch between controls. This makes pages more
accessible because it prevents the grid from becoming a keyboard trap.

Keyboard traps are not permitted by [WCAG 2.0 guideline 2.1.1](http://www.w3.org/TR/2008/REC-WCAG20-20081211/#keyboard-operation-keyboard-operable) even at an A level of accessiblity, and so without this change, ng-grid cannot be used in environments that mandate compliance with WCAG.
