### PR TITLE
Call $render method of NgModelController to reflect the original value

### DIFF
--- a/src/directives/ng-input.js
+++ b/src/directives/ng-input.js
@@ -8,7 +8,7 @@ ngGridDirectives.directive('ngInput', [function() {
                 oldCellValue = ngModel.$modelValue;
                 dereg(); // only run this watch once, we don't want to overwrite our stored value when the input changes
             });
-            
+
             elm.bind('keydown', function(evt) {
                 switch (evt.keyCode) {
                     case 37: // Left arrow
@@ -21,6 +21,7 @@ ngGridDirectives.directive('ngInput', [function() {
                         if (!scope.$$phase) {
                             scope.$apply(function() {
                                 ngModel.$setViewValue(oldCellValue);
+                                ngModel.$render();
                                 elm.blur();
                             });
                         }
@@ -37,11 +38,11 @@ ngGridDirectives.directive('ngInput', [function() {
 
             elm.bind('click', function(evt) {
                 evt.stopPropagation();
-            }); 
+            });
 
             elm.bind('mousedown', function(evt) {
                 evt.stopPropagation();
-            }); 
+            });
 
             scope.$on('ngGridEventStartCellEdit', function () {
                 elm.focus();


### PR DESCRIPTION
In the default implementation of the ng-input directive, sometimes the original value is NOT displayed, when the "ESC key" is pressed. I guess that this cause is the following processes:

(1) NgModelController.$setViewValue() called. -> The scope.row.entity.**\* value is changed.
(2) element.blur() called.
(3) $rootScope.$digest() called. -> The scope.row.entity.**\* value is re-written by the new value.

To commit the 1st value change, NgModelController.$render() method should be called after calling the $setViewValue() method.
