### PR TITLE
Create PublicApi for core grid, add row visibility logic

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -6,12 +6,6 @@ angular.module('ui.grid')
 
 /**
  * @ngdoc object
- * @name ui.grid.core
- * @description Not sure this needs to be defined, I'll see
- *
- */
-/**
- * @ngdoc object
  * @name ui.grid.core.api:PublicApi
  * @description Public Api for the core grid features
  *
@@ -129,6 +123,25 @@ angular.module('ui.grid')
 
 
   self.api = new GridApi(self);
+
+  /**
+   * @ngdoc function
+   * @name refresh
+   * @methodOf ui.grid.core.api:PublicApi
+   * @description Refresh the rendered grid on screen.
+   * 
+   */
+  this.api.registerMethod( 'core', 'refresh', this.refresh );
+
+  /**
+   * @ngdoc function
+   * @name refreshRows
+   * @methodOf ui.grid.core.api:PublicApi
+   * @description Refresh the rendered grid on screen?  Note: not functional at present
+   * @returns {promise} promise that is resolved when render completes?
+   * 
+   */
+  this.api.registerMethod( 'core', 'refreshRows', this.refreshRows );
 };
 
   /**
@@ -1253,16 +1266,6 @@ angular.module('ui.grid')
   
   /**
    * @ngdoc function
-   * @name refresh
-   * @methodOf ui.grid.core.api:PublicApi
-   * @description Refresh the rendered grid on screen.
-   * 
-   */
-  // this.api.registerMethod( 'core', 'refresh', this.refresh );
-
-
-  /**
-   * @ngdoc function
    * @name refreshRows
    * @methodOf ui.grid.class:Grid
    * @description Refresh the rendered rows on screen?  Note: not functional at present 
@@ -1282,17 +1285,6 @@ angular.module('ui.grid')
         self.refreshCanvas();
       });
   };
-
-  /**
-   * @ngdoc function
-   * @name refreshRows
-   * @methodOf ui.grid.core.api:PublicApi
-   * @description Refresh the rendered grid on screen?  Note: not functional at present
-   * @returns {promise} promise that is resolved when render completes?
-   * 
-   */
-  // this.api.registerMethod( 'core', 'refreshRows', this.refreshRows );
-
 
   /**
    * @ngdoc function

--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -55,6 +55,57 @@ angular.module('ui.grid')
       */
     // Default to true
     this.visible = true;
