### PR TITLE
RowEdit feature, row-by-row save to server

### DIFF
--- a/misc/tutorial/205_row_editable.ngdoc
+++ b/misc/tutorial/205_row_editable.ngdoc
@@ -1,0 +1,119 @@
+@ngdoc overview
+@name Tutorial: 205 Row Edit Feature
+@description
+
+The ui.grid.rowedit extends the edit feature to support callbacks for server saving of the data,
+with that data saved "row at a time."  This feature attempts to give a user an experience similar
+to a spreadsheet - in that they can edit whichever fields they wish, and the feature will seek to
+save the data "row at a time".  To the extent that the data doesn't generate errors, from a user
+perspective the saving is almost invisible - rows occassionally go grey (saving) and can't be edited whilst
+grey, but otherwise the user edits as if the data were local.  
+
+Each row is in one of four states at any point in time:
+
+- clean:  No edits have been made (or no edits since the last save)
+- `isDirty`:  Edits have been made, but the data has not yet been saved, either because the 
+  user is still editing the row or because the timer hasn't triggered as yet
+- `isSaving`: The callback to save the row has been called and has not yet returned.  The row is
+  not editable during this time, and is shown as greyed out, so as to avoid the user 
+  causing locking exceptions by editing the row again
+- `isError`: The save callback returned an error.  The row still has the updated data displayed,
+  but will be shown in red
+  
+The basic method of operation is that whenever a cell is edited (identified using the `edit.afterCellEdit`
+event) an `isDirty` flag is set on the row, and a `saveTimer` is set.  If another cell in the same row commences
+editing within 2 seconds (or other configurable time), then the timer will be destroyed again.  Otherwise
+upon the timer completing the row will be set to a status of `isSaving` and greyed out, and the `saveRow`
+event will be called.  The function called by this event must return a promise, and the rowedit feature
+will wait on that promise.
+
+If the cellNav feature is also enabled, then a setFocus on a cell within the row is sufficient to delay
+the timer (this more easily deals with situations where only some columns are editable, and a user tabs
+or clicks to a non-editable field on the same row).
+
+If the promise is successfully resolved then the row is set back to clean.  If the promise is rejected then the 
+row is set to a status of `isError`.
+
+Optionally, the calling application can request `flushDirtyRows`, which will trigger the save event for all
+currently dirty rows.
+
+Methods and properties are provided to operate with this regime:
+
+- `getDirtyRows()`: returns an array of gridRows of all currently dirty rows
+- `getErrorRows()`: returns an array of gridRows of all currently errored rows
+- `flushDirtyRows()`: flushes all currently dirty rows to the server, might be used 
+  on a page navigation request or pressing of a save button
+- `saveRow( rowEntity )`: event called when a row is ready for saving
+
+
+@example
+<example module="app">
+  <file name="app.js">
+    var app = angular.module('app', ['ui.grid', 'ui.grid.edit', 'ui.grid.rowEdit', 'ui.grid.cellNav', 'addressFormatter']);
+
+    angular.module('addressFormatter', []).filter('address', function () {
+      return function (input) {
+          return input.street + ', ' + input.city + ', ' + input.state + ', ' + input.zip;
+      };
+    });
+
+    app.controller('MainCtrl', ['$scope', '$http', '$q', '$interval', function ($scope, $http, $q, $interval) {
+      $scope.gridOptions = {};
+
+      $scope.gridOptions.columnDefs = [
+        { name: 'id', enableCellEdit: false },
+        { name: 'name', displayName: 'Name (editable)' },
+        { name: 'gender' },
+        { name: 'age', displayName: 'Age' , type: 'number'},
+        { name: 'registered', displayName: 'Registered' , type: 'date', cellFilter: 'date:"yyyy-MM-dd"'},
+        { name: 'address', displayName: 'Address', type: 'object', cellFilter: 'address'},
+        { name: 'address.city', displayName: 'Address (even rows editable)',
+             cellEditableCondition: function($scope){
+             return $scope.rowRenderIndex%2
+             }
+        },
+        { name: 'isActive', displayName: 'Active', type: 'boolean'}
+      ];
+
+      $scope.saveRow = function( rowEntity ) {
+        // create a fake promise - normally you'd use the promise returned by $http or $resource
+        var promise = $q.defer();
+        $scope.gridApi.rowEdit.setSavePromise( $scope.gridApi.grid, rowEntity, promise.promise );
+       
+        // fake a delay of 3 seconds whilst the save occurs, return error if gender is "male"
+        $interval( function() {
+          if (rowEntity.gender === 'male' ){
+            promise.reject();
+          } else {
+            promise.resolve();
+          }
+        }, 3000, 1);
+      }; 
+
+      $scope.gridOptions.onRegisterApi = function(gridApi){
+        //set gridApi on scope
+        $scope.gridApi = gridApi;
+        gridApi.rowEdit.on.saveRow($scope, $scope.saveRow);
+      };
+  
+      $http.get('/data/500_complex.json')
+      .success(function(data) {
+        for(i = 0; i < data.length; i++){
+          data[i].registered = new Date(data[i].registered);
+        }
+        $scope.gridOptions.data = data;
+      });
+    }]);
+  </file>
+  <file name="index.html">
+    <div ng-controller="MainCtrl">
+      <div ui-grid="gridOptions" ui-grid-edit ui-grid-row-edit ui-grid-cellNav class="grid"></div>
+    </div>
+  </file>
+  <file name="main.css">
+    .grid {
+      width: 600px;
+      height: 450px;
+    }
+  </file>
+</example>

