### PR TITLE
Fix support for multiple filters, add support for a custom filter.condition function

### DIFF
--- a/misc/tutorial/103_filtering.ngdoc
+++ b/misc/tutorial/103_filtering.ngdoc
@@ -2,28 +2,97 @@
 @name Tutorial: 103 Filtering
 @description
 
+### Simple setup
+
 UI-Grid allows you to filter rows. Just set the `enableFiltering` flag in your grid options (it is off by default).
 
-Filtering can be disabled at the column level by setting `enableFiltering: false` in the column def. See the last column below for an example.
+Filtering can be disabled at the column level by setting `enableFiltering: false` in the column def. See the "company" column below for an example.
 
-Default filters can be set programmatically by setting `filter: { term: 'xxx' }` in the column def.  See the second column below.
+The filter field can be pre-populated by setting `filter: { term: 'xxx' }` in the column def.  See the "gender" column below.
+
+### Conditon
+
+The `filter` object introduced above may also specify a `condition`, which defines how rows are chosen as matching the filter term. UI-Grid comes with several conditions
+out-of-the-box, which are defined by `uiGridConstants.filter.*`. See the "email" column below. 
+
+If no condition is set, UI-Grid will take a best guess based on the contents of the filter field. Even basic wildcard (*) use is supported!
+
+If you want to create your own filtering logic, the `condition` field of the `filter` object can also be a function that gets run for each 
+row. Such a function has the following signature:
+
+```Javascript
+function myCustomSorter(searchTerm, cellValue, row, column) {
+  // Custom logic that returns true if `row`
+  // passes the filter and false if it should
+  // be filtered out
+  return booleanResult;
+}
+```
+
+For an example of this, see the "phone" column below for an example of this; the custom filter condition makes sure to strip the phone number of everything
+except digits to compare to the search term.
+
+### Placeholder
+
+Set the `placeholder` property on the `filter` object to add a `placeholder=""` attribute to the input element. This is set for the "email" and "age" columns below.
+
+### Multiple filter fields
+
+Occasionally, you may want to provide two or more filters for a single column. This can be accomplished by setting a `filters` array instead of a `filter` object.
+The elements of this array are the same as the contents of the `filter` object in all the previous examples. In fact, `filter: { term: 'xxx' }` is just an alias 
+for `filters: [{ term: 'xxx' }]`. See the "age" column below for an example.
+
+
 
 @example
 <example module="app">
   <file name="app.js">
     var app = angular.module('app', ['ngAnimate', 'ui.grid']);
 
