### PR TITLE
External sorting api, a gridOption and an event

### DIFF
--- a/misc/site/data/100_ASC.json
+++ b/misc/site/data/100_ASC.json
@@ -1,0 +1,502 @@
+[
+    {
+        "name": "Beryl Rice",
+        "gender": "female",
+        "company": "Velity"
+    },
+    {
+        "name": "Bruce Strong",
+        "gender": "male",
+        "company": "Xyqag"
+    },
+    {
+        "name": "Carroll Buchanan",
+        "gender": "male",
+        "company": "Ecosys"
+    },
+    {
+        "name": "Claudine Neal",
+        "gender": "female",
+        "company": "Sealoud"
+    },
+    {
+        "name": "Dawson Barber",
+        "gender": "male",
+        "company": "Dymi"
+    },
+    {
+        "name": "Ethel Price",
+        "gender": "female",
+        "company": "Enersol"
+    },
+    {
+        "name": "Evans Hickman",
+        "gender": "male",
+        "company": "Parleynet"
+    },
+    {
+        "name": "Georgina Schultz",
+        "gender": "female",
+        "company": "Suretech"
+    },
+    {
+        "name": "Jackson Macias",
+        "gender": "male",
+        "company": "Aquamate"
+    },
+    {
+        "name": "Lynda Mendoza",
+        "gender": "female",
+        "company": "Dogspa"
+    },
+    {
+        "name": "Nellie Whitfield",
+        "gender": "female",
+        "company": "Exospace"
+    },
+    {
+        "name": "Robles Boyle",
+        "gender": "male",
+        "company": "Comtract"
+    },
+    {
+        "name": "Sarah Massey",
+        "gender": "female",
+        "company": "Bisba"
+    },
+    {
+        "name": "Schroeder Mathews",
+        "gender": "male",
+        "company": "Polarium"
+    },
+    {
+        "name": "Valarie Atkinson",
+        "gender": "female",
+        "company": "Hopeli"
+    },
+    {
+        "name": "Wilder Gonzales",
+        "gender": "male",
+        "company": "Geekko"
+    },
+    {
+        "name": "Pena Pena",
+        "gender": "male",
+        "company": "Quarx"
+    },
+    {
+        "name": "Lelia Gates",
+        "gender": "female",
+        "company": "Proxsoft"
+    },
+    {
+        "name": "Letitia Vasquez",
+        "gender": "female",
+        "company": "Slumberia"
+    },
+    {
+        "name": "Trevino Moreno",
+        "gender": "male",
+        "company": "Conjurica"
+    },
+    {
+        "name": "Barr Page",
+        "gender": "male",
+        "company": "Apex"
+    },
+    {
+        "name": "Kirkland Merrill",
+        "gender": "male",
+        "company": "Utara"
+    },
+    {
+        "name": "Blanche Conley",
+        "gender": "female",
+        "company": "Imkan"
+    },
+    {
+        "name": "Atkins Dunlap",
+        "gender": "male",
+        "company": "Comveyor"
+    },
+    {
+        "name": "Everett Foreman",
+        "gender": "male",
+        "company": "Maineland"
+    },
+    {
+        "name": "Gould Randolph",
+        "gender": "male",
+        "company": "Intergeek"
+    },
+    {
+        "name": "Kelli Leon",
+        "gender": "female",
+        "company": "Verbus"
+    },
+    {
+        "name": "Freda Mason",
+        "gender": "female",
+        "company": "Accidency"
+    },
+    {
+        "name": "Tucker Maxwell",
+        "gender": "male",
+        "company": "Lumbrex"
+    },
+    {
+        "name": "Yvonne Parsons",
+        "gender": "female",
+        "company": "Zolar"
+    },
+    {
+        "name": "Woods Key",
+        "gender": "male",
+        "company": "Bedder"
+    },
+    {
+        "name": "Stephens Reilly",
+        "gender": "male",
+        "company": "Acusage"
+    },
+    {
+        "name": "Mcfarland Sparks",
+        "gender": "male",
+        "company": "Comvey"
+    },
+    {
+        "name": "Jocelyn Sawyer",
+        "gender": "female",
+        "company": "Fortean"
+    },
+    {
+        "name": "Renee Barr",
+        "gender": "female",
+        "company": "Kiggle"
+    },
+    {
+        "name": "Gaines Beck",
+        "gender": "male",
+        "company": "Sequitur"
+    },
+    {
+        "name": "Luisa Farrell",
+        "gender": "female",
+        "company": "Cinesanct"
+    },
+    {
+        "name": "Robyn Strickland",
+        "gender": "female",
+        "company": "Obones"
+    },
+    {
+        "name": "Roseann Jarvis",
+        "gender": "female",
+        "company": "Aquazure"
+    },
+    {
+        "name": "Johnston Park",
+        "gender": "male",
+        "company": "Netur"
+    },
+    {
+        "name": "Wong Craft",
+        "gender": "male",
+        "company": "Opticall"
+    },
+    {
+        "name": "Merritt Cole",
+        "gender": "male",
+        "company": "Techtrix"
+    },
+    {
+        "name": "Dale Byrd",
+        "gender": "female",
+        "company": "Kneedles"
+    },
+    {
+        "name": "Sara Delgado",
+        "gender": "female",
+        "company": "Netagy"
+    },
+    {
+        "name": "Alisha Myers",
+        "gender": "female",
+        "company": "Intradisk"
+    },
+    {
+        "name": "Felecia Smith",
+        "gender": "female",
+        "company": "Futurity"
+    },
+    {
+        "name": "Neal Harvey",
+        "gender": "male",
+        "company": "Pyramax"
+    },
+    {
+        "name": "Nola Miles",
+        "gender": "female",
+        "company": "Sonique"
+    },
+    {
+        "name": "Herring Pierce",
+        "gender": "male",
+        "company": "Geeketron"
+    },
+    {
+        "name": "Shelley Rodriquez",
+        "gender": "female",
+        "company": "Bostonic"
+    },
+    {
+        "name": "Cora Chase",
+        "gender": "female",
+        "company": "Isonus"
+    },
+    {
+        "name": "Mckay Santos",
+        "gender": "male",
+        "company": "Amtas"
+    },
+    {
+        "name": "Hilda Crane",
+        "gender": "female",
+        "company": "Jumpstack"
+    },
+    {
+        "name": "Jeanne Lindsay",
+        "gender": "female",
+        "company": "Genesynk"
+    },
+    {
+        "name": "Frye Sharpe",
+        "gender": "male",
+        "company": "Eplode"
+    },
+    {
+        "name": "Velma Fry",
+        "gender": "female",
+        "company": "Ronelon"
+    },
+    {
+        "name": "Reyna Espinoza",
+        "gender": "female",
+        "company": "Prismatic"
+    },
+    {
+        "name": "Spencer Sloan",
+        "gender": "male",
+        "company": "Comverges"
+    },
+    {
+        "name": "Graham Marsh",
+        "gender": "male",
+        "company": "Medifax"
+    },
+    {
+        "name": "Hale Boone",
+        "gender": "male",
+        "company": "Digial"
+    },
+    {
+        "name": "Wiley Hubbard",
+        "gender": "male",
+        "company": "Zensus"
+    },
+    {
+        "name": "Blackburn Drake",
+        "gender": "male",
+        "company": "Frenex"
+    },
+    {
+        "name": "Franco Hunter",
+        "gender": "male",
+        "company": "Rockabye"
+    },
+    {
+        "name": "Barnett Case",
+        "gender": "male",
+        "company": "Norali"
+    },
+    {
+        "name": "Alexander Foley",
+        "gender": "male",
+        "company": "Geekosis"
+    },
+    {
+        "name": "Lynette Stein",
+        "gender": "female",
+        "company": "Macronaut"
+    },
+    {
+        "name": "Anthony Joyner",
+        "gender": "male",
+        "company": "Senmei"
+    },
+    {
+        "name": "Garrett Brennan",
+        "gender": "male",
+        "company": "Bluegrain"
+    },
+    {
+        "name": "Betsy Horton",
+        "gender": "female",
+        "company": "Zilla"
+    },
+    {
+        "name": "Patton Small",
+        "gender": "male",
+        "company": "Genmex"
+    },
+    {
+        "name": "Lakisha Huber",
+        "gender": "female",
+        "company": "Insource"
+    },
+    {
+        "name": "Lindsay Avery",
+        "gender": "female",
+        "company": "Unq"
+    },
+    {
+        "name": "Ayers Hood",
+        "gender": "male",
+        "company": "Accuprint"
+    },
+    {
+        "name": "Torres Durham",
+        "gender": "male",
+        "company": "Uplinx"
+    },
+    {
+        "name": "Vincent Hernandez",
+        "gender": "male",
+        "company": "Talendula"
+    },
+    {
+        "name": "Baird Ryan",
+        "gender": "male",
+        "company": "Aquasseur"
+    },
+    {
+        "name": "Georgia Mercer",
+        "gender": "female",
+        "company": "Skyplex"
+    },
+    {
+        "name": "Francesca Elliott",
+        "gender": "female",
+        "company": "Nspire"
+    },
+    {
+        "name": "Lyons Peters",
+        "gender": "male",
+        "company": "Quinex"
+    },
+    {
+        "name": "Kristi Brewer",
+        "gender": "female",
+        "company": "Oronoko"
+    },
+    {
+        "name": "Tonya Bray",
+        "gender": "female",
+        "company": "Insuron"
+    },
+    {
+        "name": "Valenzuela Huff",
+        "gender": "male",
+        "company": "Applideck"
+    },
+    {
+        "name": "Tiffany Anderson",
+        "gender": "female",
+        "company": "Zanymax"
+    },
+    {
+        "name": "Jerri King",
+        "gender": "female",
+        "company": "Eventex"
+    },
+    {
+        "name": "Rocha Meadows",
+        "gender": "male",
+        "company": "Goko"
+    },
+    {
+        "name": "Marcy Green",
+        "gender": "female",
+        "company": "Pharmex"
+    },
+    {
+        "name": "Kirk Cross",
+        "gender": "male",
+        "company": "Portico"
+    },
+    {
+        "name": "Hattie Mullen",
+        "gender": "female",
+        "company": "Zilencio"
+    },
+    {
+        "name": "Deann Bridges",
+        "gender": "female",
+        "company": "Equitox"
+    },
+    {
+        "name": "Chaney Roach",
+        "gender": "male",
+        "company": "Qualitern"
+    },
+    {
+        "name": "Consuelo Dickson",
+        "gender": "female",
+        "company": "Poshome"
+    },
+    {
+        "name": "Billie Rowe",
+        "gender": "female",
+        "company": "Cemention"
+    },
+    {
+        "name": "Bean Donovan",
+        "gender": "male",
+        "company": "Mantro"
+    },
+    {
+        "name": "Lancaster Patel",
+        "gender": "male",
+        "company": "Krog"
+    },
+    {
+        "name": "Rosa Dyer",
+        "gender": "female",
+        "company": "Netility"
+    },
+    {
+        "name": "Christine Compton",
+        "gender": "female",
+        "company": "Bleeko"
+    },
+    {
+        "name": "Milagros Finch",
+        "gender": "female",
+        "company": "Handshake"
+    },
+    {
+        "name": "Ericka Alvarado",
+        "gender": "female",
+        "company": "Lyrichord"
+    },
+    {
+        "name": "Sylvia Sosa",
+        "gender": "female",
+        "company": "Circum"
+    },
+    {
+        "name": "Humphrey Curtis",
+        "gender": "male",
+        "company": "Corepan"
+    }
+]