--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -76,7 +76,33 @@
                  * @param {object} oldValue old value
                  */
                 afterCellEdit: function (rowEntity, colDef, newValue, oldValue) {
-                }
+                },
+                /**
+                 * @ngdoc event
+                 * @name beginCellEdit
+                 * @eventOf  ui.grid.edit.api:PublicApi
+                 * @description raised when cell editing starts on a cell
+                 * <pre>
+                 *      gridApi.edit.on.beginCellEdit(scope,function(rowEntity, colDef){})
+                 * </pre>
+                 * @param {object} rowEntity the options.data element that was edited
+                 * @param {object} colDef the column that was edited
+                 */
+                beginCellEdit: function (rowEntity, colDef) {
+                },
+                /**
+                 * @ngdoc event
+                 * @name cancelCellEdit
+                 * @eventOf  ui.grid.edit.api:PublicApi
+                 * @description raised when cell editing is cancelled on a cell
+                 * <pre>
+                 *      gridApi.edit.on.cancelCellEdit(scope,function(rowEntity, colDef){})
+                 * </pre>
+                 * @param {object} rowEntity the options.data element that was edited
+                 * @param {object} colDef the column that was edited
+                 */
+                cancelCellEdit: function (rowEntity, colDef) {
+                }                
               }
             },
             methods: {
@@ -390,14 +416,15 @@
               }
             }
 
-            function shouldEdit(col) {
-              return angular.isFunction(col.colDef.cellEditableCondition) ?
-                col.colDef.cellEditableCondition($scope) :
-                col.colDef.cellEditableCondition;
+            function shouldEdit(col, row) {
+              return !row.isSaving && 
+                ( angular.isFunction(col.colDef.cellEditableCondition) ?
+                    col.colDef.cellEditableCondition($scope) :
+                    col.colDef.cellEditableCondition );
             }
 
             function beginEdit() {
-              if (!shouldEdit($scope.col)) {
+              if (!shouldEdit($scope.col, $scope.row)) {
                 return;
               }
 
@@ -454,6 +481,7 @@
               });
 
               $scope.$broadcast(uiGridEditConstants.events.BEGIN_CELL_EDIT);
+              $scope.grid.api.edit.raise.beginCellEdit($scope.row.entity, $scope.col.colDef);
             }
 
             function endEdit(retainFocus) {
@@ -479,6 +507,7 @@
               cellModel.assign($scope, origCellValue);
               $scope.$apply();
 
+              $scope.grid.api.edit.raise.cancelCellEdit($scope.row.entity, $scope.col.colDef);
               endEdit(true);
             }
 

