### PR TITLE
2.x -- Fixes typo in searchProvider.js searchColumn; typo breaks filter in version 2.0.12

### DIFF
--- a/src/classes/searchProvider.js
+++ b/src/classes/searchProvider.js
@@ -88,7 +88,7 @@
         else {
             var primitiveValues = getAllPrimitiveValues(evalObject(value, col.field));
 			for(var prop in primitiveValues) {
-				result |= condition.regex.test(primValues[prop]);
+				result |= condition.regex.test(primitiveValues[prop]);
 			}
         }
         if (result) {


### PR DESCRIPTION
Fixes typo in searchProvider.js searchColumn; typo breaks filter in version 2.12
