### PR TITLE
Fixed wrong angular dependency name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
   ],
   "dependencies": {
     "jquery": "^1.8.0",
-    "angularjs": "^1.0.8"
+    "angular": "^1.0.8"
   }
 }


### PR DESCRIPTION
"angular" is the angularjs library. "angularjs" is the repository for the site angularjs.org. The current release is breaking bower installs.
