### PR TITLE
accounting for array indices in brack notation regular expression

### DIFF
--- a/src/js/core/constants.js
+++ b/src/js/core/constants.js
@@ -8,7 +8,7 @@
     FUNC_REGEXP: /(\([^)]*\))?$/,
     DOT_REGEXP: /\./g,
     APOS_REGEXP: /'/g,
-    BRACKET_REGEXP: /^(.*)((?:\s*\[\s*"(?:[^"\\]|\\.)*"\s*\]\s*)|(?:\s*\[\s*'(?:[^'\\]|\\.)*'\s*\]\s*))(.*)$/,
+    BRACKET_REGEXP: /^(.*)((?:\s*\[\s*\d+\s*\]\s*)|(?:\s*\[\s*"(?:[^"\\]|\\.)*"\s*\]\s*)|(?:\s*\[\s*'(?:[^'\\]|\\.)*'\s*\]\s*))(.*)$/,
     COL_CLASS_PREFIX: 'ui-grid-col',
     events: {
       GRID_SCROLL: 'uiGridScroll',


### PR DESCRIPTION
https://github.com/angular-ui/ng-grid/pull/1351 - fix so as to merge the 1351 changes into the 3.0 branch. 
