### PR TITLE
Fixed issue in ng-grid-pdf-export plugin

### DIFF
--- a/plugins/ng-grid-pdf-export.js
+++ b/plugins/ng-grid-pdf-export.js
@@ -45,8 +45,9 @@ function ngGridPdfExportPlugin (options) {
         var doc = new jsPDF('landscape','mm','a4');
         doc.setFontStyle('bold');
         doc.setFontSize(12);
-        if (self.scope.reportSchema && self.scope.reportSchema.title)
+        if (self.scope.reportSchema && self.scope.reportSchema.title) {
             doc.text(self.scope.reportSchema.title,margin,margin);
+        }
         doc.setFontStyle('normal');
         doc.setFontSize(12);
         doc.cellInitialize();


### PR DESCRIPTION
Updated pdfexport plugin. Previous version of the file doesn't seem to be working anymore. I grabbed this change from Mark Chapman's plunk (http://plnkr.co/edit/t4aEBW). Fixed the missing parenthesis from issue #1298
