### PR TITLE
Allow jQuery 2.x or 1.8+ versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "GruntFile.js"
   ],
   "dependencies": {
-    "jquery": "^1.8.0",
+    "jquery": ">=1.8.0",
     "angular": "^1.0.8"
   }
 }


### PR DESCRIPTION
I was getting this during a bower install.  No reason to pin to the 1.x branch for this project.

```
Unable to find a suitable version for jquery, please choose one:
    1) jquery#^1.8.0 which resolved to 1.11.1 and is required by angular-grid#2.0.11 
    2) jquery#2.1.1 which resolved to 2.1.1 and is required by ice 
    3) jquery#>= 2.1.0 which resolved to 2.1.1 and is required by foundation#5.2.2 
```
