### PR TITLE
Added deep edit mode for more excel-like behaviour

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -515,9 +515,16 @@
                   });
                 });
 
+                $scope.deepEdit = false;
+
                 $scope.stopEdit = function () {
                   $scope.$emit(uiGridEditConstants.events.END_CELL_EDIT);
+                  $scope.deepEdit = false;
                 };
+
+                $elm.on('click', function (evt) {
+                  $scope.deepEdit = true;
+                });
 
                 $elm.on('keydown', function (evt) {
                   switch (evt.keyCode) {
@@ -528,6 +535,23 @@
                     case uiGridConstants.keymap.ENTER: // Enter (Leave Field)
                       $scope.stopEdit();
                       break;
+                  }
+
+                  if ($scope.deepEdit) {
+                    switch (evt.keyCode) {
+                      case uiGridConstants.keymap.LEFT:
+                        evt.stopPropagation();
+                        break;
+                      case uiGridConstants.keymap.RIGHT:
+                        evt.stopPropagation();
+                        break;
+                      case uiGridConstants.keymap.UP:
+                        evt.stopPropagation();
+                        break;
+                      case uiGridConstants.keymap.DOWN:
+                        evt.stopPropagation();
+                        break;
+                    }
                   }
 
                   return true;


### PR DESCRIPTION
In Excel, when you start editing a cell, type, then use your arrows, it switches cells. But, when you click in the cell when you're already editing, it goes into a sort of deep edit mode where you CAN use the arrows to move the text cursor, and only tab or enter will switch cells. This is not yet the case with ui-grid. I've included a possible implementation.
