### PR TITLE
Bug fix for filtered select and de-select

### DIFF
--- a/src/classes/selectionProvider.js
+++ b/src/classes/selectionProvider.js
@@ -141,19 +141,24 @@ var ngSelectionProvider = function (grid, $scope, $parse) {
     // @return - boolean indicating if all items are selected or not
     // @val - boolean indicating whether to select all/de-select all
     self.toggleSelectAll = function (checkAll, bypass, selectFiltered) {
-        var rows = selectFiltered ? grid.filteredRows : grid.rowCache;
+        var rows = selectFiltered ? grid.filteredRows : grid.rowCache, wasSelected, index;
         if (bypass || grid.config.beforeSelectionChange(rows, checkAll)) {
-            var selectedlength = self.selectedItems.length;
-            if (selectedlength > 0) {
+            if (!selectFiltered && self.selectedItems.length > 0) {
                 self.selectedItems.length = 0;
             }
             for (var i = 0; i < rows.length; i++) {
+                wasSelected = rows[i].selected;
                 rows[i].selected = checkAll;
                 if (rows[i].clone) {
                     rows[i].clone.selected = checkAll;
                 }
-                if (checkAll) {
+                if (!wasSelected && checkAll) {
                     self.selectedItems.push(rows[i].entity);
+                } else if (wasSelected && !checkAll) {
+                    index = self.selectedItems.indexOf(rows[i].entity);
+                    if (index > -1) {
+                        self.selectedItems.splice(index, 1);
+                    }
                 }
             }
             if (!bypass) {


### PR DESCRIPTION
Currently, when selectionBox is enabled with non-empty filter text, the toggleSelectAll is not behaving correctly, which causes inconsistency between selected row number and display of checkboxes of those rows. Because the original code tried to wipe out all other selections whether selectFilter option is true or not, which should not be the case. When selectFilter option is on, invisible rows selection shouldn't be affected.

Easy steps to reproduce:
1. Go to this plucker: http://plnkr.co/edit/gwJMKcNvrnk6FA60T2r7?p=preview
2. Click header checkbox to select All.
3. On the top filter input box, type in "Jacob"
4. Click header checkbox to De-select.
5. Look at footer info stating "Selected Items 0"
6. Clear the filter box.
7. All other rows looked still selected but they are actually not.
