### PR TITLE
Inin v2.0.7 fixes

### DIFF
--- a/src/classes/eventProvider.js
+++ b/src/classes/eventProvider.js
@@ -14,16 +14,16 @@
             });
         } else {
             grid.$groupPanel.on('mousedown', self.onGroupMouseDown).on('dragover', self.dragOver).on('drop', self.onGroupDrop);
-            grid.$headerScroller.on('mousedown', self.onHeaderMouseDown).on('dragover', self.dragOver);
+            grid.$topPanel.on('mousedown', '.ngHeaderScroller', self.onHeaderMouseDown).on('dragover', '.ngHeaderScroller', self.dragOver);
             if (grid.config.enableColumnReordering && !grid.config.enablePinning) {
-                grid.$headerScroller.on('drop', self.onHeaderDrop);
+                grid.$topPanel.on('drop', '.ngHeaderScroller', self.onHeaderDrop);
             }
         }
         $scope.$watch('renderedColumns', function() {
             $timeout(self.setDraggables);
         });
     };
-    self.dragStart = function(evt){		
+    self.dragStart = function(evt){
       //FireFox requires there to be dataTransfer if you want to drag and drop.
       evt.dataTransfer.setData('text', ''); //cannot be empty string
     };
@@ -173,37 +173,38 @@
     };
 
     self.assignGridEventHandlers = function() {
-        //Chrome and firefox both need a tab index so the grid can recieve focus.
-        //need to give the grid a tabindex if it doesn't already have one so
-        //we'll just give it a tab index of the corresponding gridcache index 
-        //that way we'll get the same result every time it is run.
-        //configurable within the options.
+        var windowThrottle;
+        var parentThrottle;
+
+        function onWindowResize(){
+            clearTimeout(windowThrottle);
+            windowThrottle = setTimeout(function() {
+                domUtilityService.RebuildGrid($scope,grid);
+            }, 100);
+        }
+
+        function onParentResize() {
+            clearTimeout(parentThrottle);
+            parentThrottle = setTimeout(function() {
+                domUtilityService.RebuildGrid($scope,grid);
+            }, 100);
+        }
+
         if (grid.config.tabIndex === -1) {
             grid.$viewport.attr('tabIndex', domUtilityService.numberOfGrids);
             domUtilityService.numberOfGrids++;
         } else {
             grid.$viewport.attr('tabIndex', grid.config.tabIndex);
         }
-        // resize on window resize
-        var windowThrottle;
-        $(window).resize(function(){
-            clearTimeout(windowThrottle);
-            windowThrottle = setTimeout(function() {
-                //in function for IE8 compatibility
-                domUtilityService.RebuildGrid($scope,grid);
-            }, 100);
-        });
-        // resize on parent resize as well.
-        var parentThrottle;
-        $(grid.$root.parent()).on('resize', function() {
-            clearTimeout(parentThrottle);
-            parentThrottle = setTimeout(function() {
-                //in function for IE8 compatibility
-                domUtilityService.RebuildGrid($scope,grid);
-            }, 100);
+
+        $(window).on('resize', onWindowResize);
+        $(grid.$root.parent()).on('resize', onParentResize);
+
+        $scope.$on('$destroy', function() {
+            $(grid.$root.parent()).off('resize', onParentResize);
+            $(window).off('resize', onWindowResize);
         });
     };
-    // In this example we want to assign grid events.
     self.assignGridEventHandlers();
     self.assignEvents();
 };

--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -467,8 +467,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             angular.forEach(percentArray, function(colDef) {
                 // Get the ngColumn that matches the current column from columnDefs
                 var ngColumn = $scope.columns[indexMap[colDef.index]];
-                var t = colDef.width;
-                var percent = parseInt(t.slice(0, -1), 10) / 100;
+                var percent = parseFloat(colDef.width) / 100;
                 percentWidth += percent;
 
                 if (!ngColumn.visible) {
@@ -483,8 +482,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 var ngColumn = $scope.columns[indexMap[colDef.index]];
                 
                 // Calc the % relative to the amount of % reserved for the visible columns (that use % based widths)
-                var t = colDef.width;
-                var percent = parseInt(t.slice(0, -1), 10) / 100;
+                var percent = parseFloat(colDef.width) / 100;
                 if (hiddenPercent > 0) {
                     percent = percent / percentWidthUsed;
                 }
@@ -493,7 +491,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 }
 
                 var pixelsForPercentBasedWidth = self.rootDim.outerWidth * percentWidth;
-                ngColumn.width = Math.floor(pixelsForPercentBasedWidth * percent);
+                ngColumn.width = pixelsForPercentBasedWidth * percent;
                 totalWidth += ngColumn.width;
             });
         }

