### PR TITLE
Update eventProvider.js

### DIFF
--- a/src/classes/eventProvider.js
+++ b/src/classes/eventProvider.js
@@ -14,9 +14,9 @@
             });
         } else {
             grid.$groupPanel.on('mousedown', self.onGroupMouseDown).on('dragover', self.dragOver).on('drop', self.onGroupDrop);
-            grid.$headerScroller.on('mousedown', self.onHeaderMouseDown).on('dragover', self.dragOver);
+            grid.$topPanel.on('mousedown', '.ngHeaderScroller', self.onHeaderMouseDown).on('dragover', '.ngHeaderScroller', self.dragOver);
             if (grid.config.enableColumnReordering) {
-                grid.$headerScroller.on('drop', self.onHeaderDrop);
+                grid.$topPanel.on('drop', '.ngHeaderScroller', self.onHeaderDrop);
             }
         }
         $scope.$watch('renderedColumns', function() {


### PR DESCRIPTION
Fixes issue with breaking changes for ngInclude in Angular 1.2.0 that broke the native column header drag&drop.
See: https://github.com/angular/angular.js/issues/3806
See also: https://github.com/angular-ui/ng-grid/issues/702