--- a/misc/site/data/100_DESC.json
+++ b/misc/site/data/100_DESC.json
@@ -1,0 +1,502 @@
+[
+    {
+        "name": "Wilder Gonzales",
+        "gender": "male",
+        "company": "Geekko"
+    },
+    {
+        "name": "Valarie Atkinson",
+        "gender": "female",
+        "company": "Hopeli"
+    },
+    {
+        "name": "Schroeder Mathews",
+        "gender": "male",
+        "company": "Polarium"
+    },
+    {
+        "name": "Sarah Massey",
+        "gender": "female",
+        "company": "Bisba"
+    },
+    {
+        "name": "Robles Boyle",
+        "gender": "male",
+        "company": "Comtract"
+    },
+    {
+        "name": "Nellie Whitfield",
+        "gender": "female",
+        "company": "Exospace"
+    },
+    {
+        "name": "Lynda Mendoza",
+        "gender": "female",
+        "company": "Dogspa"
+    },
+    {
+        "name": "Jackson Macias",
+        "gender": "male",
+        "company": "Aquamate"
+    },
+    {
+        "name": "Georgina Schultz",
+        "gender": "female",
+        "company": "Suretech"
+    },
+    {
+        "name": "Evans Hickman",
+        "gender": "male",
+        "company": "Parleynet"
+    },
+    {
+        "name": "Ethel Price",
+        "gender": "female",
+        "company": "Enersol"
+    },
+    {
+        "name": "Dawson Barber",
+        "gender": "male",
+        "company": "Dymi"
+    },
+    {
+        "name": "Claudine Neal",
+        "gender": "female",
+        "company": "Sealoud"
+    },
+    {
+        "name": "Carroll Buchanan",
+        "gender": "male",
+        "company": "Ecosys"
+    },
+    {
+        "name": "Bruce Strong",
+        "gender": "male",
+        "company": "Xyqag"
+    },
+    {
+        "name": "Beryl Rice",
+        "gender": "female",
+        "company": "Velity"
+    },
+    {
+        "name": "Pena Pena",
+        "gender": "male",
+        "company": "Quarx"
+    },
+    {
+        "name": "Lelia Gates",
+        "gender": "female",
+        "company": "Proxsoft"
+    },
+    {
+        "name": "Letitia Vasquez",
+        "gender": "female",
+        "company": "Slumberia"
+    },
+    {
+        "name": "Trevino Moreno",
+        "gender": "male",
+        "company": "Conjurica"
+    },
+    {
+        "name": "Barr Page",
+        "gender": "male",
+        "company": "Apex"
+    },
+    {
+        "name": "Kirkland Merrill",
+        "gender": "male",
+        "company": "Utara"
+    },
+    {
+        "name": "Blanche Conley",
+        "gender": "female",
+        "company": "Imkan"
+    },
+    {
+        "name": "Atkins Dunlap",
+        "gender": "male",
+        "company": "Comveyor"
+    },
+    {
+        "name": "Everett Foreman",
+        "gender": "male",
+        "company": "Maineland"
+    },
+    {
+        "name": "Gould Randolph",
+        "gender": "male",
+        "company": "Intergeek"
+    },
+    {
+        "name": "Kelli Leon",
+        "gender": "female",
+        "company": "Verbus"
+    },
+    {
+        "name": "Freda Mason",
+        "gender": "female",
+        "company": "Accidency"
+    },
+    {
+        "name": "Tucker Maxwell",
+        "gender": "male",
+        "company": "Lumbrex"
+    },
+    {
+        "name": "Yvonne Parsons",
+        "gender": "female",
+        "company": "Zolar"
+    },
+    {
+        "name": "Woods Key",
+        "gender": "male",
+        "company": "Bedder"
+    },
+    {
+        "name": "Stephens Reilly",
+        "gender": "male",
+        "company": "Acusage"
+    },
+    {
+        "name": "Mcfarland Sparks",
+        "gender": "male",
+        "company": "Comvey"
+    },
+    {
+        "name": "Jocelyn Sawyer",
+        "gender": "female",
+        "company": "Fortean"
+    },
+    {
+        "name": "Renee Barr",
+        "gender": "female",
+        "company": "Kiggle"
+    },
+    {
+        "name": "Gaines Beck",
+        "gender": "male",
+        "company": "Sequitur"
+    },
+    {
+        "name": "Luisa Farrell",
+        "gender": "female",
+        "company": "Cinesanct"
+    },
+    {
+        "name": "Robyn Strickland",
+        "gender": "female",
+        "company": "Obones"
+    },
+    {
+        "name": "Roseann Jarvis",
+        "gender": "female",
+        "company": "Aquazure"
+    },
+    {
+        "name": "Johnston Park",
+        "gender": "male",
+        "company": "Netur"
+    },
+    {
+        "name": "Wong Craft",
+        "gender": "male",
+        "company": "Opticall"
+    },
+    {
+        "name": "Merritt Cole",
+        "gender": "male",
+        "company": "Techtrix"
+    },
+    {
+        "name": "Dale Byrd",
+        "gender": "female",
+        "company": "Kneedles"
+    },
+    {
+        "name": "Sara Delgado",
+        "gender": "female",
+        "company": "Netagy"
+    },
+    {
+        "name": "Alisha Myers",
+        "gender": "female",
+        "company": "Intradisk"
+    },
+    {
+        "name": "Felecia Smith",
+        "gender": "female",
+        "company": "Futurity"
+    },
+    {
+        "name": "Neal Harvey",
+        "gender": "male",
+        "company": "Pyramax"
+    },
+    {
+        "name": "Nola Miles",
+        "gender": "female",
+        "company": "Sonique"
+    },
+    {
+        "name": "Herring Pierce",
+        "gender": "male",
+        "company": "Geeketron"
+    },
+    {
+        "name": "Shelley Rodriquez",
+        "gender": "female",
+        "company": "Bostonic"
+    },
+    {
+        "name": "Cora Chase",
+        "gender": "female",
+        "company": "Isonus"
+    },
+    {
+        "name": "Mckay Santos",
+        "gender": "male",
+        "company": "Amtas"
+    },
+    {
+        "name": "Hilda Crane",
+        "gender": "female",
+        "company": "Jumpstack"
+    },
+    {
+        "name": "Jeanne Lindsay",
+        "gender": "female",
+        "company": "Genesynk"
+    },
+    {
+        "name": "Frye Sharpe",
+        "gender": "male",
+        "company": "Eplode"
+    },
+    {
+        "name": "Velma Fry",
+        "gender": "female",
+        "company": "Ronelon"
+    },
+    {
+        "name": "Reyna Espinoza",
+        "gender": "female",
+        "company": "Prismatic"
+    },
+    {
+        "name": "Spencer Sloan",
+        "gender": "male",
+        "company": "Comverges"
+    },
+    {
+        "name": "Graham Marsh",
+        "gender": "male",
+        "company": "Medifax"
+    },
+    {
+        "name": "Hale Boone",
+        "gender": "male",
+        "company": "Digial"
+    },
+    {
+        "name": "Wiley Hubbard",
+        "gender": "male",
+        "company": "Zensus"
+    },
+    {
+        "name": "Blackburn Drake",
+        "gender": "male",
+        "company": "Frenex"
+    },
+    {
+        "name": "Franco Hunter",
+        "gender": "male",
+        "company": "Rockabye"
+    },
+    {
+        "name": "Barnett Case",
+        "gender": "male",
+        "company": "Norali"
+    },
+    {
+        "name": "Alexander Foley",
+        "gender": "male",
+        "company": "Geekosis"
+    },
+    {
+        "name": "Lynette Stein",
+        "gender": "female",
+        "company": "Macronaut"
+    },
+    {
+        "name": "Anthony Joyner",
+        "gender": "male",
+        "company": "Senmei"
+    },
+    {
+        "name": "Garrett Brennan",
+        "gender": "male",
+        "company": "Bluegrain"
+    },
+    {
+        "name": "Betsy Horton",
+        "gender": "female",
+        "company": "Zilla"
+    },
+    {
+        "name": "Patton Small",
+        "gender": "male",
+        "company": "Genmex"
+    },
+    {
+        "name": "Lakisha Huber",
+        "gender": "female",
+        "company": "Insource"
+    },
+    {
+        "name": "Lindsay Avery",
+        "gender": "female",
+        "company": "Unq"
+    },
+    {
+        "name": "Ayers Hood",
+        "gender": "male",
+        "company": "Accuprint"
+    },
+    {
+        "name": "Torres Durham",
+        "gender": "male",
+        "company": "Uplinx"
+    },
+    {
+        "name": "Vincent Hernandez",
+        "gender": "male",
+        "company": "Talendula"
+    },
+    {
+        "name": "Baird Ryan",
+        "gender": "male",
+        "company": "Aquasseur"
+    },
+    {
+        "name": "Georgia Mercer",
+        "gender": "female",
+        "company": "Skyplex"
+    },
+    {
+        "name": "Francesca Elliott",
+        "gender": "female",
+        "company": "Nspire"
+    },
+    {
+        "name": "Lyons Peters",
+        "gender": "male",
+        "company": "Quinex"
+    },
+    {
+        "name": "Kristi Brewer",
+        "gender": "female",
+        "company": "Oronoko"
+    },
+    {
+        "name": "Tonya Bray",
+        "gender": "female",
+        "company": "Insuron"
+    },
+    {
+        "name": "Valenzuela Huff",
+        "gender": "male",
+        "company": "Applideck"
+    },
+    {
+        "name": "Tiffany Anderson",
+        "gender": "female",
+        "company": "Zanymax"
+    },
+    {
+        "name": "Jerri King",
+        "gender": "female",
+        "company": "Eventex"
+    },
+    {
+        "name": "Rocha Meadows",
+        "gender": "male",
+        "company": "Goko"
+    },
+    {
+        "name": "Marcy Green",
+        "gender": "female",
+        "company": "Pharmex"
+    },
+    {
+        "name": "Kirk Cross",
+        "gender": "male",
+        "company": "Portico"
+    },
+    {
+        "name": "Hattie Mullen",
+        "gender": "female",
+        "company": "Zilencio"
+    },
+    {
+        "name": "Deann Bridges",
+        "gender": "female",
+        "company": "Equitox"
+    },
+    {
+        "name": "Chaney Roach",
+        "gender": "male",
+        "company": "Qualitern"
+    },
+    {
+        "name": "Consuelo Dickson",
+        "gender": "female",
+        "company": "Poshome"
+    },
+    {
+        "name": "Billie Rowe",
+        "gender": "female",
+        "company": "Cemention"
+    },
+    {
+        "name": "Bean Donovan",
+        "gender": "male",
+        "company": "Mantro"
+    },
+    {
+        "name": "Lancaster Patel",
+        "gender": "male",
+        "company": "Krog"
+    },
+    {
+        "name": "Rosa Dyer",
+        "gender": "female",
+        "company": "Netility"
+    },
+    {
+        "name": "Christine Compton",
+        "gender": "female",
+        "company": "Bleeko"
+    },
+    {
+        "name": "Milagros Finch",
+        "gender": "female",
+        "company": "Handshake"
+    },
+    {
+        "name": "Ericka Alvarado",
+        "gender": "female",
+        "company": "Lyrichord"
+    },
+    {
+        "name": "Sylvia Sosa",
+        "gender": "female",
+        "company": "Circum"
+    },
+    {
+        "name": "Humphrey Curtis",
+        "gender": "male",
+        "company": "Corepan"
+    }
+]

