### PR TITLE
chore(performance): remove class interpolation and do manual add/remove ...

### DIFF
--- a/src/js/core/directives/ui-grid-col.js
+++ b/src/js/core/directives/ui-grid-col.js
@@ -1,0 +1,20 @@
+(function(){
+  'use strict';
+
+  angular.module('ui.grid').directive('uiGridCol', [function() {
+    return {
+      link: {
+        post: function($scope, $elm) {
+          $elm.addClass('col' + $scope.col.index);
+          $scope.$watch('col.index', function (newValue, oldValue) {
+            if (newValue === oldValue) { return; }
+            var className = $elm.attr('class');
+            className = className.replace('col' + oldValue, 'col' + newValue);
+            $elm.attr('class', className);
+          });
+        }
+      }
+    };
+  }]);
+
+})();

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -1,153 +1,162 @@
 (function(){
+  'use strict';
 
-angular.module('ui.grid').directive('uiGridHeaderCell', ['$log', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', function ($log, $timeout, $window, $document, gridUtil, uiGridConstants) {
-  // Do stuff after mouse has been down this many ms on the header cell
-  var mousedownTimeout = 500;
+  angular.module('ui.grid').directive('uiGridHeaderCell', ['$log', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', function ($log, $timeout, $window, $document, gridUtil, uiGridConstants) {
+    // Do stuff after mouse has been down this many ms on the header cell
+    var mousedownTimeout = 500;
 
-  var uiGridHeaderCell = {
-    priority: 0,
-    scope: {
-      col: '=',
-      row: '=',
-      renderIndex: '='
-    },
-    require: '?^uiGrid',
-    templateUrl: 'ui-grid/uiGridHeaderCell',
-    replace: true,
-    link: function ($scope, $elm, $attrs, uiGridCtrl) {
-      $scope.grid = uiGridCtrl.grid;
+    var uiGridHeaderCell = {
+      priority: 0,
+      scope: {
+        col: '=',
+        row: '=',
+        renderIndex: '='
+      },
+      require: '?^uiGrid',
+      templateUrl: 'ui-grid/uiGridHeaderCell',
+      replace: true,
+      link: function ($scope, $elm, $attrs, uiGridCtrl) {
+        $scope.grid = uiGridCtrl.grid;
 
-      // Hide the menu by default
-      $scope.menuShown = false;
-
-      // Put asc and desc sort directions in scope
-      $scope.asc = uiGridConstants.ASC;
-      $scope.desc = uiGridConstants.DESC;
-
-      // Store a reference to menu element
-      var $colMenu = angular.element( $elm[0].querySelectorAll('.ui-grid-header-cell-menu') );
-
-      var $contentsElm = angular.element( $elm[0].querySelectorAll('.ui-grid-cell-contents') );
-
-      // Figure out whether this column is sortable or not
-      if (uiGridCtrl.grid.options.enableSorting && $scope.col.enableSorting) {
-        $scope.sortable = true;
-      }
-      else {
-        $scope.sortable = false;
-      }
-
-      if (uiGridCtrl.grid.options.enableFiltering && $scope.col.enableFiltering) {
-        $scope.filterable = true;
-      }
-      else {
-        $scope.filterable = false;
-      }
-
-      function handleClick(evt) {
-        // If the shift key is being held down, add this column to the sort
-        var add = false;
-        if (evt.shiftKey) {
-          add = true;
-        }
-
-        // Sort this column then rebuild the grid's rows
-        uiGridCtrl.grid.sortColumn($scope.col, add)
-          .then(function () {
-            uiGridCtrl.columnMenuCtrl.hideMenu();
-            uiGridCtrl.refresh();
-          });
-      }
-
-      // Long-click (for mobile)
-      var cancelMousedownTimeout;
-      var mousedownStartTime = 0;
-      $contentsElm.on('mousedown', function(event) {
-        if (typeof(event.originalEvent) !== 'undefined' && event.originalEvent !== undefined) {
-          event = event.originalEvent;
-        }
-
-        // Don't show the menu if it's not the left button
-        if (event.button && event.button !== 0) {
-          return;
-        }
-
-        mousedownStartTime = (new Date()).getTime();
-
-        cancelMousedownTimeout = $timeout(function() { }, mousedownTimeout);
-
-        cancelMousedownTimeout.then(function () {
-          uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+        $elm.addClass('col' + $scope.col.index);
+        $scope.$watch('col.index', function (newValue, oldValue) {
+          if (newValue === oldValue) { return; }
+          var className = $elm.attr('class');
+          className = className.replace('col' + oldValue, 'col' + newValue);
+          $elm.attr('class', className);
         });
-      });
 
-      $contentsElm.on('mouseup', function () {
-        $timeout.cancel(cancelMousedownTimeout);
-      });
+        // Hide the menu by default
+        $scope.menuShown = false;
 
-      $scope.toggleMenu = function($event) {
-        $event.stopPropagation();
+        // Put asc and desc sort directions in scope
+        $scope.asc = uiGridConstants.ASC;
+        $scope.desc = uiGridConstants.DESC;
 
-        // If the menu is already showing...
-        if (uiGridCtrl.columnMenuCtrl.shown) {
-          // ... and we're the column the menu is on...
-          if (uiGridCtrl.columnMenuCtrl.col === $scope.col) {
-            // ... hide it
-            uiGridCtrl.columnMenuCtrl.hideMenu();
+        // Store a reference to menu element
+        var $colMenu = angular.element( $elm[0].querySelectorAll('.ui-grid-header-cell-menu') );
+
+        var $contentsElm = angular.element( $elm[0].querySelectorAll('.ui-grid-cell-contents') );
+
+        // Figure out whether this column is sortable or not
+        if (uiGridCtrl.grid.options.enableSorting && $scope.col.enableSorting) {
+          $scope.sortable = true;
+        }
+        else {
+          $scope.sortable = false;
+        }
+
+        if (uiGridCtrl.grid.options.enableFiltering && $scope.col.enableFiltering) {
+          $scope.filterable = true;
+        }
+        else {
+          $scope.filterable = false;
+        }
+
+        function handleClick(evt) {
+          // If the shift key is being held down, add this column to the sort
+          var add = false;
+          if (evt.shiftKey) {
+            add = true;
           }
-          // ... and we're NOT the column the menu is on
+
+          // Sort this column then rebuild the grid's rows
+          uiGridCtrl.grid.sortColumn($scope.col, add)
+            .then(function () {
+              uiGridCtrl.columnMenuCtrl.hideMenu();
+              uiGridCtrl.refresh();
+            });
+        }
+
+        // Long-click (for mobile)
+        var cancelMousedownTimeout;
+        var mousedownStartTime = 0;
+        $contentsElm.on('mousedown', function(event) {
+          if (typeof(event.originalEvent) !== 'undefined' && event.originalEvent !== undefined) {
+            event = event.originalEvent;
+          }
+
+          // Don't show the menu if it's not the left button
+          if (event.button && event.button !== 0) {
+            return;
+          }
+
+          mousedownStartTime = (new Date()).getTime();
+
+          cancelMousedownTimeout = $timeout(function() { }, mousedownTimeout);
+
+          cancelMousedownTimeout.then(function () {
+            uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+          });
+        });
+
+        $contentsElm.on('mouseup', function () {
+          $timeout.cancel(cancelMousedownTimeout);
+        });
+
+        $scope.toggleMenu = function($event) {
+          $event.stopPropagation();
+
+          // If the menu is already showing...
+          if (uiGridCtrl.columnMenuCtrl.shown) {
+            // ... and we're the column the menu is on...
+            if (uiGridCtrl.columnMenuCtrl.col === $scope.col) {
+              // ... hide it
+              uiGridCtrl.columnMenuCtrl.hideMenu();
+            }
+            // ... and we're NOT the column the menu is on
+            else {
+              // ... move the menu to our column
+              uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+            }
+          }
+          // If the menu is NOT showing
           else {
-            // ... move the menu to our column
+            // ... show it on our column
             uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
           }
+        };
+
+        // If this column is sortable, add a click event handler
+        if ($scope.sortable) {
+          $contentsElm.on('click', function(evt) {
+            evt.stopPropagation();
+
+            $timeout.cancel(cancelMousedownTimeout);
+
+            var mousedownEndTime = (new Date()).getTime();
+            var mousedownTime = mousedownEndTime - mousedownStartTime;
+
+            if (mousedownTime > mousedownTimeout) {
+              // long click, handled above with mousedown
+            }
+            else {
+              // short click
+              handleClick(evt);
+            }
+          });
+
+          $scope.$on('$destroy', function () {
+            // Cancel any pending long-click timeout
+            $timeout.cancel(cancelMousedownTimeout);
+          });
         }
-        // If the menu is NOT showing
-        else {
-          // ... show it on our column
-          uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+
+        if ($scope.filterable) {
+          $scope.$on('$destroy', $scope.$watch('col.filter.term', function(n, o) {
+            uiGridCtrl.refresh()
+              .then(function () {
+                if (uiGridCtrl.prevScrollArgs && uiGridCtrl.prevScrollArgs.y && uiGridCtrl.prevScrollArgs.y.percentage) {
+                   uiGridCtrl.fireScrollingEvent({ y: { percentage: uiGridCtrl.prevScrollArgs.y.percentage } });
+                }
+                // uiGridCtrl.fireEvent('force-vertical-scroll');
+              });
+          }));
         }
-      };
-      
-      // If this column is sortable, add a click event handler
-      if ($scope.sortable) {
-        $contentsElm.on('click', function(evt) {
-          evt.stopPropagation();
-
-          $timeout.cancel(cancelMousedownTimeout);
-
-          var mousedownEndTime = (new Date()).getTime();
-          var mousedownTime = mousedownEndTime - mousedownStartTime;
-
-          if (mousedownTime > mousedownTimeout) {
-            // long click, handled above with mousedown
-          }
-          else {
-            // short click
-            handleClick(evt);
-          }
-        });
-
-        $scope.$on('$destroy', function () {
-          // Cancel any pending long-click timeout
-          $timeout.cancel(cancelMousedownTimeout);
-        });
       }
+    };
 
-      if ($scope.filterable) {
-        $scope.$on('$destroy', $scope.$watch('col.filter.term', function(n, o) {
-          uiGridCtrl.refresh()
-            .then(function () {
-              if (uiGridCtrl.prevScrollArgs && uiGridCtrl.prevScrollArgs.y && uiGridCtrl.prevScrollArgs.y.percentage) {
-                 uiGridCtrl.fireScrollingEvent({ y: { percentage: uiGridCtrl.prevScrollArgs.y.percentage } });
-              }
-              // uiGridCtrl.fireEvent('force-vertical-scroll');
-            });
-        }));
-      }
-    }
-  };
-
-  return uiGridHeaderCell;
-}]);
+    return uiGridHeaderCell;
+  }]);
 
 })();

--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -11,12 +11,13 @@
 
       // Extend options with ui-grid attribute reference
       self.grid = gridClassFactory.createGrid($scope.uiGrid);
+      $elm.addClass('grid' + self.grid.id);
 
 
       //add optional reference to externalScopes function to controller
       //so it can be retrieved in lower elements that have isolate scope
       self.getExternalScopes = $scope.getExternalScopes;
-      
+
       // angular.extend(self.grid.options, );
 
       //all properties of grid are available on scope
@@ -27,7 +28,7 @@
         $log.info('pre-compiling cell templates');
         columns.forEach(function (col) {
           var html = col.cellTemplate.replace(uiGridConstants.COL_FIELD, 'getCellValue(row, col)');
-          
+
           var compiledElementFn = $compile(html);
           col.compiledElementFn = compiledElementFn;
         });
@@ -196,7 +197,7 @@
         var p2 = self.grid.processColumnsProcessors(self.grid.columns).then(function (renderableColumns) {
           self.grid.setVisibleColumns(renderableColumns);
         });
-        
+
         return $q.all([p1, p2]).then(function () {
           self.redrawInPlace();
 
@@ -207,7 +208,7 @@
       // Redraw the rows and columns based on our current scroll position
       self.redrawInPlace = function redrawInPlace() {
         $log.debug('redrawInPlace');
-        
+
         for (var i in self.grid.renderContainers) {
           var container = self.grid.renderContainers[i];
 
@@ -219,7 +220,7 @@
       };
 
       /* Sorting Methods */
-      
+
 
       /* Event Methods */
 
@@ -233,7 +234,7 @@
         if (typeof(args) === 'undefined' || args === undefined) {
           args = {};
         }
-        
+
         if (typeof(args.grid) === 'undefined' || args.grid === undefined) {
           args.grid = self.grid;
         }
@@ -251,7 +252,7 @@
  *  @param {Object} uiGrid Options for the grid to use
  *  @param {Object=} external-scopes Add external-scopes='someScopeObjectYouNeed' attribute so you can access
  *            your scopes from within any custom templatedirective.  You access by $scope.getExternalScopes() function
- *  
+ *
  *  @description Create a very basic grid.
  *
  *  @example

--- a/src/templates/ui-grid/ui-grid-row.html
+++ b/src/templates/ui-grid/ui-grid-row.html
@@ -1,5 +1,5 @@
 <div>
-  <div ng-repeat="col in container.renderedColumns track by $index" class="ui-grid-cell col{{ col.index }}">
+  <div ng-repeat="col in container.renderedColumns track by $index" class="ui-grid-cell" ui-grid-col>
     <div class="ui-grid-vertical-bar">&nbsp;</div>
     <div class="ui-grid-inner-cell-contents" ui-grid-cell col="col" row="row" row-index="row.index" col-index="col.colDef.index" />
   </div>

--- a/src/templates/ui-grid/ui-grid.html
+++ b/src/templates/ui-grid/ui-grid.html
@@ -1,4 +1,4 @@
-<div ui-i18n="en" class="ui-grid grid{{ grid.id }}">
+<div ui-i18n="en" class="ui-grid">
   <!-- TODO (c0bra): add "scoped" attr here, eventually? -->
   <style ui-grid-style>
     .grid{{ grid.id }} {

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-header-cell col{{ col.index }} clearfix" ng-class="{ 'sortable': sortable }">
+<div class="ui-grid-header-cell clearfix" ng-class="{ 'sortable': sortable }">
   <div class="ui-grid-vertical-bar">&nbsp;</div>
   <div class="ui-grid-cell-contents" col-index="renderIndex">
     {{ col.displayName }}


### PR DESCRIPTION
One step forward into improving the grid performance. 

By using Chrome CPU Profiler I noticed that there was a lot of time spent on Attributes.$updateClass, which refers to interpolations on an $element class attribute. After removing some class interpolations am seeing a 15-20% performance increase but am doing manual profiling.

Any way to automate the profiling and getting average values from multiple runs?
