### PR TITLE
quick fix for issue #1202

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -435,8 +435,10 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 t = isPercent ? colDef.width : parseInt(colDef.width, 10);
             }
 
+             // has bug for resize event causing NaN for all column width after another http.get
+             // if (isNaN(t) && !$scope.hasUserChangedGridColumnWidths) {
              // check if it is a number
-            if (isNaN(t) && !$scope.hasUserChangedGridColumnWidths) {
+            if (isNaN(t)) {
                 t = colDef.width;
                 // figure out if the width is defined or if we need to calculate it
                 if (t === 'auto') { // set it for now until we have data and subscribe when it changes so we can set the width.


### PR DESCRIPTION
#1202

after resize column + http.get causes all column missing (col.width = NaN)

has bug for resize event causing NaN for all column width after another http.get

Remark: Do user really will set the column with into NaN seriously? If no then following changes will do
