### PR TITLE
#1433

### DIFF
--- a/misc/tutorial/6_editable.ngdoc
+++ b/misc/tutorial/6_editable.ngdoc
@@ -11,9 +11,10 @@ templates should be used for any editor other than the default editors.
 ColumnDef Options:
 <br/><code>editableCellTemplate</code> (default: 'ui-grid/cellNumberEditor' for numeric columns, 'ui-grid/cellBooleanEditor' for boolean columns,
 'ui-grid/cellTextEditor' for others) - Valid html, templateCache Id,  or url that returns html content to be compiled when edit mode is invoked.
-<br/><code>enableCellEdit</code> (default: true) - false to not allow editing
+<br/><code>enableCellEdit</code> (default: false for columns of type 'object', true for all other columns) - true will enable editing and false will disable it.
 <br/><code>cellEditableCondition</code>  (default: true)  Can be set to a boolean or a function that will be called with the cellScope to determine if the cell should be invoked in edit mode.
-<br/><code>type</code> (default: null) If set to number or boolean the default editor provided for editing will be numeric or boolean editor respectively.
+<br/><code>type</code> (default: null) If set to 'number' or 'boolean' the default editor provided for editing will be numeric or boolean editor respectively.
+If set to 'object' the column will not be editable by default.
 <br/>
 The following option is available only if using cellNav feature
 <br/><code>enableCellEditOnFocus</code> - true to invoke editor as soon as cell has focus
@@ -23,6 +24,7 @@ $scope.gridOptions.columnDefs = [
    { name: 'name', enableCellEdit: true, editableCellTemplate },
    { name: 'age', enableCellEdit: true, type: 'number'},
    { name: 'isActive', enableCellEdit: true, type: 'boolean'},
+   { name: 'address', displayName: 'Address', type: 'object'},
    { name: 'address.city', enableCellEdit: true, displayName: 'Address (even rows editable)', cellEditableCondition: function($scope){return $scope.rowRenderIndex%2} }
 ]
 </pre>
@@ -31,7 +33,13 @@ $scope.gridOptions.columnDefs = [
 @example
 <example module="app">
   <file name="app.js">
-    var app = angular.module('app', ['ui.grid', 'ui.grid.edit']);
+    var app = angular.module('app', ['ui.grid', 'ui.grid.edit', 'addressFormatter']);
+
+    angular.module('addressFormatter', []).filter('address', function () {
+      return function (input) {
+          return input.street + ', ' + input.city + ', ' + input.state + ', ' + input.zip;
+      };
+    });
 
     app.controller('MainCtrl', ['$scope', '$http', function ($scope, $http) {
       $scope.gridOptions = {  };
@@ -40,6 +48,7 @@ $scope.gridOptions.columnDefs = [
         { name: 'id', enableCellEdit: false },
         { name: 'name', displayName: 'Name (editable)' },
         { name: 'age', displayName: 'Age' , type: 'number'},
+        { name: 'address', displayName: 'Address', type: 'object', cellFilter: 'address'},
         { name: 'address.city', displayName: 'Address (even rows editable)',
              cellEditableCondition: function($scope){
              return $scope.rowRenderIndex%2

--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -102,10 +102,9 @@
            *  @ngdoc object
            *  @name enableCellEdit
            *  @propertyOf  ui.grid.edit.api:GridOptions
-           *  @description Default value that colDefs will take if their enableCellEdit is undefined. Defaults to true.
+           *  @description If defined, it will be the default value that colDefs will take if their enableCellEdit is
+           *  not defined. Defaults to undefined.
            */
-            //default option to true unless it was explicitly set to false
-          gridOptions.enableCellEdit = gridOptions.enableCellEdit !== false;
 
           /**
            *  @ngdoc object
@@ -165,7 +164,8 @@
            *  @propertyOf  ui.grid.edit.api:ColDef
            *  @description enable editing on column
            */
-          colDef.enableCellEdit = colDef.enableCellEdit === undefined ? gridOptions.enableCellEdit : colDef.enableCellEdit;
+          colDef.enableCellEdit = colDef.enableCellEdit === undefined ? (gridOptions.enableCellEdit === undefined ?
+            (colDef.type !== 'object'):gridOptions.enableCellEdit) : colDef.enableCellEdit;
 
           /**
            *  @ngdoc object

--- a/src/features/edit/test/uiGridEditService.spec.js
+++ b/src/features/edit/test/uiGridEditService.spec.js
@@ -23,7 +23,7 @@ describe('ui.grid.edit uiGridEditService', function () {
 
       var options = {};
       uiGridEditService.defaultGridOptions(options);
-      expect(options.enableCellEdit).toBe(true);
+      expect(options.enableCellEdit).toBe(undefined);
       expect(options.cellEditableCondition).toBe(true);
       expect(options.enableCellEditOnFocus).toBe(false);
 
@@ -83,7 +83,7 @@ describe('ui.grid.edit uiGridEditService', function () {
       expect(col.editableCellTemplate).not.toBeDefined();
     });
 
-    it('should not create additional edit properties if global enableCellEdit is true', inject(function ($timeout) {
+    it('should create additional edit properties if global enableCellEdit is true', inject(function ($timeout) {
       var  grid = gridClassFactory.createGrid();
       grid.options.enableCellEdit = true;
       grid.options.columnDefs = [
@@ -107,6 +107,20 @@ describe('ui.grid.edit uiGridEditService', function () {
       grid.options.enableCellEdit = false;
       grid.options.columnDefs = [
         {field: 'col1'}
+      ];
+      grid.buildColumns();
+
+      var colDef = grid.options.columnDefs[0];
+      var col = grid.columns[0];
+      uiGridEditService.editColumnBuilder(colDef,col,grid.options);
+      expect(col.colDef.enableCellEdit).toBe(false);
+      expect(col.colDef.editableCellTemplate).not.toBeDefined();
+    });
+
+    it('should not create additional edit properties for column of type object', function () {
+      var  grid = gridClassFactory.createGrid();
+      grid.options.columnDefs = [
+        {field: 'col1', type: 'object'}
       ];
       grid.buildColumns();
 


### PR DESCRIPTION
1. For columns of type 'object', colDef.enableCellEdit will now be false by default.
2. Default value of gridOption.enableCellEdit will now be undefined (previously this was set to true by default but that will create trouble for 1 above).
