### PR TITLE
Delete columns on change in columnDef

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -180,7 +180,7 @@ angular.module('ui.grid')
     // Synchronize self.columns with self.options.columnDefs so that columns can also be removed.
     if (self.columns.length > self.options.columnDefs.length) {
         self.columns.forEach(function (column, index) {
-            if (!self.getColDef(column.field)) {
+            if (!self.getColDef(column.name)) {
                 self.columns.splice(index, 1);
             }
         });


### PR DESCRIPTION
Mentioned in issue #1404, columns were not being removed when changing columnDefs. This was due to that there was no tracking of differences in columnDefs and existing columns lengths. To fix this, I'm checking for columnDefs being shorter in length than columns. Whenever that happens, I'm deleting the column(s) that are not in columnDefs anymore.

For the project we're working on, the committed code is working fine. However, I don't know if this code is sustainable wrt the rest of the codebase.
