### PR TITLE
Auto-size column should consider width of aggregate columns

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -417,8 +417,8 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                     origIndex--;
                 }
                 indexMap[origIndex] = i;
-            }else if(ngCol.isAggCol && ngCol.visible){ // aggregate columns are 25px in length. 
-            	totalWidth+=25;
+            } else if (ngCol.isAggCol && ngCol.visible){ // aggregate columns are 25px in length. 
+                totalWidth+=25;
             }
         });
 


### PR DESCRIPTION
Currently the aggregate columns are not considered when you have auto sized columns. This usually will force a scrollbar which in many cases is undesirable. 
In my use case, I hide the column being grouped by (e.g. grouping by 'date' hides the 'date' column), but even though I have a few auto columns when I group by it goes passed the width I set. Forcing an ugly scroll when there are only a few columns.
I know that you guys aren't really supporting 2.0.X any more but it would be a big boon as I know many other devs have had this issue. 
