### PR TITLE
Fixing the viewport height math - fixes scrollbar

### DIFF
--- a/plugins/ng-grid-flexible-height.js
+++ b/plugins/ng-grid-flexible-height.js
@@ -18,7 +18,7 @@ function ngGridFlexibleHeightPlugin (opts) {
                 }
             }
 
-            var newViewportHeight = naturalHeight + 2;
+            var newViewportHeight = naturalHeight + 3;
             if (!self.scope.baseViewportHeight || self.scope.baseViewportHeight !== newViewportHeight) {
                 self.grid.$viewport.css('height', newViewportHeight + 'px');
                 self.grid.$root.css('height', (newViewportHeight + extraHeight) + 'px');


### PR DESCRIPTION
The calculation for newViewportHeight is off by 1px in webkit-based browsers. In cases where the actual grid height is less than the grid's max-height (even if a max-height hasn't been set) vertical-overflow scrollbars are appended to the DOM. Increasing the newViewPort by 1px corrects this issue.
