### PR TITLE
Fixed error “Cannot read property ‘slice’ of undefined”

### DIFF
--- a/src/classes/searchProvider.js
+++ b/src/classes/searchProvider.js
@@ -43,7 +43,7 @@
                     if (pVal !== null && pVal !== undefined) {
                         if (typeof f === "function") {
                             // Have to slice off the quotes the parser would have removed
-                            var filterRes = f(pVal, s[1].slice(1,-1)).toString();
+                            var filterRes = f(pVal, s.length > 1 ? s[1].slice(1,-1) : null).toString();
                             result = condition.regex.test(filterRes);
                         } else {
                             result = condition.regex.test(pVal.toString());

--- a/test/unit/directivesSpec.js
+++ b/test/unit/directivesSpec.js
@@ -493,7 +493,7 @@ describe('directives', function () {
                                  { field: 'name' },
                                  { field: 'obj1.age' },
                                  { field: 'birthdate', cellFilter: "date:'MM-dd-yyyy'" },
-                                 { field: 'obj2.grade'}
+                                 { field: 'obj2.grade', cellFilter: "lowercase"}
                                  ]
                     };
 


### PR DESCRIPTION
Error text:

```
TypeError: Cannot read property 'slice' of undefined
    at searchEntireRow (http://0.0.0.0:9000/vendor/ng-grid/ng-grid.debug.js:2613:57)
    at filterFunc (http://0.0.0.0:9000/vendor/ng-grid/ng-grid.debug.js:2658:26)
    at http://0.0.0.0:9000/vendor/ng-grid/ng-grid.debug.js:2674:24
    at Array.filter (native)
    at self.evalFilter (http://0.0.0.0:9000/vendor/ng-grid/ng-grid.debug.js:2673:47)
    at Object.fn (http://0.0.0.0:9000/vendor/ng-grid/ng-grid.debug.js:2780:18)
    at Scope.$digest (http://0.0.0.0:9000/bower_components/angular/angular.js:11789:29)
    at Scope.$apply (http://0.0.0.0:9000/bower_components/angular/angular.js:12042:24)
    at HTMLInputElement.listener (http://0.0.0.0:9000/bower_components/angular/angular.js:16040:15)
    at HTMLInputElement.jQuery.event.dispatch (http://0.0.0.0:9000/bower_components/jquery/jquery.js:5095:9) 
```

Error occurs when you define a `cellFilter` for a field, using a filter with no parameter like `cellFilter: "lowercase"`.
I have edited the unit test to prove this and a plunker to show the error: http://plnkr.co/edit/wso8bo
