### PR TITLE
Fix searches of dates that have filters applied to them

### DIFF
--- a/src/classes/searchProvider.js
+++ b/src/classes/searchProvider.js
@@ -17,7 +17,7 @@
                     continue;
                 }
                 var pVal = item[prop];
-                if(typeof pVal === 'object'){
+                if(typeof pVal === 'object' && !(pVal instanceof Date)) {
                     result = searchEntireRow(condition, pVal, c);
                     if (result) {
                         return true;
@@ -31,7 +31,8 @@
                     }
                     if (pVal !== null && pVal !== undefined) {
                         if (typeof f === "function") {
-                            var filterRes = f(pVal, s[1]).toString();
+                            // Have to slice off the quotes the parser would have removed
+                            var filterRes = f(pVal, s[1].slice(1,-1)).toString();
                             result = condition.regex.test(filterRes);
                         } else {
                             result = condition.regex.test(pVal.toString());
@@ -79,10 +80,10 @@
                 result = searchEntireRow(condition, item, self.fieldMap);
             } else {
                 result = searchColumn(condition, item);
-            }     
+            }
             if(!result) {
                 return false;
-            }      
+            }
         }
         return true;
     };
@@ -98,7 +99,7 @@
         for (var i = 0; i < grid.filteredRows.length; i++)
         {
             grid.filteredRows[i].rowIndex = i;
-            
+
         }
         grid.rowFactory.filteredRowsChanged();
     };

--- a/test/unit/directivesSpec.js
+++ b/test/unit/directivesSpec.js
@@ -35,7 +35,7 @@ describe('directives', function () {
         $compile(elm)(scope);
         scope.$digest();
     }));
-    
+
     describe('ng-cell-has-focus', function() {
         it('should do something', function() {
             //add work here
@@ -126,7 +126,7 @@ describe('directives', function () {
                     });
                 }));
             });
-            
+
             describe('column', function () {
                 describe('cell editing', function () {
                     var elm, element, $scope, $compile, $sniffer;
@@ -194,14 +194,14 @@ describe('directives', function () {
                         );
 
                         $scope.myData = [
-                            { 
+                            {
                                 address: '123 Main St',
                                 person: {
                                     name: 'Bob',
                                     age: 20
                                 }
                             },
-                            { 
+                            {
                                 address: '1600 Pennsylvania Ave.',
                                 person: {
                                     name: 'Barack',
@@ -321,7 +321,7 @@ describe('directives', function () {
                                          {name: "Jacob", age: 27},
                                          {name: "Nephi", age: 29},
                                          {name: "Enos", age: 34}];
-                
+
                     scope.gridOptions = {
                         data: 'myData',
                         totalServerItems: 357
@@ -429,11 +429,12 @@ describe('directives', function () {
                     filterText: ''
                     };
 
-                    scope.myData = [{name: "Moroni", obj1: {age: 50}, obj2: {grade: 'one'} },
-                                    {name: "Tiancum", obj1: {age: 43}, obj2: {grade: 'two'} },
-                                    {name: "Jacob", obj1: {age: 27}, obj2: {grade: 'three'} },
-                                    {name: "Nephi", obj1: {age: 29}, obj2: {grade: 'four'} },
-                                    {name: "Enos", obj1: {age: 34}, obj2: {grade: 'five'} }];
+                    scope.myData = [
+                        {name: "Moroni",  obj1: {age: 50}, birthdate: new Date(1963, 9, 13, 5,6,7,0), obj2: {grade: 'one'} },
+                        {name: "Tiancum", obj1: {age: 43}, birthdate: new Date(1970, 2, 13, 8,5,4,0), obj2: {grade: 'two'} },
+                        {name: "Jacob",   obj1: {age: 27}, birthdate: new Date(1989, 3, 13, 4,4,3,0), obj2: {grade: 'three'} },
+                        {name: "Nephi",   obj1: {age: 29}, birthdate: new Date(1987, 4, 13, 7,3,2,0), obj2: {grade: 'four'} },
+                        {name: "Enos",    obj1: {age: 34}, birthdate: new Date(1979, 5, 13, 9,2,1,0), obj2: {grade: 'five'} }];
 
                     scope.gridOptions = {
                     data: 'myData',
@@ -442,21 +443,42 @@ describe('directives', function () {
                     columnDefs: [
                                  { field: 'name' },
                                  { field: 'obj1.age' },
-                                 { field: 'obj2.grade' }
+                                 { field: 'birthdate', cellFilter: "date:'MM-dd-yyyy'" },
+                                 { field: 'obj2.grade'}
                                  ]
                     };
-					
+
                     $compile(elm)(scope);
                     scope.$digest();
                 }));
 
                 it('should find values in properties that come after the first object', function() {
                     expect(elm.find('.ngFooterTotalItems').text()).toContain(5);
-                    
+
                     // Enter search text
                     scope.filterOptions.filterText = 'two';
                     scope.$digest();
                     expect(elm.find('.ngFooterTotalItems').text()).toContain('Showing Items: 1');
+                });
+                it('should find formatted dates', function() {
+                    expect(elm.find('.ngFooterTotalItems').text()).toContain(5);
+
+                    // Enter search text
+                    scope.filterOptions.filterText = '10-13-1963';
+                    scope.$digest();
+                    expect(elm.find('.ngFooterTotalItems').text()).toContain('Showing Items: 1');
+
+                    scope.filterOptions.filterText = '-13-';
+                    scope.$digest();
+                    expect(elm.find('.ngFooterTotalItems').text()).toContain('Showing Items: 5');
+                });
+                it('should find values string fields case insensitively', function() {
+                    expect(elm.find('.ngFooterTotalItems').text()).toContain(5);
+
+                    // Enter search text (should find enos and nephi) + (one and three)
+                    scope.filterOptions.filterText = 'E';
+                    scope.$digest();
+                    expect(elm.find('.ngFooterTotalItems').text()).toContain('Showing Items: 4');
                 });
             });
             describe('selectionProvider', function () {


### PR DESCRIPTION
Bumped into this bug while trying to filter by date.  Seems that dates are objects, so if you want to be able to search/filter them when they have a date filter.

Added 2 or 3 new test cases and all of them pass.  One test does not pass, but it was broken when I got it.
