### PR TITLE
IE string sorting workaround

### DIFF
--- a/src/services/SortService.js
+++ b/src/services/SortService.js
@@ -113,7 +113,7 @@
                 };
                 data.sort();
                 Object.prototype.toString = origToStringFn;
-                var direction = sortInfo.directions[0];
+                direction = sortInfo.directions[0];
                 if (direction !== ASC) {
                     data.reverse();
                 }


### PR DESCRIPTION
The sorting performance is very bad in IE. I have a grid of 30k rows and it takes ~20s to sort a column in IE10. This is a workaround for IE. It can speed up sorting by >10 times in the most popular case when sorting a single row whose data type is string. It can't cover other cases such as rows with number type or multiple row sorting, and falls back to standard sorting. The tweak is discussed here: http://blog.vjeux.com/2009/javascript/speed-up-javascript-sort.html. The other library SlickGrid also uses the same trick.

You can check the performance out from this plnkr: http://plnkr.co/edit/4u3EDk?p=preview
In my environment: 20s (first column) vs 400ms (2nd column)
