### PR TITLE
Let columnDefs set column ordering so that new columns can be inserted and not just appended.

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -169,7 +169,7 @@ angular.module('ui.grid')
 
       if (!col) {
         col = new GridColumn(colDef, index, self);
-        self.columns.push(col);
+        self.columns.splice(index, 0, col);
       }
       else {
         col.updateColumnDef(colDef, col.index);


### PR DESCRIPTION
In our project, we need to fix one column to the far right of the grid; new columns should always be inserted left of that one. To overcome this, I'm now pushing new columns based on the index in columnDefs. This results in columnDef representing the actual column ordering within the grid.
