### PR TITLE
2.0.8 - fix bug for programmatic change of sortInfo

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -623,7 +623,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             } else {
                 self.config.sortInfo.directions[indx] = col.sortDirection;
             }
-        } else if (!self.config.useExternalSorting || (self.config.useExternalSorting && evt && self.config.sortInfo )) {
+        } else if (!self.config.useExternalSorting || (self.config.useExternalSorting && self.config.sortInfo )) {
             var isArr = $.isArray(col);
             self.config.sortInfo.columns.length = 0;
             self.config.sortInfo.fields.length = 0;

--- a/test/unit/directivesSpec.js
+++ b/test/unit/directivesSpec.js
@@ -377,6 +377,56 @@ describe('directives', function () {
                     }));
                 });
 
+                describe('sortData', function (){
+                    it('should properly sort even when no event is passed ( programatically )', inject(function($rootScope, $compile) {
+                        var sortOptions = angular.extend( scope.gridOptions, {
+                            useExternalSorting: true,
+                            columnDefs: [
+                                { field:'name' },
+                                { field:'age' }
+                            ],
+                            sortInfo: { fields: ['name'], directions: [ 'asc' ] }
+                        });
+
+                        var elm = angular.element(
+                            '<div ng-grid="gridOptions" style="width: 1000px; height: 1000px"></div>'
+                        );
+                        $compile(elm)($rootScope);
+                        $rootScope.$digest();
+
+                        //checking that the arrow is displayed on the correct row in the correct orientation
+                        //and the other columns are not changed
+                        expect( elm.find('.ngHeaderSortColumn:last .ngSortButtonUp').hasClass('ng-hide')).toBe( true );
+                        expect( elm.find('.ngHeaderSortColumn:first .ngSortButtonUp').hasClass('ng-hide')).toBe( true );
+                        expect( elm.find('.ngHeaderSortColumn:last .ngSortButtonDown').hasClass('ng-hide')).toBe( true );
+                        expect( elm.find('.ngHeaderSortColumn:first .ngSortButtonDown').hasClass('ng-hide')).toBe( false ); //the first column ( name ) show be sorted asc
+
+                        //programatically trigger sort
+                        sortOptions.sortInfo.fields[0] = 'age';
+                        $rootScope.$digest();
+
+                        //checking that the arrow is displayed on the correct row in the correct orientation
+                        //and the other columns are not changed
+                        expect( elm.find('.ngHeaderSortColumn:last .ngSortButtonUp').hasClass('ng-hide')).toBe( true );
+                        expect( elm.find('.ngHeaderSortColumn:first .ngSortButtonUp').hasClass('ng-hide')).toBe( true );
+                        expect( elm.find('.ngHeaderSortColumn:last .ngSortButtonDown').hasClass('ng-hide')).toBe( false ); //the second column ( age ) show be sorted asc
+                        expect( elm.find('.ngHeaderSortColumn:first .ngSortButtonDown').hasClass('ng-hide')).toBe( true );
+
+                        //programatically trigger sort
+                        sortOptions.sortInfo.fields[0] = 'name';
+                        sortOptions.sortInfo.directions[0] = 'desc';
+                        $rootScope.$digest();
+
+                        //checking that the arrow is displayed on the correct row in the correct orientation
+                        //and the other columns are not changed
+                        expect( elm.find('.ngHeaderSortColumn:last .ngSortButtonUp').hasClass('ng-hide')).toBe( true );
+                        expect( elm.find('.ngHeaderSortColumn:first .ngSortButtonUp').hasClass('ng-hide')).toBe( false ); //the first column ( name ) show be sorted desc
+                        expect( elm.find('.ngHeaderSortColumn:last .ngSortButtonDown').hasClass('ng-hide')).toBe( true );
+                        expect( elm.find('.ngHeaderSortColumn:first .ngSortButtonDown').hasClass('ng-hide')).toBe( true );
+
+                    }));
+                });
+
                 describe('sortActual', function(){
                     it('should maintain row selection post-sort', function(){
                         scope.gridOptions.selectItem(0, true);


### PR DESCRIPTION
This patch fixes a bug where when a user programmatically changed the sortInfo reference, the previously sorted column would maintain its sort arrow.

I found that this is due to an addition in 2.0.8 in the sortData method of the grid class. The else condition checks for an event. If the event is not present this block is never entered and the sort is not rendered properly. This is easily fixed by removing the check for the event, I could not see a use for the check for event ( I could be wrong ) :).

I've added tests to ensure the arrow renders only in the spot it is intended.