--- a/src/classes/rowFactory.js
+++ b/src/classes/rowFactory.js
@@ -110,13 +110,10 @@
 
     self.fixRowCache = function () {
         var newLen = grid.data.length;
-        var diff = newLen - grid.rowCache.length;
-        if (diff < 0) {
-            grid.rowCache.length = grid.rowMap.length = newLen;
-        } else {
-            for (var i = grid.rowCache.length; i < newLen; i++) {
-                grid.rowCache[i] = grid.rowFactory.buildEntityRow(grid.data[i], i);
-            }
+        grid.rowCache.length = grid.rowMap.length = newLen;
+        for (var i = 0; i < newLen; i++) {
+            grid.rowMap[i] = i;
+            grid.rowCache[i] = grid.rowFactory.buildEntityRow(grid.data[i], i);
         }
     };
 

--- a/src/directives/ng-grid.js
+++ b/src/directives/ng-grid.js
@@ -7,6 +7,7 @@
                     var $element = $(iElement);
                     var options = $scope.$eval(iAttrs.ngGrid);
                     options.gridDim = new ngDimension({ outerHeight: $($element).height(), outerWidth: $($element).width() });
+					options.watchData = typeof options.watchData !== 'undefined' ? options.watchData : true;
 
                     var grid = new ngGrid($scope, options, sortService, domUtilityService, $filter, $templateCache, $utils, $timeout, $parse, $http, $q);
                     return grid.init().then(function() {
@@ -50,18 +51,11 @@
                         }
                         
                         // if it is a string we can watch for data changes. otherwise you won't be able to update the grid data
-                        if (typeof options.data === "string") {
+                        if (options.watchData && typeof options.data === "string") {
                             var dataWatcher = function (a) {
-                                // make a temporary copy of the data
+				// make a temporary copy of the data
                                 grid.data = $.extend([], a);
                                 grid.rowFactory.fixRowCache();
-                                angular.forEach(grid.data, function (item, j) {
-                                    var indx = grid.rowMap[j] || j;
-                                    if (grid.rowCache[indx]) {
-                                        grid.rowCache[indx].ensureEntity(item);
-                                    }
-                                    grid.rowMap[indx] = j;
-                                });
                                 grid.searchProvider.evalFilter();
                                 grid.configureColumnWidths();
                                 grid.refreshDomSizes();
@@ -71,10 +65,19 @@
                                 }
                                 $scope.$emit("ngGridEventData", grid.gridId);
                             };
-                            $scope.$parent.$watch(options.data, dataWatcher);
-                            $scope.$parent.$watch(options.data + '.length', function() {
-                                dataWatcher($scope.$eval(options.data));
-                            });
+
+                            if (options.watchData === 'deep') {
+                                $scope.$parent.$watch(options.data, dataWatcher, true);
+                            }
+                            else if (typeof $scope.$parent.$watchCollection === 'function') {
+                                $scope.$parent.$watchCollection(options.data, dataWatcher, true);
+                            }
+                            else {
+                                $scope.$parent.$watch(options.data, dataWatcher);
+                                $scope.$parent.$watch(options.data + '.length', function() {
+                                    dataWatcher($scope.$eval(options.data));
+                                });
+                            }
                         }
                         
                         grid.footerController = new ngFooter($scope, grid);

--- a/src/directives/ng-input.js
+++ b/src/directives/ng-input.js
@@ -26,7 +26,7 @@ ngGridDirectives.directive('ngInput', [function() {
                         }
                         break;
                     case 13: // Enter (Leave Field)
-                        if(scope.enableCellEditOnFocus && scope.totalFilteredItemsLength() - 1 > scope.row.rowIndex && scope.row.rowIndex > 0  || scope.enableCellEdit) {
+                        if(scope.enableCellEditOnFocus && scope.totalFilteredItemsLength() - 1 >= scope.row.rowIndex && scope.row.rowIndex >= 0  || scope.enableCellEdit) {
                             elm.blur();
                         }
                         break;

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -96,7 +96,7 @@ var ngMoveSelectionHandler = function($scope, elm, evt, grid) {
     
     if (offset) {
         var r = items[rowIndex + offset];
-        if (r.beforeSelectionChange(r, evt)) {
+        if (r && r.beforeSelectionChange(r, evt)) {
             r.continueSelection(evt);
             $scope.$emit('ngGridEventDigestGridParent');
 


### PR DESCRIPTION
- #645 : external filtering and sorting breaks selection
- #632 : watching array.length does not always work
- #893 : Edit mode of first and last row of grid doesn't respond to
  enter key
- #938 : $(window).resize not unhooked when $scope destroyed, causing
  leaks/performance problems
- #3806 : angular 1.2.0+ broke drag/drop on the ng-grid columns (And
  thus re-ordering didn't work either)
