### PR TITLE
ng-grid-csv-export.js: only stringify properties

### DIFF
--- a/plugins/ng-grid-csv-export.js
+++ b/plugins/ng-grid-csv-export.js
@@ -14,7 +14,12 @@ function ngGridCsvExportPlugin (opts) {
         self.scope = scope;
         function showDs() {
             var keys = [];
-            for (var f in grid.config.columnDefs) { keys.push(grid.config.columnDefs[f].field);}
+            for (var f in grid.config.columnDefs) { 
+                if (grid.config.columnDefs.hasOwnProperty(f))
+                {   
+                    keys.push(grid.config.columnDefs[f].field);
+                }   
+            }   
             var csvData = '';
             function csvStringify(str) {
                 if (str == null) { // we want to catch anything null-ish, hence just == not ===


### PR DESCRIPTION
- Only try to iterate over own properties in columnDefs.