--- a/misc/tutorial/307_external_sorting.ngdoc
+++ b/misc/tutorial/307_external_sorting.ngdoc
@@ -1,0 +1,86 @@
+@ngdoc overview
+@name Tutorial: 307 External Sorting
+@description
+
+Sometimes you want to sort data externally, either on the client using custom sort routines (that are over and
+above those you can achieve with {@link tutorial/xxxxxx custom sort functions}, or on the server as part of
+your data retrieve.
+
+UI-Grid provides two functions that support this, firstly a sortChanged event that tells you when a user has
+changed their requested sort using the grid ui, and secondly a useExternalSorting property to turn off
+the grid native sorting.
+
+@example
+In this example we suppress the internal sorting, and emulate an external sort by picking one of three 
+json files to show - one sorted ASC, one sorted DESC, and one not sorted.  To further illustrate that this
+is using external sorting, the external sort routine (consisting of me manually editing json files) got bored
+of sorting after the first 10 or so rows.
+
+<example module="app">
+  <file name="app.js">
+    var app = angular.module('app', ['ui.grid']);
+
+    app.controller('MainCtrl', ['$scope', '$http', '$interval', 'uiGridConstants', function ($scope, $http, $interval, uiGridConstants) {
+
+      $scope.gridOptions = {
+        useExternalSorting: true,
+        columnDefs: [
+          { name: 'name' },
+          { name: 'gender', enableSorting: false},
+          { name: 'company', enableSorting: false}
+        ],
+        onRegisterApi: function( gridApi ) {
+          $scope.gridApi = gridApi;
+          $interval(function() {
+            $scope.gridApi.core.on.sortChanged( $scope, function( grid, sortColumns ) {
+              if( sortColumns.length === 0 ){
+                $http.get('/data/100.json')
+                .success(function(data) {
+                  $scope.gridOptions.data = data;
+                });
+              } else {
+                switch( sortColumns[0].sort.direction ) {
+                  case uiGridConstants.ASC:
+                    $http.get('/data/100_ASC.json')
+                    .success(function(data) {
+                      $scope.gridOptions.data = data;
+                    });
+                    break;
+                  case uiGridConstants.DESC:
+                    $http.get('/data/100_DESC.json')
+                    .success(function(data) {
+                      $scope.gridOptions.data = data;
+                    });
+                    break;
+                  case undefined:
+                    $http.get('/data/100.json')
+                    .success(function(data) {
+                      $scope.gridOptions.data = data;
+                    });
+                    break;
+                }
+              }
+            });
+          }, 200, 1);
+        }
+      };
+      
+      $http.get('/data/100.json')
+      .success(function(data) {
+        $scope.gridOptions.data = data;
+      });
+      
+    }]);
+  </file>
+  <file name="index.html">
+    <div ng-controller="MainCtrl">
+      <div ui-grid="gridOptions" class="grid"></div>
+    </div>
+  </file>
+  <file name="main.css">
+    .grid {
+      width: 500px;
+      height: 250px;
+    }
+  </file>
+</example>

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -133,7 +133,7 @@ angular.module('ui.grid')
    * @description Refresh the rendered grid on screen.
    * 
    */
-  this.api.registerMethod( 'core', 'refresh', this.refresh );
+  self.api.registerMethod( 'core', 'refresh', this.refresh );
 
   /**
    * @ngdoc function
@@ -143,7 +143,28 @@ angular.module('ui.grid')
    * @returns {promise} promise that is resolved when render completes?
    * 
    */
-  this.api.registerMethod( 'core', 'refreshRows', this.refreshRows );
+  self.api.registerMethod( 'core', 'refreshRows', this.refreshRows );
+
+
+  /**
+   * @ngdoc function
+   * @name sortChanged
+   * @methodOf  ui.grid.core.api:PublicApi
+   * @description The sort criteria on one or more columns has
+   * changed.  Provides as parameters the grid and the output of
+   * getColumnSorting, which is an array of gridColumns
+   * that have sorting on them, sorted in priority order. 
+   * 
+   * @param {Grid} grid the grid
+   * @param {array} sortColumns an array of columns with 
+   * sorts on them, in priority order
+   * 
+   * @example
+   * <pre>
+   *      gridApi.core.on.sortChanged( grid, sortColumns );
+   * </pre>
+   */
+  self.api.registerEvent( 'core', 'sortChanged' );
 };
 
     /**
@@ -1242,6 +1263,7 @@ angular.module('ui.grid')
    * @name sortColumn
    * @methodOf ui.grid.class:Grid
    * @description Set the sorting on a given column, optionally resetting any existing sorting on the Grid.
+   * Emits the sortChanged event whenever the sort criteria are changed.
    * @param {GridColumn} column Column to set the sorting on
    * @param {uiGridConstants.ASC|uiGridConstants.DESC} [direction] Direction to sort by, either descending or ascending.
    *   If not provided, the column will iterate through the sort directions: ascending, descending, unsorted.
@@ -1290,6 +1312,8 @@ angular.module('ui.grid')
     else {
       column.sort.direction = direction;
     }
+    
+    self.api.core.raise.sortChanged( self, self.getColumnSorting() );
 
     return $q.when(column);
   };

--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -66,7 +66,9 @@ angular.module('ui.grid')
      * both grid refresh and emits the rowsVisibleChanged event
      * @param {object} rowEntity gridOptions.data[] array instance
      */
