### PR TITLE
RTL css fix: only apply when dir=rtl

### DIFF
--- a/src/less/rtl.less
+++ b/src/less/rtl.less
@@ -17,13 +17,12 @@
   right: 0;
 }
 
-.ui-grid[dir=rtl] .ui-grid-native-scrollbar.vertical
-{
-    left: 0px;
-    right: inherit;
+.ui-grid[dir=rtl] .ui-grid-native-scrollbar.vertical {
+  left: 0;
+  right: inherit;
 }
 
-.grid[dir=rtl] .ui-grid-column-menu-button {
+.ui-grid[dir=rtl] .ui-grid-column-menu-button {
   position: absolute;
   left: 1px;
   top: 0;
@@ -40,7 +39,7 @@
   border-color: @borderColor;
 }
 
-.ui-grid-header-cell:first-child .ui-grid-vertical-bar,
-.ui-grid-cell:first-child .ui-grid-vertical-bar {
+.ui-grid[dir=rtl] .ui-grid-header-cell:first-child .ui-grid-vertical-bar,
+.ui-grid[dir=rtl] .ui-grid-cell:first-child .ui-grid-vertical-bar {
   width: 0;
 }


### PR DESCRIPTION
**Bugged behaviour:**
![screen shot 2014-08-15 at 10 17 35](https://cloud.githubusercontent.com/assets/2545042/3931237/ab08fafc-2454-11e4-963d-052e1a5bd382.png)

**Fix:**
Changed some rtl-specific css from
`.ui-grid-header-cell:first-child .ui-grid-vertical-bar`
to
`.ui-grid[dir=rtl] .ui-grid-header-cell:first-child .ui-grid-vertical-bar,`

So now the vertical-bar in the first cell is only hidden when dir="rtl".
