### PR TITLE
fixed retrieving value for group header from booleans

### DIFF
--- a/src/classes/rowFactory.js
+++ b/src/classes/rowFactory.js
@@ -195,7 +195,7 @@
                 var col = filterCols(cols, group)[0];
 
                 var val = $utils.evalProperty(model, group);
-                val = val ? val.toString() : 'null';
+                val = val != null? val.toString() : 'null';
                 if (!ptr[val]) {
                     ptr[val] = {};
                 }


### PR DESCRIPTION
When grouping by a column with boolean values the grouping is not correct.

http://plnkr.co/edit/FeTf4DN7hIx7ZJSdQgTO?p=preview

When grouping by the 'test' column instead of getting 3 groups: 'true', 'false' and 'null' 'false' and 'null' are grouped together into 'null'

https://github.com/angular-ui/ng-grid/blob/master/src/classes/rowFactory.js#L198 should check if val != null