-    this.grid.api.registerMethod( 'core', 'setRowInvisible', this.setRowInvisible );
+    if (!this.grid.api.core.setRowInvisible){
+      this.grid.api.registerMethod( 'core', 'setRowInvisible', this.setRowInvisible );
+    }
 
     /**
      * @ngdoc function
@@ -79,7 +81,9 @@ angular.module('ui.grid')
      * TODO: if a filter is active then we can't just set it to visible?
      * @param {object} rowEntity gridOptions.data[] array instance
      */
-    this.grid.api.registerMethod( 'core', 'clearRowInvisible', this.clearRowInvisible );
+    if (!this.grid.api.core.clearRowInvisible){
+      this.grid.api.registerMethod( 'core', 'clearRowInvisible', this.clearRowInvisible );
+    }
 
     /**
      * @ngdoc function
@@ -89,7 +93,9 @@ angular.module('ui.grid')
      * @param {Grid} grid the grid you want to get visible rows from
      * @returns {array} an array of gridRow 
      */
-    this.grid.api.registerMethod( 'core', 'getVisibleRows', this.getVisibleRows );
+    if (!this.grid.api.core.getVisibleRows){
+      this.grid.api.registerMethod( 'core', 'getVisibleRows', this.getVisibleRows );
+    }
     
     /**
      * @ngdoc event
@@ -104,7 +110,9 @@ angular.module('ui.grid')
      * and that is the one that would have been useful.
      * 
      */
