### PR TITLE
Fix bug for aggregate setExpand not updating icon

### DIFF
--- a/src/classes/aggregate.js
+++ b/src/classes/aggregate.js
@@ -27,6 +27,9 @@ ngAggregate.prototype.toggleExpand = function () {
 };
 ngAggregate.prototype.setExpand = function (state) {
     this.collapsed = state;
+    if (this.orig) {
+        this.orig.collapsed = state;
+    }
     this.notifyChildren();
 };
 ngAggregate.prototype.notifyChildren = function () {


### PR DESCRIPTION
If calling toggleExpand, the icon of expanded or collapsed on the row will adjust to the state, but when calling setExpand directly, the icon is not updated.
