### PR TITLE
Fix for: Sorting when external sorting is enabled is broken

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -614,7 +614,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             } else {
                 self.config.sortInfo.directions[indx] = col.sortDirection;
             }
-        } else if (evt && self.config.sortInfo ) {
+        } else if (!self.config.useExternalSorting || (self.config.useExternalSorting && evt && self.config.sortInfo )) {
             var isArr = $.isArray(col);
             self.config.sortInfo.columns.length = 0;
             self.config.sortInfo.fields.length = 0;


### PR DESCRIPTION
Provides fix for the following condition:
When external sorting is enabled, attempting to sort via multiple
columns is futile because as soon as you click the column, all of the
sorting turns off.  The problem is related NG-Grid improperly handling
an unexpected DOM event.