+
+    /**
+     * @ngdoc function
+     * @name setRowInvisible
+     * @methodOf  ui.grid.core.api:PublicApi
+     * @description Sets an override on the row to make it always invisible,
+     * which will override any filtering or other visibility calculations.  
+     * If the row is currently visible then sets it to invisible and calls
+     * both grid refresh and emits the rowsVisibleChanged event
+     * @param {object} rowEntity gridOptions.data[] array instance
+     */
+    this.grid.api.registerMethod( 'core', 'setRowInvisible', this.setRowInvisible );
+
+    /**
+     * @ngdoc function
+     * @name clearRowInvisible
+     * @methodOf  ui.grid.core.api:PublicApi
+     * @description Clears any override on visibility for the row so that it returns to 
+     * using normal filtering and other visibility calculations.  
+     * If the row is currently invisible then sets it to visible and calls
+     * both grid refresh and emits the rowsVisibleChanged event
+     * TODO: if a filter is active then we can't just set it to visible?
+     * @param {object} rowEntity gridOptions.data[] array instance
+     */
+    this.grid.api.registerMethod( 'core', 'clearRowInvisible', this.clearRowInvisible );
+
+    /**
+     * @ngdoc function
+     * @name getVisibleRows
+     * @methodOf  ui.grid.core.api:PublicApi
+     * @description Returns all visible rows
+     * @param {Grid} grid the grid you want to get visible rows from
+     * @returns {array} an array of gridRow 
+     */
+    this.grid.api.registerMethod( 'core', 'getVisibleRows', this.getVisibleRows );
+    
+    /**
+     * @ngdoc event
+     * @name rowsVisibleChanged
+     * @eventOf  ui.grid.core.api:PublicApi
+     * @description  is raised after the rows that are visible
+     * change.  The filtering is zero-based, so it isn't possible
+     * to say which rows changed (unlike in the selection feature).
+     * We can plausibly know which row was changed when setRowInvisible
+     * is called, but in that situation the user already knows which row
+     * they changed.  When a filter runs we don't know what changed, 
+     * and that is the one that would have been useful.
+     * 
+     */
+    this.grid.api.registerEvent( 'core', 'rowsVisibleChanged' );
+    
   }
 
   /**
@@ -82,6 +133,70 @@ angular.module('ui.grid')
   GridRow.prototype.getEntityQualifiedColField = function(col) {
     return gridUtil.preEval('entity.' + col.field);
   };
+  
+  
+  /**
+   * @ngdoc function
+   * @name setRowInvisible
+   * @methodOf  ui.grid.class:GridRow
+   * @description Sets an override on the row that forces it to always
+   * be invisible, and if the row is currently visible then marks it
+   * as invisible and refreshes the grid.  Emits the rowsVisibleChanged
+   * event if it changed the row visibility
+   * @param {GridRow} row row to force invisible, needs to be a GridRow,
+   * which can be found from your data entity using grid.findRow
+   */
+  GridRow.prototype.setRowInvisible = function (row) {
+    if (row !== null) {
+      row.forceInvisible = true;
+      
+      if ( row.visible ){
+        row.visible = false;
+        row.grid.refresh();
+        row.grid.api.core.raise.rowsVisibleChanged();
+      }
+    }        
+  };
+
+  /**
+   * @ngdoc function
+   * @name clearRowInvisible
+   * @methodOf ui.grid.class:GridRow
+   * @description Clears any override on the row visibility, returning it 
+   * to normal visibility calculations.  If the row is currently invisible
+   * then sets it to visible and calls refresh and emits the rowsVisibleChanged
+   * event
+   * TODO: if filter in action, then is this right?
+   * @param {GridRow} row row clear force invisible, needs to be a GridRow,
+   * which can be found from your data entity using grid.findRow
+   */
+  GridRow.prototype.clearRowInvisible = function (row) {
+    if (row !== null) {
+      row.forceInvisible = false;
+      
+      if ( !row.visible ){
+        row.visible = true;
+        row.grid.refresh();
+        row.grid.api.core.raise.rowsVisibleChanged();
+      }
+    }        
+  };
+
+  /**
+   * @ngdoc function
+   * @name getVisibleRows
+   * @methodOf ui.grid.class:GridRow
+   * @description Returns all the visible rows
+   * @param {Grid} grid the grid to return rows from
+   * @returns {array} rows that are currently visible, returns the
+   * GridRows rather than gridRow.entity
+   * TODO: should this come from visible row cache instead?
+   */
+  GridRow.prototype.getVisibleRows = function ( grid ) {
+    return grid.rows.filter(function (row) {
+      return row.visible;
+    });
+  };  
 
   return GridRow;
 }]);

