### PR TITLE
Fixing filtering bugs

### DIFF
--- a/src/classes/searchProvider.js
+++ b/src/classes/searchProvider.js
@@ -30,7 +30,7 @@
 		else {
 			return [value];
 		}
-	}
+	};
 	
     var searchEntireRow = function(condition, item, fieldMap){
         var result;


### PR DESCRIPTION
Example Plunker: plnkr.co/edit/nL1dvjMAnuvHdHPgGv9L

The s array gets created with a split on character ':' .
If the cellFilter is a simple one like 'currency', than s[1] will be undefined and calling slice on it will throw an exception.