--- a/src/features/row-edit/js/gridRowEdit.js
+++ b/src/features/row-edit/js/gridRowEdit.js
@@ -1,0 +1,544 @@
+(function () {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @name ui.grid.rowEdit
+   * @description
+   *
+   *  # ui.grid.rowEdit
+   * This module extends the edit feature to provide tracking and saving of rows
+   * of data.  The tutorial provides more information on how this feature is best
+   * used {@link tutorial/205_row_editable here}.
+   * <br/>
+   * This feature depends on usage of the ui-grid-edit feature, and also benefits
+   * from use of ui-grid-cellNav to provide the full spreadsheet-like editing 
+   * experience
+   * 
+   */
+
+  var module = angular.module('ui.grid.rowEdit', ['ui.grid', 'ui.grid.edit', 'ui.grid.cellNav']);
+
+  /**
+   *  @ngdoc object
+   *  @name ui.grid.rowEdit.constant:uiGridRowEditConstants
+   *
+   *  @description constants available in row edit module
+   */
+  module.constant('uiGridRowEditConstants', {
+  });
+
+  /**
+   *  @ngdoc service
+   *  @name ui.grid.rowEdit.service:uiGridRowEditService
+   *
+   *  @description Services for row editing features
+   */
+  module.service('uiGridRowEditService', ['$interval', '$log', '$q', 'uiGridConstants', 'uiGridRowEditConstants', 'gridUtil', 
+    function ($interval, $log, $q, uiGridConstants, uiGridRowEditConstants, gridUtil) {
+
+      var service = {
+
+        initializeGrid: function (scope, grid) {
+          /**
+           *  @ngdoc object
+           *  @name ui.grid.rowEdit.api:PublicApi
+           *
+           *  @description Public Api for rowEdit feature
+           */
+          var publicApi = {
+            events: {
+              rowEdit: {
+                /**
+                 * @ngdoc event
+                 * @eventOf ui.grid.rowEdit.api:PublicApi
+                 * @name saveRow
+                 * @description raised when a row is ready for saving.  Once your
+                 * row has saved you may need to use angular.extend to update the
+                 * data entity with any changed data from your save (for example, 
+                 * lock version information if you're using optimistic locking,
+                 * or last update time/user information).
+                 * 
+                 * Your method should call setSavePromise somewhere in the body before
+                 * returning control.  The feature will then wait, with the gridRow greyed out 
+                 * whilst this promise is being resolved.
+                 * 
+                 * <pre>
+                 *      gridApi.rowEdit.on.saveRow(scope,function(rowEntity){})
+                 * </pre>
+                 * and somewhere within the event handler:
+                 * <pre>
+                 *      gridApi.rowEdit.setSavePromise( grid, rowEntity, savePromise)
+                 * </pre>
+                 * @param {object} rowEntity the options.data element that was edited
+                 * @returns {promise} Your saveRow method should return a promise, the
+                 * promise should either be resolved (implying successful save), or 
+                 * rejected (implying an error).
+                 */
+                saveRow: function (rowEntity) {
+                }
+              }
+            },
+            methods: {
+              rowEdit: {
+                /**
+                 * @ngdoc method
+                 * @methodOf ui.grid.rowEdit.api:PublicApi
+                 * @name setSavePromise
+                 * @description Sets the promise associated with the row save, mandatory that
+                 * the saveRow event handler calls this method somewhere before returning.
+                 * <pre>
+                 *      gridApi.rowEdit.setSavePromise(grid, rowEntity)
+                 * </pre>
+                 * @param {object} grid the grid for which dirty rows should be returned
+                 * @param {object} rowEntity a data row from the grid for which a save has
+                 * been initiated
+                 * @param {promise} savePromise the promise that will be resolved when the
+                 * save is successful, or rejected if the save fails
+                 * 
+                 */
+                setSavePromise: function (grid, rowEntity, savePromise) {
+                  service.setSavePromise(grid, rowEntity, savePromise);
+                },
+                /**
+                 * @ngdoc method
+                 * @methodOf ui.grid.rowEdit.api:PublicApi
+                 * @name getDirtyRows
+                 * @description Returns all currently dirty rows
+                 * <pre>
+                 *      gridApi.rowEdit.getDirtyRows(grid)
+                 * </pre>
+                 * @param {object} grid the grid for which dirty rows should be returned
+                 * @returns {array} An array of gridRows that are currently dirty
+                 * 
+                 */
+                getDirtyRows: function (grid) {
+                  return grid.rowEditDirtyRows;
+                },
+                /**
+                 * @ngdoc method
+                 * @methodOf ui.grid.rowEdit.api:PublicApi
+                 * @name getErrorRows
+                 * @description Returns all currently errored rows
+                 * <pre>
+                 *      gridApi.rowEdit.getErrorRows(grid)
+                 * </pre>
+                 * @param {object} grid the grid for which errored rows should be returned
+                 * @returns {array} An array of gridRows that are currently in error
+                 * 
+                 */
+                getErrorRows: function (grid) {
+                  return grid.rowEditErrorRows;
+                },
+                /**
+                 * @ngdoc method
+                 * @methodOf ui.grid.rowEdit.api:PublicApi
+                 * @name flushDirtyRows
+                 * @description Triggers a save event for all currently dirty rows, could
+                 * be used where user presses a save button or navigates away from the page
+                 * <pre>
+                 *      gridApi.rowEdit.flushDirtyRows(grid)
+                 * </pre>
+                 * @param {object} grid the grid for which dirty rows should be flushed
+                 * @returns {promise} a promise that represents the aggregate of all
+                 * of the individual save promises - i.e. it will be resolved when all
+                 * the individual save promises have been resolved.
+                 * 
+                 */
+                flushDirtyRows: function (grid) {
+                  return service.flushDirtyRows(grid);
+                }
+              }
+            }
+          };
+
+          grid.api.registerEventsFromObject(publicApi.events);
+          grid.api.registerMethodsFromObject(publicApi.methods);
+          
+          grid.api.core.on.renderingComplete( scope, function ( gridApi ) {
+            grid.api.edit.on.afterCellEdit( scope, service.endEditCell );
+            grid.api.edit.on.beginCellEdit( scope, service.beginEditCell );
+            grid.api.edit.on.cancelCellEdit( scope, service.cancelEditCell );
+            
+            if ( grid.api.cellNav ) {
+              grid.api.cellNav.on.navigate( scope, service.navigate );
+            }              
+          });
+
+        },
+
+        defaultGridOptions: function (gridOptions) {
+
+          /**
+           *  @ngdoc object
+           *  @name ui.grid.rowEdit.api:GridOptions
+           *
+           *  @description Options for configuring the rowEdit feature, these are available to be  
+           *  set using the ui-grid {@link ui.grid.class:GridOptions gridOptions}
+           */
+
+        },
+
+
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name saveRow
+         * @description  Returns a function that saves the specified row from the grid,
+         * and returns a promise
+         * @param {object} grid the grid for which dirty rows should be flushed
+         * @param {GridRow} gridRow the row that should be saved
+         * @returns {function} the saveRow function returns a function.  That function
+         * in turn, when called, returns a promise relating to the save callback
+         */
+        saveRow: function ( grid, gridRow ) {
+          var self = this;
+
+          return function() {
+            gridRow.isSaving = true;
+
+            var promise = grid.api.rowEdit.raise.saveRow( gridRow.entity );
+            
+            if ( gridRow.rowEditSavePromise ){
+              gridRow.rowEditSavePromise.then( self.processSuccessPromise( grid, gridRow ), self.processErrorPromise( grid, gridRow ));
+            } else {
+              $log.log( 'A promise was not returned when saveRow event was raised, either nobody is listening to event, or event handler did not return a promise' );
+            }
+            return promise;
+          };
+        },
+        
+
+        /**
+         * @ngdoc method
+         * @methodOf  ui.grid.rowEdit.service:uiGridRowEditService
+         * @name setSavePromise
+         * @description Sets the promise associated with the row save, mandatory that
+         * the saveRow event handler calls this method somewhere before returning.
+         * <pre>
+         *      gridApi.rowEdit.setSavePromise(grid, rowEntity)
+         * </pre>
+         * @param {object} grid the grid for which dirty rows should be returned
+         * @param {object} rowEntity a data row from the grid for which a save has
+         * been initiated
+         * @param {promise} savePromise the promise that will be resolved when the
+         * save is successful, or rejected if the save fails
+         * 
+         */
+        setSavePromise: function (grid, rowEntity, savePromise) {
+          var gridRow = grid.getRow( rowEntity );
+          gridRow.rowEditSavePromise = savePromise;
+        },
+
+
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name processSuccessPromise
+         * @description  Returns a function that processes the successful
+         * resolution of a save promise  
+         * @param {object} grid the grid for which the promise should be processed
+         * @param {GridRow} gridRow the row that has been saved
+         * @returns {function} the success handling function
+         */
+        processSuccessPromise: function ( grid, gridRow ) {
+          var self = this;
+          
+          return function() {
+            delete gridRow.isSaving;
+            delete gridRow.isDirty;
+            delete gridRow.isError;
+            delete gridRow.rowEditSaveTimer;
+            self.removeRow( grid.rowEditErrorRows, gridRow );
+            self.removeRow( grid.rowEditDirtyRows, gridRow );
+          };
+        },
+        
+
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name processErrorPromise
+         * @description  Returns a function that processes the failed
+         * resolution of a save promise  
+         * @param {object} grid the grid for which the promise should be processed
+         * @param {GridRow} gridRow the row that is now in error
+         * @returns {function} the error handling function
+         */
+        processErrorPromise: function ( grid, gridRow ) {
+          return function() {
+            delete gridRow.isSaving;
+            delete gridRow.rowEditSaveTimer;
+
+            gridRow.isError = true;
+            
+            if (!grid.rowEditErrorRows){
+              grid.rowEditErrorRows = [];
+            }
+            grid.rowEditErrorRows.push( gridRow );
+          };
+        },
+        
+        
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name removeRow
+         * @description  Removes a row from a cache of rows - either
+         * grid.rowEditErrorRows or grid.rowEditDirtyRows.  If the row
+         * is not present silently does nothing. 
+         * @param {array} rowArray the array from which to remove the row
+         * @param {GridRow} gridRow the row that should be removed
+         */
+        removeRow: function( rowArray, removeGridRow ){
+          angular.forEach( rowArray, function( gridRow, index ){
+            if ( gridRow.uid === removeGridRow.uid ){
+              rowArray.splice( index, 1);
+            }
+          });
+        },
+        
+        
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name flushDirtyRows
+         * @description Triggers a save event for all currently dirty rows, could
+         * be used where user presses a save button or navigates away from the page
+         * <pre>
+         *      gridApi.rowEdit.flushDirtyRows(grid)
+         * </pre>
+         * @param {object} grid the grid for which dirty rows should be flushed
+         * @returns {promise} a promise that represents the aggregate of all
+         * of the individual save promises - i.e. it will be resolved when all
+         * the individual save promises have been resolved.
+         * 
+         */
+        flushDirtyRows: function(grid){
+          var promises = [];
+          angular.forEach(grid.rowEditDirtyRows, function( gridRow ){
+            service.saveRow( grid, gridRow )();
+            promises.push( gridRow.rowEditSavePromise );
+          });
+          
+          return $q.all( promises );
+        },
+        
+        
+        /**
+         * @ngdoc property
+         * @propertyOf ui.grid.rowEdit.api:GridOptions
+         * @name rowEditWaitInterval
+         * @description How long the grid should wait for another change on this row
+         * before triggering a save (in milliseconds)
+         * 
+         * @example
+         * Setting the wait interval to 4 seconds
+         * <pre>
+         *   $scope.gridOptions = { rowEditWaitInterval: 4000 }
+         * </pre>
+         * 
+         */
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name endEditCell
+         * @description Receives an afterCellEdit event from the edit function,
+         * and sets flags as appropriate.  Only the rowEntity parameter
+         * is processed, although other params are available.  Grid
+         * is automatically provided by the gridApi. 
+         * @param {object} rowEntity the data entity for which the cell
+         * was edited
+         */        
+        endEditCell: function( rowEntity, colDef, newValue, previousValue ){
+          var grid = this.grid;
+          var gridRow = grid.getRow( rowEntity );
+          if ( !gridRow ){ $log.log( 'Unable to find rowEntity in grid data, dirty flag cannot be set' ); return; }
+
+          if ( newValue !== previousValue || gridRow.isDirty ){
+            if ( !grid.rowEditDirtyRows ){
+              grid.rowEditDirtyRows = [];
+            }
+            
+            if ( !gridRow.isDirty ){
+              gridRow.isDirty = true;
+              grid.rowEditDirtyRows.push( gridRow );
+            }
+            
+            delete gridRow.isError;
+            
+            service.considerSetTimer( grid, gridRow );
+          }
+        },
+        
+        
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name beginEditCell
+         * @description Receives a beginCellEdit event from the edit function,
+         * and cancels any rowEditSaveTimers if present, as the user is still editing
+         * this row.  Only the rowEntity parameter
+         * is processed, although other params are available.  Grid
+         * is automatically provided by the gridApi. 
+         * @param {object} rowEntity the data entity for which the cell
+         * editing has commenced
+         */
+        beginEditCell: function( rowEntity, colDef ){
+          var grid = this.grid;
+          var gridRow = grid.getRow( rowEntity );
+          if ( !gridRow ){ $log.log( 'Unable to find rowEntity in grid data, timer cannot be cancelled' ); return; }
+          
+          service.cancelTimer( grid, gridRow );
+        },
+
+
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name cancelEditCell
+         * @description Receives a cancelCellEdit event from the edit function,
+         * and if the row was already dirty, restarts the save timer.  If the row
+         * was not already dirty, then it's not dirty now either and does nothing.
+         * 
+         * Only the rowEntity parameter
+         * is processed, although other params are available.  Grid
+         * is automatically provided by the gridApi.
+         *  
+         * @param {object} rowEntity the data entity for which the cell
+         * editing was cancelled
+         */        
+        cancelEditCell: function( rowEntity, colDef ){
+          var grid = this.grid;
+          var gridRow = grid.getRow( rowEntity );
+          if ( !gridRow ){ $log.log( 'Unable to find rowEntity in grid data, timer cannot be set' ); return; }
+          
+          service.considerSetTimer( grid, gridRow );
+        },
+        
+        
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name navigate
+         * @description cellNav tells us that the selected cell has changed.  If
+         * the new row had a timer running, then stop it similar to in a beginCellEdit
+         * call.  If the old row is dirty and not the same as the new row, then 
+         * start a timer on it.
+         * @param {object} newRowCol the row and column that were selected
+         * @param {object} oldRowCol the row and column that was left
+         * 
+         */
+        navigate: function( newRowCol, oldRowCol ){
+          var grid = this.grid;
+          if ( newRowCol.row.rowEditSaveTimer ){
+            service.cancelTimer( grid, newRowCol.row );
+          }
+
+          if ( oldRowCol && oldRowCol.row && oldRowCol.row !== newRowCol.row ){
+            service.considerSetTimer( grid, oldRowCol.row );
+          }
+        },
+        
+        
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name considerSetTimer
+         * @description Consider setting a timer on this row (if it is dirty).  if there is a timer running 
+         * on the row and the row isn't currently saving, cancel it, using cancelTimer, then if the row is 
+         * dirty and not currently saving then set a new timer
+         * @param {object} grid the grid for which we are processing
+         * @param {GridRow} gridRow the row for which the timer should be adjusted
+         * 
+         */
+        considerSetTimer: function( grid, gridRow ){
+          service.cancelTimer( grid, gridRow );
+          
+          if ( gridRow.isDirty && !gridRow.isSaving ){
+            var waitTime = grid.options.rowEditWaitInterval ? grid.options.rowEditWaitInterval : 2000;
+            gridRow.rowEditSaveTimer = $interval( service.saveRow( grid, gridRow ), waitTime, 1);
+          }
+        },
+        
+
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name cancelTimer
+         * @description cancel the $interval for any timer running on this row
+         * then delete the timer itself
+         * @param {object} grid the grid for which we are processing
+         * @param {GridRow} gridRow the row for which the timer should be adjusted
+         * 
+         */
+        cancelTimer: function( grid, gridRow ){
+          if ( gridRow.rowEditSaveTimer && !gridRow.isSaving ){
+            $interval.cancel(gridRow.rowEditSaveTimer);
+            delete gridRow.rowEditSaveTimer;
+          }
+        }
+      };
+
+      return service;
+
+    }]);
+
+  /**
+   *  @ngdoc directive
+   *  @name ui.grid.rowEdit.directive:uiGridEdit
+   *  @element div
+   *  @restrict A
+   *
+   *  @description Adds row editing features to the ui-grid-edit directive.
+   *
+   */
+  module.directive('uiGridRowEdit', ['$log', 'uiGridRowEditService', 'uiGridEditConstants', 
+  function ($log, uiGridRowEditService, uiGridEditConstants) {
+    return {
+      replace: true,
+      priority: 0,
+      require: '^uiGrid',
+      scope: false,
+      compile: function () {
+        return {
+          pre: function ($scope, $elm, $attrs, uiGridCtrl) {
+            uiGridRowEditService.initializeGrid($scope, uiGridCtrl.grid);
+          },
+          post: function ($scope, $elm, $attrs, uiGridCtrl) {            
+          }
+        };
+      }
+    };
+  }]);
+
+
+  /**
+   *  @ngdoc directive
+   *  @name ui.grid.rowEdit.directive:uiGridViewport
+   *  @element div
+   *
+   *  @description Stacks on top of ui.grid.uiGridViewport to alter the attributes used
+   *  for the grid row to allow coloring of saving and error rows
+   */
+  module.directive('uiGridViewport',
+    ['$compile', 'uiGridConstants', '$log', '$parse',
+      function ($compile, uiGridConstants, $log, $parse) {
+        return {
+          priority: -200, // run after default  directive
+          scope: false,
+          compile: function ($elm, $attrs) {
+            var rowRepeatDiv = angular.element($elm.children().children()[0]);
+            rowRepeatDiv.attr("ng-class", "{'ui-grid-row-saving': row.isSaving, 'ui-grid-row-error': row.isError}");
+            return {
+              pre: function ($scope, $elm, $attrs, controllers) {
+
+              },
+              post: function ($scope, $elm, $attrs, controllers) {
+              }
+            };
+          }
+        };
+      }]);
+
+})();

