### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
   ],
   "dependencies": {
     "jquery": "^1.8.0",
-    "angularjs": "^1.0.8"
+    "angular": "^1.0.8"
   }
 }


### PR DESCRIPTION
Fix angular dependancy in bower.json.
The official angular framework is known as angular, not as angularjs in bower registry.
