### PR TITLE
Provide hideHeader on gridOptions

### DIFF
--- a/src/js/core/directives/ui-grid-header.js
+++ b/src/js/core/directives/ui-grid-header.js
@@ -3,6 +3,7 @@
 
   angular.module('ui.grid').directive('uiGridHeader', ['$log', '$templateCache', '$compile', 'uiGridConstants', 'gridUtil', '$timeout', function($log, $templateCache, $compile, uiGridConstants, gridUtil, $timeout) {
     var defaultTemplate = 'ui-grid/ui-grid-header';
+    var emptyTemplate = 'ui-grid/ui-grid-no-header';
 
     return {
       restrict: 'EA',
@@ -23,7 +24,20 @@
             containerCtrl.header = $elm;
             containerCtrl.colContainer.header = $elm;
 
-            var headerTemplate = ($scope.grid.options.headerTemplate) ? $scope.grid.options.headerTemplate : defaultTemplate;
+            /**
+             * @ngdoc property
+             * @name hideHeader
+             * @propertyOf ui.grid.class:GridOptions
+             * @description Null by default. When set to true, this setting will replace the
+             * standard header template with '<div></div>', resulting in no header being shown.
+             */
+            
+            var headerTemplate;
+            if ($scope.grid.options.hideHeader){
+              headerTemplate = emptyTemplate;
+            } else {
+              headerTemplate = ($scope.grid.options.headerTemplate) ? $scope.grid.options.headerTemplate : defaultTemplate;            
+            }
 
              gridUtil.getTemplate(headerTemplate)
               .then(function (contents) {

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -210,12 +210,19 @@ angular.module('ui.grid')
      * @name headerTemplate
      * @propertyOf ui.grid.class:GridOptions
      * @description Null by default. When provided, this setting uses a custom header
-     * template. Can be set to either the name of a template file:
+     * template, rather than the default template. Can be set to either the name of a template file:
      * <pre>  $scope.gridOptions.headerTemplate = 'header_template.html';</pre>
      * inline html 
      * <pre>  $scope.gridOptions.headerTemplate = '<div class="ui-grid-top-panel" style="text-align: center">I am a Custom Grid Header</div>'</pre>
      * or the id of a precompiled template (TBD how to use this).  
      * </br>Refer to the custom header tutorial for more information.
+     * If you want no header at all, you can set to an empty div:
+     * <pre>  $scope.gridOptions.headerTemplate = '<div></div>';</pre>
+     * 
+     * If you want to only have a static header, then you can set to static content.  If
+     * you want to tailor the existing column headers, then you should look at the
+     * current 'ui-grid-header.html' template in github as your starting point.
+     * 
      */
     this.headerTemplate = null;
 

--- a/src/templates/ui-grid/ui-grid-no-header.html
+++ b/src/templates/ui-grid/ui-grid-no-header.html
@@ -1,0 +1,2 @@
+<div class="ui-grid-top-panel">
+</div>


### PR DESCRIPTION
Uses the ui-grid-no-header.html template instead of ui-grid-header.html.  A
little more elegant than just setting headerTemplate to an empty
div.

Should close #1402 