--- a/src/features/row-edit/less/rowEdit.less
+++ b/src/features/row-edit/less/rowEdit.less
@@ -1,0 +1,13 @@
+@import '../../../less/variables';
+
+.ui-grid-row-saving {
+   .ui-grid-cell {
+     color: @rowSavingForeground !important;
+  }
+}
+
+.ui-grid-row-error {
+   .ui-grid-cell {
+     color: @rowErrorForeground !important;
+  }
+}

--- a/src/features/row-edit/test/uiGridRowEditService.spec.js
+++ b/src/features/row-edit/test/uiGridRowEditService.spec.js
@@ -1,0 +1,462 @@
+describe('ui.grid.edit uiGridRowEditService', function () {
+  var uiGridRowEditService;
+  var uiGridEditService;
+  var uiGridCellNavService;
+  var gridClassFactory;
+  var grid; 
+  var $rootScope;
+  var $scope;
+  var $interval;
+  var $q;
+  
+  beforeEach(module('ui.grid.rowEdit'));
+
+  beforeEach(inject(function (_uiGridRowEditService_, _uiGridEditService_, _uiGridCellNavService_, 
+                              _gridClassFactory_, $templateCache, 
+                              _$rootScope_, _$interval_, _$q_) {
+    uiGridRowEditService = _uiGridRowEditService_;
+    uiGridEditService = _uiGridEditService_;    
+    uiGridCellNavService = _uiGridCellNavService_;    
+    gridClassFactory = _gridClassFactory_;
+    $rootScope = _$rootScope_;
+    $scope = $rootScope.$new();
+    $interval = _$interval_;
+    $q = _$q_;
+
+    grid = gridClassFactory.createGrid( { id: 1234 });
+    grid.options.columnDefs = [
+      {name: 'col1'},
+      {name: 'col2'},
+      {name: 'col3'},
+      {name: 'col4'},
+    ];
+    grid.options.data = [
+      {col1: '1_1', col2: '1_2', col3: '1_3', col4: '1_4'},
+      {col1: '2_1', col2: '2_2', col3: '2_3', col4: '2_4'},
+      {col1: '3_1', col2: '3_2', col3: '3_3', col4: '3_4'},
+      {col1: '4_1', col2: '4_2', col3: '4_3', col4: '4_4'},
+    ];
+    
+    grid.buildColumns();
+    grid.modifyRows(grid.options.data);
+    
+//    $templateCache.put('ui-grid/uiGridCell', '<div/>');
+//    $templateCache.put('ui-grid/cellEditor', '<div ui-grid-editor></div>');
+
+
+  }));
+
+  describe('initialisation: ', function () {
+
+    it('register api, rowEdit methods and events are registered', function () {
+
+      uiGridRowEditService.initializeGrid( $scope, grid );
+      uiGridEditService.initializeGrid( grid );
+      
+      grid.renderingComplete();    
+      
+      expect( grid.api.rowEdit.on.saveRow ).toEqual( jasmine.any(Function) );
+      expect( grid.api.rowEdit.getDirtyRows ).toEqual( jasmine.any(Function) );
+      expect( grid.api.rowEdit.getErrorRows ).toEqual( jasmine.any(Function) );
+      expect( grid.api.rowEdit.flushDirtyRows ).toEqual( jasmine.any(Function) );
+
+    });
+
+    it('register api, listener in place on edit events', function () {
+
+      uiGridRowEditService.initializeGrid( $scope, grid );
+      uiGridEditService.initializeGrid( grid );
+      
+      spyOn( uiGridRowEditService, 'endEditCell' ).andCallFake( function() {} );
+      spyOn( uiGridRowEditService, 'beginEditCell' ).andCallFake( function() {} );
+      spyOn( uiGridRowEditService, 'cancelEditCell' ).andCallFake( function() {} );
+      
+      grid.renderingComplete();    
+
+      grid.api.edit.raise.afterCellEdit( );
+      grid.api.edit.raise.beginCellEdit( );
+      grid.api.edit.raise.cancelCellEdit( );
+
+      expect( uiGridRowEditService.endEditCell ).toHaveBeenCalled();
+      expect( uiGridRowEditService.beginEditCell ).toHaveBeenCalled();
+      expect( uiGridRowEditService.cancelEditCell ).toHaveBeenCalled();
+
+    });
+
+  });
+  
+  describe( 'beginEditCell: ', function() {
+    beforeEach( function() {
+      uiGridRowEditService.initializeGrid( $scope, grid );
+      uiGridEditService.initializeGrid( grid );
+      grid.renderingComplete();      
+    });
+    
+    it( 'no edit timer in place', function() {
+      grid.api.edit.raise.beginCellEdit( grid.options.data[0], grid.options.columnDefs[0] );
+      
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+    });
+
+    it( 'edit timer in place is cancelled', function() {
+      var called = false;
+      
+      grid.rows[0].rowEditSaveTimer = $interval( function() { called = true; }, 1000, 2 );
+      $interval.flush(1500);
+      expect( called ).toEqual( true );
+
+      called = false;
+      grid.api.edit.raise.beginCellEdit( grid.options.data[0], grid.options.columnDefs[0] );
+      
+      $interval.flush(1500);
+      expect( called ).toEqual( false );
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+    });
+  });
+
+  describe( 'endEditCell: ', function() {
+    beforeEach( function() {
+      uiGridRowEditService.initializeGrid( $scope, grid );
+      uiGridEditService.initializeGrid( grid );
+      grid.renderingComplete();      
+    });
+    
+    it( 'no change to cell value, nothing done', function() {
+      var called = false;
+      spyOn( uiGridRowEditService, 'saveRow' ).andCallFake( function() {
+        return function() { called = true;};
+      });
+      
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+      
+      grid.api.edit.raise.afterCellEdit( grid.options.data[0], grid.options.columnDefs[0], '1', '1' );
+      expect( uiGridRowEditService.saveRow ).not.toHaveBeenCalled();
+      expect( grid.rows[0].isDirty ).toEqual( undefined );
+      expect( grid.rowEditDirtyRows ).toEqual( undefined );
+      
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+    });
+       
+    it( 'timer is not present beforehand, interval triggered at 2000ms', function() {
+      var called = false;
+      spyOn( uiGridRowEditService, 'saveRow' ).andCallFake( function() {
+        return function() { called = true;};
+      });
+      
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+      
+      grid.api.edit.raise.afterCellEdit( grid.options.data[0], grid.options.columnDefs[0], '1', '2' );
+      expect( uiGridRowEditService.saveRow ).toHaveBeenCalledWith( grid, grid.rows[0] );
+      expect( grid.rows[0].isDirty ).toEqual( true );
+      expect( grid.rowEditDirtyRows.length ).toEqual( 1 );
+      
+      expect( grid.rows[0].rowEditSaveTimer ).not.toEqual( undefined );
+      
+      $interval.flush(1900);
+      expect( called ).toEqual(false);
+
+      $interval.flush(200);
+      expect( called ).toEqual(true);
+    });
+    
+    it( 'row already dirty so even though value not changed, interval triggered at 2000ms', function() {
+      var called = false;
+      spyOn( uiGridRowEditService, 'saveRow' ).andCallFake( function() {
+        return function() { called = true;};
+      });
+      grid.rows[0].isDirty = true;
+      grid.rowEditDirtyRows = [ grid.rows[0] ];
+      
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+      
+      grid.api.edit.raise.afterCellEdit( grid.options.data[0], grid.options.columnDefs[0], '1', '1' );
+      expect( uiGridRowEditService.saveRow ).toHaveBeenCalledWith( grid, grid.rows[0] );
+      expect( grid.rows[0].isDirty ).toEqual( true );
+      expect( grid.rowEditDirtyRows.length ).toEqual( 1 );
+      
+      expect( grid.rows[0].rowEditSaveTimer ).not.toEqual( undefined );
+      
+      $interval.flush(1900);
+      expect( called ).toEqual(false);
+
+      $interval.flush(200);
+      expect( called ).toEqual(true);
+    });    
+
+    it( 'edit timer is in place beforehand and is cancelled, a new one is created and triggered at non-standard 4000ms', function() {
+      var called = false;
+      spyOn( uiGridRowEditService, 'saveRow' ).andCallFake( function() {
+        return function() { called = true;};
+      });
+      grid.options.rowEditWaitInterval = 4000;
+      
+      grid.rows[0].rowEditSaveTimer = $interval( function() { called = true; }, 1000 );
+      $interval.flush(900);
+      expect( called ).toEqual( false );
+
+      grid.api.edit.raise.afterCellEdit( grid.options.data[0], grid.options.columnDefs[0], '1', '2' );
+      expect( uiGridRowEditService.saveRow ).toHaveBeenCalledWith( grid, grid.rows[0] );
+      expect( grid.rows[0].isDirty ).toEqual( true );
+      expect( grid.rowEditDirtyRows.length ).toEqual( 1 );
+      
+      // old interval not called
+      $interval.flush(200);
+      expect( called ).toEqual( false );
+      
+      // only 2.1 seconds, new interval not called yet
+      $interval.flush(1900);
+      expect( called ).toEqual(false);
+      
+      // 4.1 seconds, now should be called
+      $interval.flush(2000);
+      expect( called ).toEqual(true);
+    });
+  });
+  
+
+  describe( 'cancelEditCell: ', function() {
+    beforeEach( function() {
+      uiGridRowEditService.initializeGrid( $scope, grid );
+      uiGridEditService.initializeGrid( grid );
+      grid.renderingComplete();      
+    });
+  
+    it( 'do nothing if row not previously dirty', function() {
+      grid.api.edit.raise.cancelCellEdit( grid.options.data[0], grid.options.columnDefs[0] );
+      
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+    });
+
+    it( 'reinstate timer if row was previously dirty', function() {
+      grid.rows[0].isDirty = true;
+      
+      grid.api.edit.raise.cancelCellEdit( grid.options.data[0], grid.options.columnDefs[0] );
+      
+      expect( grid.rows[0].rowEditSaveTimer ).not.toEqual( undefined );
+    });
+  });
+
+
+  describe( 'navigate: ', function() {
+    var oldCell;
+    var newCell;
+    
+    beforeEach( function() {
+      uiGridRowEditService.initializeGrid( $scope, grid );
+      uiGridEditService.initializeGrid( grid );
+      uiGridCellNavService.initializeGrid( grid );
+      grid.renderingComplete();
+      
+      oldCell = { row: grid.rows[2], col: grid.columns[2] };      
+      newCell = { row: grid.rows[1], col: grid.columns[1] };      
+    });
+  
+    it( 'new row dirty, had a timer, timer cancelled', function() {
+      grid.rows[1].rowEditSaveTimer = $interval( function() {}, 1000 );
+      grid.rows[1].isDirty = true;
+      
+      grid.api.cellNav.raise.navigate( newCell, oldCell );
+      
+      expect( grid.rows[1].rowEditSaveTimer ).toEqual( undefined );
+    });
+
+    it( 'new row dirty, but is saving, timer not cancelled', function() {
+      grid.rows[1].rowEditSaveTimer = $interval( function() {}, 1000 );
+      grid.rows[1].isDirty = true;
+      grid.rows[1].isSaving = true;
+      
+      grid.api.cellNav.raise.navigate( newCell, oldCell );
+      
+      expect( grid.rows[1].rowEditSaveTimer ).not.toEqual( undefined );
+    });
+
+    it( 'old row clean, no timer created', function() {
+      grid.api.cellNav.raise.navigate( newCell, oldCell );
+      
+      expect( grid.rows[2].rowEditSaveTimer ).toEqual( undefined );
+    });
+
+    it( 'old row dirty, timer created', function() {
+      grid.rows[2].isDirty = true;
+      
+      grid.api.cellNav.raise.navigate( newCell, oldCell );
+      
+      expect( grid.rows[2].rowEditSaveTimer ).not.toEqual( undefined );
+    });
+
+    it( 'old row saving, no timer created', function() {
+      grid.rows[2].isSaving = true;
+      grid.api.cellNav.raise.navigate( newCell, oldCell );
+      
+      expect( grid.rows[2].rowEditSaveTimer ).toEqual( undefined );
+    });
+  });
+
+
+  describe( 'saveRow and promises: ', function() {
+    beforeEach( function() {
+      uiGridRowEditService.initializeGrid( $scope, grid );
+      uiGridEditService.initializeGrid( grid );
+      grid.renderingComplete();      
+    });
+  
+    it( 'saveRow on previously errored row, promise resolved successfully', function() {
+      var promise = $q.defer();
+      
+      grid.rows[0].isDirty = true;
+      grid.rows[0].isError = true;
+      grid.rowEditDirtyRows = [ grid.rows[0] ];
+      grid.rowEditErrorRows = [ grid.rows[0] ];
+      grid.api.rowEdit.on.saveRow( $scope, function(){
+        grid.api.rowEdit.setSavePromise(grid, grid.options.data[0], promise.promise); 
+      });
+      
+      uiGridRowEditService.saveRow( grid, grid.rows[0] )();
+      expect( grid.rows[0].isSaving ).toEqual(true);
+      expect( grid.rows[0].isDirty ).toEqual(true);
+      expect( grid.rows[0].isError ).toEqual(true);
+      expect( grid.rowEditDirtyRows.length ).toEqual(1);
+      expect( grid.rowEditErrorRows.length ).toEqual(1);
+      
+      promise.resolve(1);
+      $rootScope.$apply();
+      
+      expect( grid.rows[0].isSaving ).toEqual(undefined);
+      expect( grid.rows[0].isDirty ).toEqual(undefined);
+      expect( grid.rows[0].isError ).toEqual(undefined);
+      expect( grid.rowEditDirtyRows.length ).toEqual(0);
+      expect( grid.rowEditErrorRows.length ).toEqual(0);
+    });
+
+    it( 'saveRow on dirty row, promise rejected so goes to error state', function() {
+      var promise = $q.defer();
+      
+      grid.rows[0].isDirty = true;
+      grid.rowEditDirtyRows = [ grid.rows[0] ];
+      grid.api.rowEdit.on.saveRow( $scope, function(){
+        grid.api.rowEdit.setSavePromise(grid, grid.options.data[0], promise.promise); 
+      });
+      
+      uiGridRowEditService.saveRow( grid, grid.rows[0] )();
+      expect( grid.rows[0].isSaving ).toEqual(true);
+      expect( grid.rows[0].isDirty ).toEqual(true);
+      expect( grid.rows[0].isError ).toEqual(undefined);
+      expect( grid.rowEditDirtyRows.length ).toEqual(1);
+      expect( grid.rowEditErrorRows ).toEqual(undefined);
+      
+      promise.reject();
+      $rootScope.$apply();
+      
+      expect( grid.rows[0].isSaving ).toEqual(undefined);
+      expect( grid.rows[0].isDirty ).toEqual(true);
+      expect( grid.rows[0].isError ).toEqual(true);
+      expect( grid.rowEditDirtyRows.length ).toEqual(1);
+      expect( grid.rowEditErrorRows.length ).toEqual(1);
+    });  
+  });
+  
+
+  describe( 'flushDirtyRows: ', function() {
+    beforeEach( function() {
+      uiGridRowEditService.initializeGrid( $scope, grid );
+      uiGridEditService.initializeGrid( grid );
+      grid.renderingComplete();      
+    });
+  
+    it( 'three dirty rows, all save successfully', function() {
+      var promises = [$q.defer(), $q.defer(), $q.defer()];
+      var promiseCounter = 0;
+      var success = false;
+      var failure = false;
+      
+      grid.rows[0].isDirty = true;
+      grid.rows[2].isDirty = true;
+      grid.rows[3].isDirty = true;
+
+      grid.rowEditDirtyRows = [ grid.rows[0], grid.rows[2], grid.rows[3] ];
+      
+      grid.api.rowEdit.on.saveRow( $scope, function( rowEntity ){
+        grid.api.rowEdit.setSavePromise(grid, rowEntity, promises[promiseCounter].promise);
+        promiseCounter++; 
+      });
+      
+      var overallPromise = uiGridRowEditService.flushDirtyRows( grid );
+      overallPromise.then( function() { success = true; }, function() { failure = true; });
+      
+      expect( grid.rows[0].isSaving ).toEqual(true);
+      expect( grid.rows[1].isSaving ).toEqual(undefined);
+      expect( grid.rows[2].isSaving ).toEqual(true);
+      expect( grid.rows[3].isSaving ).toEqual(true);
+      expect( grid.rowEditDirtyRows.length ).toEqual(3);
+      
+      promises[0].resolve(1);
+      $rootScope.$apply();
+      
+      expect( grid.rows[0].isSaving ).toEqual(undefined);
+      expect( grid.rows[0].isDirty ).toEqual(undefined);
+      expect( grid.rowEditDirtyRows.length ).toEqual(2);
+      expect( success ).toEqual(false);
+      
+      promises[1].resolve(1);
+      promises[2].resolve(1);
+      $rootScope.$apply();
+
+      expect( grid.rows[2].isSaving ).toEqual(undefined);
+      expect( grid.rows[2].isDirty ).toEqual(undefined);
+      expect( grid.rows[3].isSaving ).toEqual(undefined);
+      expect( grid.rows[3].isDirty ).toEqual(undefined);
+      expect( grid.rowEditDirtyRows.length ).toEqual(0);
+      expect( success ).toEqual(true);
+      expect( failure ).toEqual(false);
+    });
+
+    it( 'three dirty rows, one save fails', function() {
+      var promises = [$q.defer(), $q.defer(), $q.defer()];
+      var promiseCounter = 0;
+      var success = false;
+      var failure = false;
+      
+      grid.rows[0].isDirty = true;
+      grid.rows[2].isDirty = true;
+      grid.rows[3].isDirty = true;
+
+      grid.rowEditDirtyRows = [ grid.rows[0], grid.rows[2], grid.rows[3] ];
+      
+      grid.api.rowEdit.on.saveRow( $scope, function( rowEntity ){
+        grid.api.rowEdit.setSavePromise(grid, rowEntity, promises[promiseCounter].promise);
+        promiseCounter++; 
+      });
+      
+      var overallPromise = uiGridRowEditService.flushDirtyRows( grid );
+      overallPromise.then( function() { success = true; }, function() { failure = true; });
+      
+      expect( grid.rows[0].isSaving ).toEqual(true);
+      expect( grid.rows[1].isSaving ).toEqual(undefined);
+      expect( grid.rows[2].isSaving ).toEqual(true);
+      expect( grid.rows[3].isSaving ).toEqual(true);
+      expect( grid.rowEditDirtyRows.length ).toEqual(3);
+      
+      promises[0].resolve(1);
+      $rootScope.$apply();
+      
+      expect( grid.rows[0].isSaving ).toEqual(undefined);
+      expect( grid.rows[0].isDirty ).toEqual(undefined);
+      expect( grid.rowEditDirtyRows.length ).toEqual(2);
+      expect( success ).toEqual(false);
+      
+      promises[1].reject();
+      promises[2].resolve(1);
+      $rootScope.$apply();
+
+      expect( grid.rows[2].isSaving ).toEqual(undefined);
+      expect( grid.rows[2].isDirty ).toEqual(true);
+      expect( grid.rows[2].isError ).toEqual(true);
+      expect( grid.rows[3].isSaving ).toEqual(undefined);
+      expect( grid.rows[3].isDirty ).toEqual(undefined);
+      expect( grid.rowEditDirtyRows.length ).toEqual(1);
+      expect( grid.rowEditErrorRows.length ).toEqual(1);
+      expect( success ).toEqual(false);
+      expect( failure ).toEqual(true);
+    });  
+  });    
+});

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1327,6 +1327,7 @@ angular.module('ui.grid')
     if (angular.isFunction(this.options.onRegisterApi)) {
       this.options.onRegisterApi(this.api);
     }
