### PR TITLE
Ignore unnecessary files in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,18 @@
 {
   "name": "ng-grid",
   "version": "2.0.7",
-  "main": ["./ng-grid.min.css", "./build/ng-grid.min.js"]
+  "main": ["./ng-grid.min.css", "./build/ng-grid.min.js"],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "config",
+    "lib",
+    "scripts",
+    "src",
+    "test",
+    "workbench",
+    "conf.js",
+    "GruntFile.js"
+  ]
 }


### PR DESCRIPTION
It's considered a good practice to ignore any unnecessary files in bower so people aren't forced to download them all (eg. tests, build/deploy scripts, src files, etc.)

I've left the build folder, markdown files (README, CHANGELOG, etc.), and the assets at the root of the directory. This should be everything that a person would need for bower.

https://github.com/bower/bower#defining-a-package
