### PR TITLE
fix for row header in selection feature

### DIFF
--- a/src/features/selection/templates/selectionRowHeader.html
+++ b/src/features/selection/templates/selectionRowHeader.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-row-header-cell">
+<div class="ui-grid-row-header-cell ui-grid-disable-selection">
   <div class="ui-grid-cell-contents">
     <ui-grid-selection-row-header-buttons></ui-grid-selection-row-header-buttons>
   </div>


### PR DESCRIPTION
added ui-grid-disable-selection class to disable native user selection
for row header cell in selection feature
