### PR TITLE
Add hide column to column menu

### DIFF
--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -121,6 +121,14 @@ angular.module('ui.grid').directive('uiGridColumnMenu', ['$log', '$timeout', '$w
           shown: function() {
             return (sortable() && typeof($scope.col) !== 'undefined' && (typeof($scope.col.sort) !== 'undefined' && typeof($scope.col.sort.direction) !== 'undefined') && $scope.col.sort.direction !== null);
           }
+        },
+        {
+          title: i18nService.getSafeText('column.hide'),
+          icon: 'ui-grid-icon-cancel',
+          action: function ($event) {
+            $event.stopPropagation();
+            $scope.hideColumn();
+          }
         }
       ];
 
@@ -272,6 +280,13 @@ angular.module('ui.grid').directive('uiGridColumnMenu', ['$log', '$timeout', '$w
 
       $scope.unsortColumn = function () {
         $scope.col.unsort();
+
+        uiGridCtrl.grid.refresh();
+        self.hideMenu();
+      };
+
+      $scope.hideColumn = function () {
+        $scope.col.colDef.visible = false;
 
         uiGridCtrl.grid.refresh();
         self.hideMenu();

--- a/src/js/i18n/da.js
+++ b/src/js/i18n/da.js
@@ -21,6 +21,9 @@
           },
           menu:{
             text: 'Vælg kolonner:',
+          },
+          column: {
+            hide: 'Skjul kolonne'
           }
         });
       return $delegate;

--- a/src/js/i18n/de.js
+++ b/src/js/i18n/de.js
@@ -24,6 +24,9 @@
         },
         menu: {
           text: 'Spalten auswählen:'
+        },
+        column: {
+          hide: 'Spalte ausblenden'
         }
       });
       return $delegate;

--- a/src/js/i18n/en.js
+++ b/src/js/i18n/en.js
@@ -29,6 +29,9 @@
           ascending: 'Sort Ascending',
           descending: 'Sort Descending',
           remove: 'Remove Sort'
+        },
+        column: {
+          hide: 'Hide Column'
         }
       });
       return $delegate;

--- a/src/js/i18n/es.js
+++ b/src/js/i18n/es.js
@@ -21,6 +21,9 @@
         },
         menu: {
           text: 'Elegir columnas:'
+        },
+        column: {
+          hide: 'Ocultar la columna'
         }
       });
       return $delegate;

--- a/src/js/i18n/fa.js
+++ b/src/js/i18n/fa.js
@@ -21,6 +21,9 @@
         },
         menu: {
           text: 'انتخاب ستون\u200cها:'
+        },
+        column: {
+          hide: 'ستون پنهان کن'
         }
       });
       return $delegate;

--- a/src/js/i18n/fr.js
+++ b/src/js/i18n/fr.js
@@ -21,6 +21,9 @@
         },
         menu: {
           text: 'Choisir des colonnes:'
+        },
+        column: {
+          hide: 'Colonne de peau'
         }
       });
       return $delegate;

--- a/src/js/i18n/he.js
+++ b/src/js/i18n/he.js
@@ -29,6 +29,9 @@
                     ascending: 'סדר עולה',
                     descending: 'סדר יורד',
                     remove: 'בטל'
+                },
+                column: {
+                  hide: 'טור הסתר'
                 }
             });
             return $delegate;

--- a/src/js/i18n/nl.js
+++ b/src/js/i18n/nl.js
@@ -26,6 +26,9 @@
           ascending: 'Sorteer oplopend',
           descending: 'Sorteer aflopend',
           remove: 'Verwijder sortering'
+        },
+        column: {
+          hide: 'Kolom te verbergen'
         }
       });
       return $delegate;

--- a/src/js/i18n/pt-br.js
+++ b/src/js/i18n/pt-br.js
@@ -21,6 +21,9 @@
         },
         menu: {
           text: 'Selecione as colunas:'
+        },
+        column: {
+          hide: 'Esconder coluna'
         }
       });
       return $delegate;

--- a/src/js/i18n/ru.js
+++ b/src/js/i18n/ru.js
@@ -29,6 +29,9 @@
           ascending: 'По возрастанию',
           descending: 'По убыванию',
           remove: 'Убрать сортировку'
+        },
+        column: {
+          hide: 'спрятать столбец'
         }
       });
       return $delegate;

--- a/src/js/i18n/zh-cn.js
+++ b/src/js/i18n/zh-cn.js
@@ -21,6 +21,9 @@
         },
         menu: {
           text: '数据分组与选择列：'
+        },
+        column: {
+          hide: '隐藏列'
         }
       });
       return $delegate;

--- a/src/js/i18n/zh-tw.js
+++ b/src/js/i18n/zh-tw.js
@@ -21,6 +21,9 @@
         },
         menu: {
           text: '選擇欄位：'
+        },
+        column: {
+          hide: '隐藏列'
         }
       });
       return $delegate;


### PR DESCRIPTION
Also includes "google translation" standard translations, except
for Taiwanese, for which I've used Chinese as Google doesn't
understand Taiwanese apparently.

Noted that error is occurring intermittently in testing:
ui-grid watch for new pinned containers fires watch for right container FAILED

Tested and validated that this is also occurring on upstream/master,
so presume not to do with changes I've made.