-    app.controller('MainCtrl', ['$scope', '$http', function ($scope, $http) {
+    app.controller('MainCtrl', ['$scope', '$http', 'uiGridConstants', function ($scope, $http, uiGridConstants) {
       $scope.gridOptions = {
         enableFiltering: true,
         columnDefs: [
+          // default
           { field: 'name' },
+          // pre-populated search field
           { field: 'gender', filter: { term: 'male' } },
-          { field: 'company', enableFiltering: false  }
+          // no filter input
+          { field: 'company', enableFiltering: false  },
+          // specifies one of the built-in conditions
+          // and a placeholder for the input
+          {
+            field: 'email',
+            filter: {
+              condition: uiGridConstants.filter.ENDS_WITH,
+              placeholder: 'ends with'
+            }
+          },
+          // custom condition function
+          {
+            field: 'phone',
+            filter: {
+              condition: function(searchTerm, cellValue) {
+                var strippedValue = (cellValue + '').replace(/[^\d]/g, '');
+                return strippedValue.indexOf(searchTerm) >= 0;
+              }
+            }
+          },
+          // multiple filters
+          { field: 'age', filters: [
+            {
+              condition: uiGridConstants.filter.GREATER_THAN,
+              placeholder: 'greater than'
+            },
+            {
+              condition: uiGridConstants.filter.LESS_THAN,
+              placeholder: 'less than'
+            }
+          ]}
         ]
       };
 
-      $http.get('/data/100.json')
+      $http.get('/data/500_complex.json')
         .success(function(data) {
           $scope.gridOptions.data = data;
         });
@@ -42,7 +111,7 @@ Default filters can be set programmatically by setting `filter: { term: 'xxx' }`
   </file>
   <file name="main.css">
     .grid {
-      width: 500px;
+      width: 650px;
       height: 400px;
     }
   </file>

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -151,15 +151,23 @@
             }
     
             if ($scope.filterable) {
-              $scope.$on('$destroy', $scope.$watch('col.filter.term', function(n, o) {
-                uiGridCtrl.grid.refresh()
-                  .then(function () {
-                    if (uiGridCtrl.prevScrollArgs && uiGridCtrl.prevScrollArgs.y && uiGridCtrl.prevScrollArgs.y.percentage) {
-                       uiGridCtrl.fireScrollingEvent({ y: { percentage: uiGridCtrl.prevScrollArgs.y.percentage } });
-                    }
-                    // uiGridCtrl.fireEvent('force-vertical-scroll');
-                  });
-              }));
+              var filterDeregisters = [];
+              angular.forEach($scope.col.filters, function(filter, i) {
+                filterDeregisters.push($scope.$watch('col.filters[' + i + '].term', function(n, o) {
+                  uiGridCtrl.grid.refresh()
+                    .then(function () {
+                      if (uiGridCtrl.prevScrollArgs && uiGridCtrl.prevScrollArgs.y && uiGridCtrl.prevScrollArgs.y.percentage) {
+                         uiGridCtrl.fireScrollingEvent({ y: { percentage: uiGridCtrl.prevScrollArgs.y.percentage } });
+                      }
+                      // uiGridCtrl.fireEvent('force-vertical-scroll');
+                    });
+                }));  
+              });
+              $scope.$on('$destroy', function() {
+                angular.forEach(filterDeregisters, function(filterDeregister) {
+                  filterDeregister();
+                });
+              });
             }
           }
         };

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -86,9 +86,9 @@ angular.module('ui.grid')
     * @ngdoc property
     * @name filter
     * @propertyOf ui.grid.class:GridColumn
-    * @description Filter to insert against this column.  
+    * @description Filter on this column.  
     * @example
-    * <pre>{ term: 'text' }</pre>
+    * <pre>{ term: 'text', condition: uiGridConstants.filter.STARTS_WITH, placeholder: 'type to filter...' }</pre>
     *
     */
 
@@ -96,9 +96,17 @@ angular.module('ui.grid')
     * @ngdoc property
     * @name filter
     * @propertyOf ui.grid.class:GridOptions.columnDef
-    * @description Filter to insert against this column.  
+    * @description Specify a single filter field on this column.
     * @example
-    * <pre>{ term: 'text' }</pre>
+    * <pre>$scope.gridOptions.columnDefs = [ 
+    *   {
+    *     field: 'field1',
+    *     filter: {
+    *       condition: uiGridConstants.filter.STARTS_WITH,
+    *       placeholder: 'starts with...'
+    *     }
+    *   }
+    * ]; </pre>
     *
     */
     
@@ -211,8 +219,46 @@ angular.module('ui.grid')
     * @ngdoc array
     * @name filters
     * @propertyOf ui.grid.class:GridOptions.columnDef
-    * @description unclear what this does or how it's used, but it does something.
+    * @description Specify multiple filter fields.
+    * @example
+    * <pre>$scope.gridOptions.columnDefs = [ 
+    *   {
+    *     field: 'field1', filters: [
+    *       {
+    *         condition: uiGridConstants.filter.STARTS_WITH,
+    *         placeholder: 'starts with...'
+    *       },
+    *       {
+    *         condition: uiGridConstants.filter.ENDS_WITH,
+    *         placeholder: 'ends with...'
+    *       }
+    *     ]
+    *   }
+    * ]; </pre>
     *
+    * 
+    */ 
+   
+   /** 
+    * @ngdoc array
+    * @name filters
+    * @propertyOf ui.grid.class:GridColumn
+    * @description Filters for this column. Includes 'term' property bound to filter input elements.
+    * @example
+    * <pre>[
+    *   {
+    *     term: 'foo', // ngModel for <input>
+    *     condition: uiGridConstants.filter.STARTS_WITH,
+    *     placeholder: 'starts with...'
+    *   },
+    *   {
+    *     term: 'baz',
+    *     condition: uiGridConstants.filter.ENDS_WITH,
+    *     placeholder: 'ends with...'
+    *   }
+    * ] </pre>
+    *
+    * 
     */   
 
    /** 
@@ -361,19 +407,74 @@ angular.module('ui.grid')
     // Use the column definition sort if we were passed it
     self.setPropertyOrDefault(colDef, 'sort');
 
+    // Set up default filters array for when one is not provided.
+    //   In other words, this (in column def):
+    //   
+    //       filter: { term: 'something', flags: {}, condition: [CONDITION] }
+    //       
+    //   is just shorthand for this:
+    //   
+    //       filters: [{ term: 'something', flags: {}, condition: [CONDITION] }]
+    //       
+    var defaultFilters = [];
+    if (colDef.filter) {
+      defaultFilters.push(colDef.filter);
+    }
+    else if (self.enableFiltering && self.grid.options.enableFiltering) {
+      // Add an empty filter definition object, which will
+      // translate to a guessed condition and no pre-populated
+      // value for the filter <input>.
+      defaultFilters.push({});
+    }
+
+    /**
+     * @ngdoc object
+     * @name ui.grid.class:GridOptions.columnDef.filter
+     * @propertyOf ui.grid.class:GridOptions.columnDef
+     * @description An object defining filtering for a column.
+     */    
+
+    /**
+     * @ngdoc property
+     * @name condition
+     * @propertyOf ui.grid.class:GridOptions.columnDef.filter
+     * @description Defines how rows are chosen as matching the filter term. This can be set to
+     * one of the constants in uiGridConstants.filter, or you can supply a custom filter function
+     * that gets passed the following arguments: [searchTerm, cellValue, row, column].
+     */
+    
+    /**
+     * @ngdoc property
+     * @name term
+     * @propertyOf ui.grid.class:GridOptions.columnDef.filter
+     * @description If set, the filter field will be pre-populated
+     * with this value.
+     */
+
+    /**
+     * @ngdoc property
+     * @name placeholder
+     * @propertyOf ui.grid.class:GridOptions.columnDef.filter
+     * @description String that will be set to the <input>.placeholder attribute.
+     */
+
     /*
 
       self.filters = [
         {
           term: 'search term'
-          condition: uiGridContants.filter.CONTAINS
+          condition: uiGridConstants.filter.CONTAINS,
+          placeholder: 'my placeholder',
+          flags: {
+            caseSensitive: true
+          }
         }
       ]
 
     */
 
     self.setPropertyOrDefault(colDef, 'filter');
-    self.setPropertyOrDefault(colDef, 'filters', []);
+    self.setPropertyOrDefault(colDef, 'filters', defaultFilters);
   };
 
 

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -12,11 +12,11 @@
     <i class="ui-grid-icon-angle-down">&nbsp;<i>
   </div>
 
-  <div ng-if="filterable" class="ui-grid-filter-container">
-    <input type="text" class="ui-grid-filter-input" ng-model="col.filter.term" ng-click="$event.stopPropagation()" />
+  <div ng-if="filterable" class="ui-grid-filter-container" ng-repeat="colFilter in col.filters">
+    <input type="text" class="ui-grid-filter-input" ng-model="colFilter.term" ng-click="$event.stopPropagation()" ng-attr-placeholder="{{colFilter.placeholder || ''}}" />
 
-    <div class="ui-grid-filter-button" ng-click="col.filter.term = null">
-      <i class="ui-grid-icon-cancel right" ng-show="!!col.filter.term">&nbsp;</i> <!-- use !! because angular interprets 'f' as false -->
+    <div class="ui-grid-filter-button" ng-click="colFilter.term = null">
+      <i class="ui-grid-icon-cancel right" ng-show="!!colFilter.term">&nbsp;</i> <!-- use !! because angular interprets 'f' as false -->
     </div>
   </div>
 </div>


### PR DESCRIPTION
![ui-grid-filtering](https://cloud.githubusercontent.com/assets/1390651/4342629/16be11fc-4047-11e4-8489-17d6c18e21f1.gif)

Messages from relevant squashed commits:

```
Remove unnecessary term attribute from filter.

When filtering is enabled for a column but no filter or filters
property is set on the columnDef, a default filter object is
added to the column. This default object had an unnecessary
"term" property set to an empty string. This commit removes it.

Update API docs to reflect filter changes.

Also add a new definition for ui.grid.class:GridOptions.columnDef.filter
to docblocks, however this is not getting picked up by ngDoc. Perhaps
this is something someone else can help me figure out. Or it is not
something that is necessary, in which case we can take it out.

Add placeholder option to filter definition.

This allows for the placeholder attribute to be
added to the filter input element.

Add support for multiple filter fields.

This seems to have been the original plan for column filters.
A slight API change was necessary for the column definition object,
which I will properly document in an upcoming commit.

Fix #1538. Passing correct filter model to stripTerm.

Add support for a custom filter.condition function.

Instead of passing a uiGridConstants.filter.CONSTANT or RegExp
as a filter.condition, a user may pass a custom function that
will be run for each row. The function gets the following
arguments passed to it: searchTerm, cellValue, row, column.
It should return true if that row passes the filter, false if
it does not.
```