-    this.grid.api.registerEvent( 'core', 'rowsVisibleChanged' );
+    if (!this.grid.api.core.raise.rowsVisibleChanged){
+      this.grid.api.registerEvent( 'core', 'rowsVisibleChanged' );
+    }
     
   }
 

--- a/src/js/core/services/rowSorter.js
+++ b/src/js/core/services/rowSorter.js
@@ -2,6 +2,15 @@
 
 var module = angular.module('ui.grid');
 
+/**
+ * @ngdoc object
+ * @name ui.grid.class:RowSorter
+ * @description RowSorter provides the default sorting mechanisms, 
+ * including guessing column types and applying appropriate sort 
+ * algorithms
+ * 
+ */ 
+
 module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGridConstants) {
   var currencyRegexStr = 
     '(' +
@@ -186,10 +195,34 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
     }
   };
 
+  /**
+   * @ngdoc object
+   * @name useExternalSorting
+   * @propertyOf ui.grid.class:GridOptions
+   * @description Prevents the internal sorting from executing.  Events will
+   * still be fired when the sort changes, and the sort information on
+   * the columns will be updated, allowing an external sorter (for example,
+   * server sorting) to be implemented.  Defaults to false. 
+   * 
+   */
+  /**
+   * @ngdoc method
+   * @methodOf ui.grid.class:RowSorter
+   * @name sort
+   * @description sorts the grid 
+   * @param {Object} grid the grid itself
+   * @param {Object} rows the rows to be sorted
+   * @param {Object} columns the columns in which to look
+   * for sort criteria
+   */
   rowSorter.sort = function rowSorterSort(grid, rows, columns) {
     // first make sure we are even supposed to do work
     if (!rows) {
       return;
+    }
+    
+    if (grid.options.useExternalSorting){
+      return rows;
     }
 
     // Build the list of columns to sort by

--- a/test/unit/core/row-sorting.spec.js
+++ b/test/unit/core/row-sorting.spec.js
@@ -111,6 +111,15 @@ describe('rowSorter', function() {
       expect(ret[0].entity.name).toEqual('Jim');
     });
 
+    it('should not sort if useExternalSorting is set', function() {
+      cols[0].sort.direction = uiGridConstants.DESC;
+      grid.options.useExternalSorting = true;
+
+      var ret = rowSorter.sort(grid, rows, cols);
+
+      expect(ret[0].entity.name).toEqual('Bob');
+    });
+
     // TODO(c0bra) ...
     describe('with a custom sorting algorithm', function () {
       beforeEach(function() {


### PR DESCRIPTION
Add external sorting api, gridOption.useExternalSorting, and
api.core.on.sortChanged().

Includes unit tests of the sort suppression (but not the
event raise, as there weren't existing sort unit tests) and a
tutorial demonstrating the usage.
