### PR TITLE
Fix row.getProperty() for numeric column names

### DIFF
--- a/src/services/UtilityService.js
+++ b/src/services/UtilityService.js
@@ -26,7 +26,7 @@
             }
         },
         evalProperty: function (entity, path) {
-            return $parse(path)(entity);
+            return $parse("entity." + path)({ entity: entity });
         },
         endsWith: function(str, suffix) {
             if (!str || !suffix || typeof str !== "string") {


### PR DESCRIPTION
If a column name is numeric and a custom template is used, `{{row.getProperty(col.field)}}` displays the column name instead of the cell value.

Plunker: http://plnkr.co/edit/yElmST?p=preview
