### PR TITLE
Don't override keyboard if in an input element

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -4,6 +4,10 @@ var ngMoveSelectionHandler = function($scope, elm, evt, grid) {
         return true;
     }
 
+    if (document.activeElement.tagName === "INPUT") {
+        return true;
+    }
+
     var charCode = evt.which || evt.keyCode,
         newColumnIndex,
         lastInRow = false,


### PR DESCRIPTION
Without this change, when a cell template had a text input element, you couldn't use cursor keys to navigate inside the text area.
