### PR TITLE
Bugfix: Allows a column name to be any string, including special characters.

### DIFF
--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -57,7 +57,7 @@ angular.module('ui.grid')
    * @returns {string} resulting name that can be evaluated on scope
    */
   GridRow.prototype.getQualifiedColField = function(col) {
-    return 'row.entity["' + col.field + '"]';
+    return "row.entity['" + col.field + "']";
   };
 
     /**
@@ -70,7 +70,7 @@ angular.module('ui.grid')
      * @returns {string} resulting name that can be evaluated against a row
      */
   GridRow.prototype.getEntityQualifiedColField = function(col) {
-    return 'entity["' + col.field + '"]';
+    return "entity['" + col.field + "']";
   };
 
   return GridRow;


### PR DESCRIPTION
Use the brackets syntax instead of the dot syntax for selecting a column so it allows for column names with special characters.

For example, using an UUID as a column name such as "3f73c374-bf4e-4c64-8d07-d5ef722b5cba":

row.entity.3f73c374-bf4e-4c64-8d07-d5ef722b5cba would fail because it interprets the dashes as minus signs.

row.entity["3f73c374-bf4e-4c64-8d07-d5ef722b5cba"] works.
