### PR TITLE
ngGridEventSorted will fire on "shift" sorts as well

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -623,6 +623,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             } else {
                 self.config.sortInfo.directions[indx] = col.sortDirection;
             }
+            $scope.$emit('ngGridEventSorted', self.config.sortInfo);
         } else if (!self.config.useExternalSorting || (self.config.useExternalSorting && self.config.sortInfo )) {
             var isArr = $.isArray(col);
             self.config.sortInfo.columns.length = 0;


### PR DESCRIPTION
ngGridEventSorted wasn't fired when user made multi sort, using shift button
