### PR TITLE
fix: Allow colDef.name to be empty string

### DIFF
--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -180,7 +180,7 @@
        * validates that name or field is present
        */
       Grid.prototype.preprocessColDef = function (colDef) {
-        if (!colDef.field && !colDef.name) {
+        if (colDef.field === undefined && colDef.name === undefined) {
           throw new Error('colDef.name or colDef.field property is required');
         }
 


### PR DESCRIPTION
In my case some column names were empty strings (I loaded CSV).

I think it is reasonable to allow empty column names.
