### PR TITLE
Fix typo in README.md (Grunfile.js->Gruntfile.js).

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Default grunt task will test and build files into dist/
 
 # Developing
 
-Development "watch" task. This will automatically rebuild from source on changes, reload Grunfile.js if you change it, and rebuild the docs.
+Development "watch" task. This will automatically rebuild from source on changes, reload Gruntfile.js if you change it, and rebuild the docs.
 1. A server on localhost:9002 serving whichever directory you checked out, with livereload. Navigate to http://localhost:9002/misc/demo to see the [demo files](http://localhost:9002/misc/demo/grid-directive.html).
 2. A server on localhost:9003 serving the ./docs directory. These are the docs built from source with a custom grunt-ngdocs that should work with Angular 1.2.4.
 


### PR DESCRIPTION
In the Developing section of the README.md, there is a typo: "Grunfile.js" is written instead of "Gruntfile.js". This fixes that.
