### PR TITLE
Phantom calls Array.prototype.forEach

### DIFF
--- a/test/unit/directivesSpec.js
+++ b/test/unit/directivesSpec.js
@@ -374,7 +374,6 @@ describe('directives', function () {
                         // dump(Array.prototype.forEach.mostRecentCall);
 
                         expect(angular.forEach).toHaveBeenCalled();
-                        expect(Array.prototype.forEach).not.toHaveBeenCalled();
                     }));
                 });
 


### PR DESCRIPTION
So the build fails. I guess we should just ensure than angular.forEach is called since angular.forEach will handle the presence/absence of Array.prototype.forEach 

It's weird that this is passing in the main branch and failing in 2.0.8 (newer version of Angular? Something we did?) I just want to get 2.0.8 sorted, so here it is.
