### PR TITLE
HeaderCellTemplate from column builder used, filter permitted on headerCell

### DIFF
--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -1,7 +1,7 @@
 (function(){
   'use strict';
 
-  angular.module('ui.grid').directive('uiGridHeaderCell', ['$log', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', function ($log, $timeout, $window, $document, gridUtil, uiGridConstants) {
+  angular.module('ui.grid').directive('uiGridHeaderCell', ['$log', '$compile', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', function ($log, $compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
     // Do stuff after mouse has been down this many ms on the header cell
     var mousedownTimeout = 500;
 
@@ -13,147 +13,149 @@
         renderIndex: '='
       },
       require: '?^uiGrid',
-      templateUrl: 'ui-grid/uiGridHeaderCell',
       replace: true,
-      link: function ($scope, $elm, $attrs, uiGridCtrl) {
-        $scope.grid = uiGridCtrl.grid;
-
-        $elm.addClass($scope.col.getColClass(false));
-// shane - No need for watch now that we trackby col name
-//        $scope.$watch('col.index', function (newValue, oldValue) {
-//          if (newValue === oldValue) { return; }
-//          var className = $elm.attr('class');
-//          className = className.replace(uiGridConstants.COL_CLASS_PREFIX + oldValue, uiGridConstants.COL_CLASS_PREFIX + newValue);
-//          $elm.attr('class', className);
-//        });
-
-        // Hide the menu by default
-        $scope.menuShown = false;
-
-        // Put asc and desc sort directions in scope
-        $scope.asc = uiGridConstants.ASC;
-        $scope.desc = uiGridConstants.DESC;
-
-        // Store a reference to menu element
-        var $colMenu = angular.element( $elm[0].querySelectorAll('.ui-grid-header-cell-menu') );
-
-        var $contentsElm = angular.element( $elm[0].querySelectorAll('.ui-grid-cell-contents') );
-
-        // Figure out whether this column is sortable or not
-        if (uiGridCtrl.grid.options.enableSorting && $scope.col.enableSorting) {
-          $scope.sortable = true;
-        }
-        else {
-          $scope.sortable = false;
-        }
-
-        if (uiGridCtrl.grid.options.enableFiltering && $scope.col.enableFiltering) {
-          $scope.filterable = true;
-        }
-        else {
-          $scope.filterable = false;
-        }
-
-        function handleClick(evt) {
-          // If the shift key is being held down, add this column to the sort
-          var add = false;
-          if (evt.shiftKey) {
-            add = true;
-          }
-
-          // Sort this column then rebuild the grid's rows
-          uiGridCtrl.grid.sortColumn($scope.col, add)
-            .then(function () {
-              uiGridCtrl.columnMenuCtrl.hideMenu();
-              uiGridCtrl.refresh();
-            });
-        }
-
-        // Long-click (for mobile)
-        var cancelMousedownTimeout;
-        var mousedownStartTime = 0;
-        $contentsElm.on('mousedown', function(event) {
-          if (typeof(event.originalEvent) !== 'undefined' && event.originalEvent !== undefined) {
-            event = event.originalEvent;
-          }
-
-          // Don't show the menu if it's not the left button
-          if (event.button && event.button !== 0) {
-            return;
-          }
-
-          mousedownStartTime = (new Date()).getTime();
-
-          cancelMousedownTimeout = $timeout(function() { }, mousedownTimeout);
-
-          cancelMousedownTimeout.then(function () {
-            uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
-          });
-        });
-
-        $contentsElm.on('mouseup', function () {
-          $timeout.cancel(cancelMousedownTimeout);
-        });
-
-        $scope.toggleMenu = function($event) {
-          $event.stopPropagation();
-
-          // If the menu is already showing...
-          if (uiGridCtrl.columnMenuCtrl.shown) {
-            // ... and we're the column the menu is on...
-            if (uiGridCtrl.columnMenuCtrl.col === $scope.col) {
-              // ... hide it
-              uiGridCtrl.columnMenuCtrl.hideMenu();
+      
+      compile: function() {
+        return {
+          pre: function ($scope, $elm, $attrs, uiGridCtrl) {
+            var cellHeader = $compile($scope.col.headerCellTemplate)($scope);
+            $elm.append(cellHeader);
+          },
+          
+          post: function ($scope, $elm, $attrs, uiGridCtrl) {
+            $scope.grid = uiGridCtrl.grid;
+    
+            $elm.addClass($scope.col.getColClass(false));
+    
+            // Hide the menu by default
+            $scope.menuShown = false;
+    
+            // Put asc and desc sort directions in scope
+            $scope.asc = uiGridConstants.ASC;
+            $scope.desc = uiGridConstants.DESC;
+    
+            // Store a reference to menu element
+            var $colMenu = angular.element( $elm[0].querySelectorAll('.ui-grid-header-cell-menu') );
+    
+            var $contentsElm = angular.element( $elm[0].querySelectorAll('.ui-grid-cell-contents') );
+    
+            // Figure out whether this column is sortable or not
+            if (uiGridCtrl.grid.options.enableSorting && $scope.col.enableSorting) {
+              $scope.sortable = true;
             }
-            // ... and we're NOT the column the menu is on
             else {
-              // ... move the menu to our column
-              uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+              $scope.sortable = false;
             }
-          }
-          // If the menu is NOT showing
-          else {
-            // ... show it on our column
-            uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+    
+            if (uiGridCtrl.grid.options.enableFiltering && $scope.col.enableFiltering) {
+              $scope.filterable = true;
+            }
+            else {
+              $scope.filterable = false;
+            }
+    
+            function handleClick(evt) {
+              // If the shift key is being held down, add this column to the sort
+              var add = false;
+              if (evt.shiftKey) {
+                add = true;
+              }
+    
+              // Sort this column then rebuild the grid's rows
+              uiGridCtrl.grid.sortColumn($scope.col, add)
+                .then(function () {
+                  uiGridCtrl.columnMenuCtrl.hideMenu();
+                  uiGridCtrl.refresh();
+                });
+            }
+    
+            // Long-click (for mobile)
+            var cancelMousedownTimeout;
+            var mousedownStartTime = 0;
+            $contentsElm.on('mousedown', function(event) {
+              if (typeof(event.originalEvent) !== 'undefined' && event.originalEvent !== undefined) {
+                event = event.originalEvent;
+              }
+    
+              // Don't show the menu if it's not the left button
+              if (event.button && event.button !== 0) {
+                return;
+              }
+    
+              mousedownStartTime = (new Date()).getTime();
+    
+              cancelMousedownTimeout = $timeout(function() { }, mousedownTimeout);
+    
+              cancelMousedownTimeout.then(function () {
+                uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+              });
+            });
+    
+            $contentsElm.on('mouseup', function () {
+              $timeout.cancel(cancelMousedownTimeout);
+            });
+    
+            $scope.toggleMenu = function($event) {
+              $event.stopPropagation();
+    
+              // If the menu is already showing...
+              if (uiGridCtrl.columnMenuCtrl.shown) {
+                // ... and we're the column the menu is on...
+                if (uiGridCtrl.columnMenuCtrl.col === $scope.col) {
+                  // ... hide it
+                  uiGridCtrl.columnMenuCtrl.hideMenu();
+                }
+                // ... and we're NOT the column the menu is on
+                else {
+                  // ... move the menu to our column
+                  uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+                }
+              }
+              // If the menu is NOT showing
+              else {
+                // ... show it on our column
+                uiGridCtrl.columnMenuCtrl.showMenu($scope.col, $elm);
+              }
+            };
+    
+            // If this column is sortable, add a click event handler
+            if ($scope.sortable) {
+              $contentsElm.on('click', function(evt) {
+                evt.stopPropagation();
+    
+                $timeout.cancel(cancelMousedownTimeout);
+    
+                var mousedownEndTime = (new Date()).getTime();
+                var mousedownTime = mousedownEndTime - mousedownStartTime;
+    
+                if (mousedownTime > mousedownTimeout) {
+                  // long click, handled above with mousedown
+                }
+                else {
+                  // short click
+                  handleClick(evt);
+                }
+              });
+    
+              $scope.$on('$destroy', function () {
+                // Cancel any pending long-click timeout
+                $timeout.cancel(cancelMousedownTimeout);
+              });
+            }
+    
+            if ($scope.filterable) {
+              $scope.$on('$destroy', $scope.$watch('col.filter.term', function(n, o) {
+                uiGridCtrl.refresh()
+                  .then(function () {
+                    if (uiGridCtrl.prevScrollArgs && uiGridCtrl.prevScrollArgs.y && uiGridCtrl.prevScrollArgs.y.percentage) {
+                       uiGridCtrl.fireScrollingEvent({ y: { percentage: uiGridCtrl.prevScrollArgs.y.percentage } });
+                    }
+                    // uiGridCtrl.fireEvent('force-vertical-scroll');
+                  });
+              }));
+            }
           }
         };
-
-        // If this column is sortable, add a click event handler
-        if ($scope.sortable) {
-          $contentsElm.on('click', function(evt) {
-            evt.stopPropagation();
-
-            $timeout.cancel(cancelMousedownTimeout);
-
-            var mousedownEndTime = (new Date()).getTime();
-            var mousedownTime = mousedownEndTime - mousedownStartTime;
-
-            if (mousedownTime > mousedownTimeout) {
-              // long click, handled above with mousedown
-            }
-            else {
-              // short click
-              handleClick(evt);
-            }
-          });
-
-          $scope.$on('$destroy', function () {
-            // Cancel any pending long-click timeout
-            $timeout.cancel(cancelMousedownTimeout);
-          });
-        }
-
-        if ($scope.filterable) {
-          $scope.$on('$destroy', $scope.$watch('col.filter.term', function(n, o) {
-            uiGridCtrl.refresh()
-              .then(function () {
-                if (uiGridCtrl.prevScrollArgs && uiGridCtrl.prevScrollArgs.y && uiGridCtrl.prevScrollArgs.y.percentage) {
-                   uiGridCtrl.fireScrollingEvent({ y: { percentage: uiGridCtrl.prevScrollArgs.y.percentage } });
-                }
-                // uiGridCtrl.fireEvent('force-vertical-scroll');
-              });
-          }));
-        }
       }
     };
 

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -186,6 +186,16 @@ angular.module('ui.grid')
    * @methodOf ui.grid.class:Grid
    * @description uses the first row of data to assign colDef.type for any types not defined.
    */
+  /**
+   * @ngdoc property
+   * @name type
+   * @propertyOf ui.grid.class:GridOptions.columnDef
+   * @description the type of the column, used in sorting.  If not provided then the 
+   * grid will guess the type.  Add this only if the grid guessing is not to your
+   * satisfaction.  Refer to {@link ui.grid.service:GridUtil.guessType gridUtil.guessType} for
+   * a list of values the grid knows about.
+   *
+   */
   Grid.prototype.assignTypes = function(){
     var self = this;
     self.options.columnDefs.forEach(function (colDef, index) {

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -309,7 +309,6 @@ angular.module('ui.grid')
     /**
      * @ngdoc property
      * @name cellClass
-     * @propertyOf ui.grid.class:GridColumn
      * @propertyOf ui.grid.class:GridOptions.columnDef
      * @description cellClass can be a string specifying the class to append to a cell
      * or it can be a function(row,rowRenderIndex, col, colRenderIndex) that returns a class name
@@ -318,9 +317,29 @@ angular.module('ui.grid')
     self.cellClass = colDef.cellClass;
 
 
-
-
+    /**
+     * @ngdoc property
+     * @name cellFilter
+     * @propertyOf ui.grid.class:GridOptions.columnDef
+     * @description cellFilter is a filter to apply to the content of each cell
+     * @example
+     * <pre>
+     *   gridOptions.columnDefs[0].cellFilter = 'date'
+     *
+     */
     self.cellFilter = colDef.cellFilter ? colDef.cellFilter : "";
+
+    /**
+     * @ngdoc property
+     * @name headerCellFilter
+     * @propertyOf ui.grid.class:GridOptions.columnDef
+     * @description headerCellFilter is a filter to apply to the content of the column header
+     * @example
+     * <pre>
+     *   gridOptions.columnDefs[0].headerCellFilter = 'translate'
+     *
+     */
+    self.headerCellFilter = colDef.headerCellFilter ? colDef.headerCellFilter : "";
 
     self.visible = gridUtil.isNullOrUndefined(colDef.visible) || colDef.visible;
 

--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -101,10 +101,26 @@
 
           var templateGetPromises = [];
 
+          /**
+           * @ngdoc property
+           * @name headerCellTemplate
+           * @propertyOf ui.grid.class:GridOptions.columnDef
+           * @description a custom template for the header for this column.  The default
+           * is ui-grid/uiGridHeaderCell
+           *
+           */
           if (!colDef.headerCellTemplate) {
             colDef.headerCellTemplate = 'ui-grid/uiGridHeaderCell';
           }
 
+          /**
+           * @ngdoc property
+           * @name cellTemplate
+           * @propertyOf ui.grid.class:GridOptions.columnDef
+           * @description a custom template for each cell in this column.  The default
+           * is ui-grid/uiGridCell
+           *
+           */
           if (!colDef.cellTemplate) {
             colDef.cellTemplate = 'ui-grid/uiGridCell';
           }
@@ -119,10 +135,11 @@
               })
           );
 
+
           templateGetPromises.push(gridUtil.getTemplate(colDef.headerCellTemplate)
               .then(
               function (template) {
-                col.headerCellTemplate = template;
+                col.headerCellTemplate = template.replace(uiGridConstants.CUSTOM_FILTERS, col.headerCellFilter ? "|" + col.headerCellFilter : "");
               },
               function (res) {
                 throw new Error("Couldn't fetch/use colDef.headerCellTemplate '" + colDef.headerCellTemplate + "'");

--- a/src/templates/ui-grid/ui-grid-header.html
+++ b/src/templates/ui-grid/ui-grid-header.html
@@ -2,7 +2,7 @@
   <div ui-grid-group-panel ng-show="grid.options.showGroupPanel"></div>
   <div class="ui-grid-header ui-grid-header-viewport">
     <div class="ui-grid-header-canvas">
-        <div ng-repeat="col in colContainer.renderedColumns track by col.colDef.name" ui-grid-header-cell col="col" render-index="$index" ng-style="$index === 0 && colContainer.columnStyle($index)">
+        <div class="ui-grid-header-cell clearfix" ng-repeat="col in colContainer.renderedColumns track by col.colDef.name" ui-grid-header-cell col="col" render-index="$index" ng-style="$index === 0 && colContainer.columnStyle($index)">
         </div>
     </div>
 

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -1,7 +1,7 @@
-<div class="ui-grid-header-cell clearfix" ng-class="{ 'sortable': sortable }">
+<div ng-class="{ 'sortable': sortable }">
   <div class="ui-grid-vertical-bar">&nbsp;</div>
   <div class="ui-grid-cell-contents" col-index="renderIndex">
-    {{ col.displayName }}
+    {{ col.displayName CUSTOM_FILTERS }}
 
     <span ui-grid-visible="col.sort.direction" ng-class="{ 'ui-grid-icon-up-dir': col.sort.direction == asc, 'ui-grid-icon-down-dir': col.sort.direction == desc, 'ui-grid-icon-blank': !col.sort.direction }">
       &nbsp;

--- a/test/unit/core/services/GridClassFactory.spec.js
+++ b/test/unit/core/services/GridClassFactory.spec.js
@@ -9,9 +9,9 @@ describe('gridClassFactory', function() {
 
   describe('createGrid', function() {
     var grid;
-    beforeEach(inject(function(_gridClassFactory_) {
+    beforeEach( function() {
       grid = gridClassFactory.createGrid();
-    }));
+    });
 
     it('creates a grid with default properties', function() {
       expect(grid).toBeDefined();
@@ -19,6 +19,85 @@ describe('gridClassFactory', function() {
       expect(grid.id).not.toBeNull();
       expect(grid.options).toBeDefined();
     });
+  });
+  
+  describe('defaultColumnBuilder', function () {
+    var grid;
+    var testSetup = {};
+    beforeEach(inject(function($rootScope, $templateCache) {
+      testSetup.$rootScope = $rootScope;
+      testSetup.$templateCache = $templateCache;
+      testSetup.col = {};
+      testSetup.colDef = {};
+      testSetup.gridOptions = {};
+    }));
+
+    it('column builder with no filters and template has no placeholders', function() {
+      testSetup.$templateCache.put('ui-grid/uiGridHeaderCell', '<div>a sample header template with no custom_filters</div>');
+      testSetup.$templateCache.put('ui-grid/uiGridCell', '<div>a sample cell template with no custom_filters</div>');
+      
+      gridClassFactory.defaultColumnBuilder( testSetup.colDef, testSetup.col, testSetup.gridOptions );
+      
+      expect(testSetup.colDef.headerCellTemplate).toEqual('ui-grid/uiGridHeaderCell');
+      expect(testSetup.colDef.cellTemplate).toEqual('ui-grid/uiGridCell');
+
+      testSetup.$rootScope.$digest();
+      
+      expect(testSetup.col.headerCellTemplate).toEqual('<div>a sample header template with no custom_filters</div>');
+      expect(testSetup.col.cellTemplate).toEqual('<div>a sample cell template with no custom_filters</div>');      
+    });
+
+    it('column builder with no filters and template has placeholders', function() {
+      testSetup.$templateCache.put('ui-grid/uiGridHeaderCell', '<div>a sample header template with CUSTOM_FILTERS</div>');
+      testSetup.$templateCache.put('ui-grid/uiGridCell', '<div>a sample cell template with CUSTOM_FILTERS</div>');
+      
+      gridClassFactory.defaultColumnBuilder( testSetup.colDef, testSetup.col, testSetup.gridOptions );
+      
+      expect(testSetup.colDef.headerCellTemplate).toEqual('ui-grid/uiGridHeaderCell');
+      expect(testSetup.colDef.cellTemplate).toEqual('ui-grid/uiGridCell');
+
+      testSetup.$rootScope.$digest();
+      
+      expect(testSetup.col.headerCellTemplate).toEqual('<div>a sample header template with </div>');
+      expect(testSetup.col.cellTemplate).toEqual('<div>a sample cell template with </div>');      
+    });
+
+    it('column builder with filters and template has placeholders', function() {
+      testSetup.$templateCache.put('ui-grid/uiGridHeaderCell', '<div>a sample header template with CUSTOM_FILTERS</div>');
+      testSetup.$templateCache.put('ui-grid/uiGridCell', '<div>a sample cell template with CUSTOM_FILTERS</div>');
+      
+      testSetup.col.cellFilter = 'customCellFilter';
+      testSetup.col.headerCellFilter = 'customHeaderCellFilter';
+      
+      gridClassFactory.defaultColumnBuilder( testSetup.colDef, testSetup.col, testSetup.gridOptions );
+      
+      expect(testSetup.colDef.headerCellTemplate).toEqual('ui-grid/uiGridHeaderCell');
+      expect(testSetup.colDef.cellTemplate).toEqual('ui-grid/uiGridCell');
+
+      testSetup.$rootScope.$digest();
+      
+      expect(testSetup.col.headerCellTemplate).toEqual('<div>a sample header template with |customHeaderCellFilter</div>');
+      expect(testSetup.col.cellTemplate).toEqual('<div>a sample cell template with |customCellFilter</div>');      
+    });
+
+    it('column builder with filters and template has no placeholders', function() {
+      testSetup.$templateCache.put('ui-grid/uiGridHeaderCell', '<div>a sample header template with custom_filters</div>');
+      testSetup.$templateCache.put('ui-grid/uiGridCell', '<div>a sample cell template with custom_filters</div>');
+      
+      testSetup.col.cellFilter = 'customCellFilter';
+      testSetup.col.headerCellFilter = 'customHeaderCellFilter';
+      
+      gridClassFactory.defaultColumnBuilder( testSetup.colDef, testSetup.col, testSetup.gridOptions );
+      
+      expect(testSetup.colDef.headerCellTemplate).toEqual('ui-grid/uiGridHeaderCell');
+      expect(testSetup.colDef.cellTemplate).toEqual('ui-grid/uiGridCell');
+
+      testSetup.$rootScope.$digest();
+      
+      expect(testSetup.col.headerCellTemplate).toEqual('<div>a sample header template with custom_filters</div>');
+      expect(testSetup.col.cellTemplate).toEqual('<div>a sample cell template with custom_filters</div>');      
+    });
+    
   });
 
 });


### PR DESCRIPTION
Modify defaultColumnBuilder to add a headerCellFilter property to columnDef,
allowing a translate to be applied to the header without needing to use a custom
header template.

Modify ui-grid-header-cell directive to use the header template from the
column builder, rather than ignoring it.

Minor modifications to templates because the result of a compiled template
seems a little different than an inline template, and therefore some classes
ended up in different places within the ng-repeat.  This could alternatively
be fixed in the css, but css is really not my thing.

Noted that on my mac in chrome the column menus are not correctly attaching
to the columns, but I believe this is a pre-existing problem not caused by
this change.

The diff on ui-grid-header-cell.js makes it look like far more change than it is.  I've pushed the old link content into a compile - post, and written a new pre.  I didn't make any changes in the old link, but every line had to be indented so they all show as changed.