--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -46,7 +46,7 @@
           // Reset all rows to visible initially
           grid.registerRowsProcessor(function allRowsVisible(rows) {
             rows.forEach(function (row) {
-              row.visible = true;
+              row.visible = !row.forceInvisible;
             });
 
             return rows;

--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -336,11 +336,13 @@ module.service('rowSearcher', ['$log', 'uiGridConstants', function ($log, uiGrid
     if (filterCols.length > 0) {
       filterCols.forEach(function foreachFilterCol(col) {
         rows.forEach(function foreachRow(row) {
-          if (!rowSearcher.searchColumn(grid, row, col, termCache)) {
+          if (row.forceInvisible || !rowSearcher.searchColumn(grid, row, col, termCache)) {
             row.visible = false;
           }
         });
       });
+      
+      grid.api.core.raise.rowsVisibleChanged();
 
       // rows.forEach(function (row) {
       //   var matchesAllColumns = true;

--- a/test/unit/core/factories/GridRow.spec.js
+++ b/test/unit/core/factories/GridRow.spec.js
@@ -1,14 +1,15 @@
 describe('GridRow factory', function () {
-  var $q, $scope, grid, Grid, GridRow, gridUtil;
+  var $q, $scope, grid, Grid, GridRow, gridUtil, gridClassFactory;
 
   beforeEach(module('ui.grid'));
 
-  beforeEach(inject(function (_$q_, _$rootScope_, _Grid_, _GridRow_, _gridUtil_) {
+  beforeEach(inject(function (_$q_, _$rootScope_, _Grid_, _GridRow_, _gridUtil_, _gridClassFactory_) {
     $q = _$q_;
     $scope = _$rootScope_;
     Grid = _Grid_;
     GridRow = _GridRow_;
     gridUtil = _gridUtil_;
+    gridClassFactory = _gridClassFactory_;
   }));
 
 
@@ -37,6 +38,77 @@ describe('GridRow factory', function () {
       expect(gridRow.getQualifiedColField(col)).toBe('row.entity[\'simpleProp\']');
     });
 
+  });
+  
+  
+  describe('row visibility', function() {
+    var grid;
+    var rowsVisibleChanged;
+    
+    beforeEach(function() {
+      rowsVisibleChanged = false;
+      
+      grid = new Grid({id: 'a'});
+      
+      grid.options.columnDefs = [{ field: 'col1' }];
+      for (var i = 0; i < 10; i++) {
+        grid.options.data.push({col1:'a_' + i});
+      }
+
+      grid.buildColumns();
+      grid.modifyRows(grid.options.data);
+    });
+    
+    it('should set then unset forceInvisible on visible row, raising visible rows changed event', function () {
+      grid.api.core.on.rowsVisibleChanged( $scope, function() { rowsVisibleChanged = true; });
+
+      expect(grid.api.core.getVisibleRows(grid).length).toEqual(10);
+      
+      grid.api.core.setRowInvisible(grid.rows[0]);
+      expect(grid.rows[0].forceInvisible).toBe(true);
+      expect(grid.rows[0].visible).toBe(false);
+      
+      expect(rowsVisibleChanged).toEqual(true);
+      
+      expect(grid.api.core.getVisibleRows(grid).length).toEqual(9);
+      
+      rowsVisibleChanged = false;
+
+      grid.api.core.clearRowInvisible(grid.rows[0]);
+      expect(grid.rows[0].forceInvisible).toBe(false);
+      expect(grid.rows[0].visible).toBe(true);
+
+      expect(rowsVisibleChanged).toEqual(true);
+
+      expect(grid.api.core.getVisibleRows(grid).length).toEqual(10);
+    });
+
+    it('should set then clear forceInvisible on invisible row, doesn\'t raise visible rows changed event', function () {
+      grid.api.core.on.rowsVisibleChanged( $scope, function() { rowsVisibleChanged = true; });
+      grid.rows[0].visible = false;
+      
+      grid.api.core.setRowInvisible(grid.rows[0]);
+      expect(grid.rows[0].forceInvisible).toBe(true);
+      expect(grid.rows[0].visible).toBe(false);
+      
+      expect(rowsVisibleChanged).toEqual(false);
+      
+      grid.rows[0].visible = true;
+      
+      grid.api.core.clearRowInvisible(grid.rows[0]);
+      expect(grid.rows[0].forceInvisible).toBe(false);
+      expect(grid.rows[0].visible).toBe(true);
+      
+      expect(rowsVisibleChanged).toEqual(false);
+    });
+
+    it('row not found is OK, no event raised', function () {
+      grid.api.core.on.rowsVisibleChanged( $scope, function() { rowsVisibleChanged = true; });
+
+      grid.api.core.setRowInvisible(grid, {col1: 'not in grid'});
+      
+      expect(rowsVisibleChanged).toEqual(false);
+    });
   });
 
 

--- a/test/unit/core/row-sorting.spec.js
+++ b/test/unit/core/row-sorting.spec.js
@@ -171,8 +171,6 @@ describe('rowSorter', function() {
     beforeEach(inject(function(_$timeout_) {
       $timeout = _$timeout_;
 
-      timeoutRows = [new GridRow({ name: 'Frank' }, 0)];
-
       grid = gridClassFactory.createGrid({
         externalSort: jasmine.createSpy('externalSort')
                         .andCallFake(function (r) {
@@ -182,6 +180,8 @@ describe('rowSorter', function() {
                           }, 1000);
                         })
       });
+
+      timeoutRows = [new GridRow({ name: 'Frank' }, 0, grid)];
 
       // grid.options.externalSort = function (grid, column, rows) {
       //   // sort stuff here


### PR DESCRIPTION
Refer #1507 and #1207 

Create a PublicApi for core, along with the ngdocs for this.

Add methods to that PublicApi, including grid.refresh,
gridRow.setRowInvisible, gridRow.clearRowInvisible and
gridRow.getRowsVisible.

Create new methods to force grid rows to invisible, and
an event that is fired whenever the rows visible changes.