+    this.api.core.raise.renderingComplete( this.api );
   };
 
   Grid.prototype.createRowHashMap = function createRowHashMap() {

--- a/src/js/core/factories/GridApi.js
+++ b/src/js/core/factories/GridApi.js
@@ -13,6 +13,29 @@
         var GridApi = function GridApi(grid) {
           this.grid = grid;
           this.listeners = [];
+          
+          /**
+           * @ngdoc function
+           * @name renderingComplete
+           * @methodOf  ui.grid.core.api:PublicApi
+           * @description Rendering is complete, called at the same
+           * time as `onRegisterApi`, but provides a way to obtain
+           * that same event within features without stopping end
+           * users from getting at the onRegisterApi method.
+           * 
+           * Included in gridApi so that it's always there - otherwise
+           * there is still a timing problem with when a feature can
+           * call this. 
+           * 
+           * @param {GridApi} gridApi the grid api, as normally 
+           * returned in the onRegisterApi method
+           * 
+           * @example
+           * <pre>
+           *      gridApi.core.on.renderingComplete( grid );
+           * </pre>
+           */
+          this.registerEvent( 'core', 'renderingComplete' );
         };
 
         /**
@@ -209,7 +232,7 @@
           });
 
         };
-
+        
         return GridApi;
 
       }]);

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -43,6 +43,8 @@
 // TODO: color for menu background
 
 @rowSelected: #C9DDE1;
+@rowSavingForeground: #848484;
+@rowErrorForeground: #FF0000;
 
 // TODO: color for cell selections
 @focusedCell: #b3c4c7;


### PR DESCRIPTION
Provide a feature, tutorial and unit tests for rowEdit feature.

```
Seeks to save row-at-a-time, including stopping editing a row
that is currently saving, showing error rows in red, and noticing
when a user is still editing the same row, and not saving until
they move off that row.

Includes three changes in non-row-edit files:

- add beginCellEdit and cancelCellEdit events to the edit feature,
rather than listening to non-public api calls
- modify edit feature to not allow editing of a row that is currently
saving (one line change)
- add a `renderingComplete` event to core, and register that event
immediately the api is instantiated, allowing features and external
users to register for that event in their initialize block.  This
event does the same thing as onRegisterApi, but is multi-user/broadcast,
rather than only accessible to a single module.  (Otherwise if rowEdit
used onRegisterApi it was no longer available to the end-user to use)
```
