### PR TITLE
check for null references on $destroy and updateGridLayout

### DIFF
--- a/src/classes/eventProvider.js
+++ b/src/classes/eventProvider.js
@@ -21,7 +21,9 @@
             grid.$topPanel.on('mousedown', '.ngHeaderScroller', self.onHeaderMouseDown).on('dragover', '.ngHeaderScroller', self.dragOver);
 
             grid.$groupPanel.on('$destroy', function() {
-                grid.$groupPanel.off('mousedown');
+                if (grid.$groupPanel){
+                    grid.$groupPanel.off('mousedown');
+                }
 
                 grid.$groupPanel = null;
             });
@@ -31,9 +33,11 @@
             }
 
             grid.$topPanel.on('$destroy', function() {
-                grid.$topPanel.off('mousedown');
+                if (grid.$topPanel){
+                    grid.$topPanel.off('mousedown');
+                }
 
-                if (grid.config.enableColumnReordering) {
+                if (grid.config.enableColumnReordering && grid.$topPanel) {
                     grid.$topPanel.off('drop');
                 }
 

--- a/src/services/DomUtilityService.js
+++ b/src/services/DomUtilityService.js
@@ -70,6 +70,9 @@
         return width;
     };
     domUtilityService.UpdateGridLayout = function($scope, grid) {
+        if (!grid.$root){
+            return;
+        }
         //catch this so we can return the viewer to their original scroll after the resize!
         var scrollTop = grid.$viewport.scrollTop();
         grid.elementDims.rootMaxW = grid.$root.width();


### PR DESCRIPTION
This is a proposed fix for https://github.com/angular-ui/ng-grid/issues/1130 ( admittedly hacky )

It's defensive in nature and just checks if references are null before calling a method on them. I was running into instances where on routeChange, $destroy was being called several times and throwing an error.
