### PR TITLE
Added new option to download CSV file directly without showing CSV Export button

### DIFF
--- a/plugins/ng-grid-csv-export.js
+++ b/plugins/ng-grid-csv-export.js
@@ -10,6 +10,7 @@ function ngGridCsvExportPlugin (opts) {
     self.grid = null;
     self.scope = null;
     self.services = null;
+    self.csvData = null;
 
     self.init = function(scope, grid, services) {
         self.grid = grid;
@@ -18,12 +19,12 @@ function ngGridCsvExportPlugin (opts) {
 
         function showDs() {
             var keys = [];
-            for (var f in grid.config.columnDefs) { 
+            for (var f in grid.config.columnDefs) {
                 if (grid.config.columnDefs.hasOwnProperty(f))
-                {   
+                {
                     keys.push(grid.config.columnDefs[f].field);
-                }   
-            }   
+                }
+            }
             var csvData = '';
             function csvStringify(str) {
                 if (str == null) { // we want to catch anything null-ish, hence just == not ===
@@ -65,14 +66,17 @@ function ngGridCsvExportPlugin (opts) {
                 }
                 csvData = swapLastCommaForNewline(csvData);
             }
-            var fp = grid.$root.find(".ngFooterPanel");
-            var csvDataLinkPrevious = grid.$root.find('.ngFooterPanel .csv-data-link-span');
-            if (csvDataLinkPrevious != null) {csvDataLinkPrevious.remove() ; }
-            var csvDataLinkHtml = "<span class=\"csv-data-link-span\">";
-            csvDataLinkHtml += "<br><a href=\"data:text/csv;charset=UTF-8,";
-            csvDataLinkHtml += encodeURIComponent(csvData);
-            csvDataLinkHtml += "\" download=\"Export.csv\">CSV Export</a></br></span>" ;
-            fp.append(csvDataLinkHtml);
+            if (!opts.inhibitButton) {
+                var fp = grid.$root.find(".ngFooterPanel");
+                var csvDataLinkPrevious = grid.$root.find('.ngFooterPanel .csv-data-link-span');
+                if (csvDataLinkPrevious != null) {csvDataLinkPrevious.remove() ; }
+                var csvDataLinkHtml = "<span class=\"csv-data-link-span\">";
+                csvDataLinkHtml += "<br><a href=\"data:text/csv;charset=UTF-8,";
+                csvDataLinkHtml += encodeURIComponent(csvData);
+                csvDataLinkHtml += "\" download=\"Export.csv\">CSV Export</a></br></span>" ;
+                fp.append(csvDataLinkHtml);
+            }
+            self.csvData = csvData;
         }
         setTimeout(showDs, 0);
         scope.catHashKeys = function() {
@@ -88,4 +92,13 @@ function ngGridCsvExportPlugin (opts) {
             scope.$watch(scope.catHashKeys, showDs);
         }
     };
+
+    self.downloadCSV = function() {
+        var element = angular.element('<a/>');
+         element.attr({
+             href: 'data:attachment/csv;charset=utf-8,' + encodeURIComponent(self.csvData),
+             target: '_blank',
+             download: opts.downloadFileName ? opts.downloadFileName : 'csvFile.csv'
+         })[0].click();
+    }
 }


### PR DESCRIPTION
Added an option to exclude CSVExport button from Grid footer panel, added new downloadCSV() function to download the CSV file.
To hide CSV export button from hide set 'inhibitButton' value to true in the CSV options. 
CSV options now accepts new parameter 'downloadFileName', downloadCSV function will use this parameter to name the file name.
