### PR TITLE
Update searchProvider.js

### DIFF
--- a/src/classes/searchProvider.js
+++ b/src/classes/searchProvider.js
@@ -23,7 +23,7 @@
         for (var prop in item) {
             if (item.hasOwnProperty(prop)) {
                 var c = fieldMap[prop.toLowerCase()];
-                if (!c) {
+                if (!c || !c.visible) {
                     continue;
                 }
                 var pVal = item[prop];


### PR DESCRIPTION
The grid filter mechanism should only apply for rows that are currently visible.
It is not reasonable to filter on columns that aren't visible. Otherwise, it is consistent to show the data in the grid when the user try to filter some rows.
