### PR TITLE
Fix performance hit in the CSV export plugin.

### DIFF
--- a/plugins/ng-grid-csv-export.js
+++ b/plugins/ng-grid-csv-export.js
@@ -51,6 +51,7 @@ function ngGridCsvExportPlugin (opts) {
             csvData = swapLastCommaForNewline(csvData);
             var gridData = grid.data;
             for (var gridRow in gridData) {
+                var rowData = '';
                 for ( k in keys) {
                     var curCellRaw;
 
@@ -61,9 +62,9 @@ function ngGridCsvExportPlugin (opts) {
                         curCellRaw = self.services.UtilityService.evalProperty(gridData[gridRow], keys[k]);
                     }
 
-                    csvData += '"' + csvStringify(curCellRaw) + '",';
+                    rowData += '"' + csvStringify(curCellRaw) + '",';
                 }
-                csvData = swapLastCommaForNewline(csvData);
+                csvData = swapLastCommaForNewline(rowData);
             }
             var fp = grid.$root.find(".ngFooterPanel");
             var csvDataLinkPrevious = grid.$root.find('.ngFooterPanel .csv-data-link-span');


### PR DESCRIPTION
The previous version of the plugin scanned the entire csvData set when replacing the last comma with a newline. This is a huge performance hit for large datasets.

This version only scans the current row to replace the comma with a newline.
