### PR TITLE
Fix left/right scroll on OSX/trackpad

### DIFF
--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -504,7 +504,7 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
 
       // Webkit
       if ( orgEvent.wheelDeltaY !== undefined ) { deltaY = orgEvent.wheelDeltaY; }
-      if ( orgEvent.wheelDeltaX !== undefined ) { deltaX = orgEvent.wheelDeltaX * -1; }
+      if ( orgEvent.wheelDeltaX !== undefined ) { deltaX = orgEvent.wheelDeltaX; }
 
       // Look for lowest delta to normalize the delta values
       absDelta = Math.abs(delta);


### PR DESCRIPTION
Relates to #1541 

Speculative change - this fixes left/right scrolling for me.  However
it is entirely possible that it breaks left/right scrolling for other
trackpads that issue wheel events - none of my other devices issue
left/right wheel events (and perhaps such devices are few and far
between).  Submitted to see whether anyone else is impacted.
