### PR TITLE
Update ng-grid-flexible-height.js

### DIFF
--- a/plugins/ng-grid-flexible-height.js
+++ b/plugins/ng-grid-flexible-height.js
@@ -43,7 +43,7 @@ function ngGridFlexibleHeightPlugin (opts) {
             hash += grid.$canvas.prop('scrollWidth');
             hash += grid.$canvas.prop('scrollHeight');
             return hash;
-        }
+        };
 
         self.scope.$watch('catHashKeys()', innerRecalcForData);
         self.scope.$watch('sizeHash()', innerRecalcForData);


### PR DESCRIPTION
Now, plugin watch for all size changes. Also plugin can understand when we have horizontal scrollbar and add 15px to height. So if we have horizontal scrollbar, all rows will be visible.
