### PR TITLE
End to end testing framework and tests for most of 100 series tutorials

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -328,7 +328,7 @@ module.exports = function(grunt) {
 
       protractor: {
         files: ['.tmp/doc-scenarios/**/*.spec.js', 'test/e2e/**/*.spec.js'],
-        tasks: ['protractor-watch:auto']
+        tasks: ['ngdocs', 'protractor-watch:auto']
       },
 
       less: {
@@ -453,7 +453,7 @@ module.exports = function(grunt) {
         navTemplate: 'misc/doc/templates/nav.html'
       },
       api: {
-        src: ['src/**/*.js', 'misc/api/**/*.ngdoc'],
+        src: ['src/**/*.js', 'misc/api/**/*.ngdoc', 'test/e2e/**/*.js'],
         title: 'API'
       },
       tutorial: {

--- a/misc/tutorial/101_intro.ngdoc
+++ b/misc/tutorial/101_intro.ngdoc
@@ -94,7 +94,7 @@ Steps:
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl">
-      <div ui-grid="{ data: myData }" class="grid"></div>
+      <div id="grid1" ui-grid="{ data: myData }" class="grid"></div>
     </div>
   </file>
   <file name="main.css">
@@ -102,5 +102,37 @@ Steps:
       width: 500px;
       height: 250px;
     }
+  </file>
+
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    it('grid should have three visible rows', function () {
+      gridTestUtils.expectRowCount( 'grid1', 3 );
+    });
+
+    it('grid should have four visible columns', function () {
+      gridTestUtils.expectHeaderColumnCount( 'grid1', 4 );
+    });
+
+    it('header values should be as expected', function () {
+      gridTestUtils.expectHeaderCellValueMatch( 'grid1', 0, 'First Name' );
+      gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, 'Last Name' );
+      gridTestUtils.expectHeaderCellValueMatch( 'grid1', 2, 'Company' );
+      gridTestUtils.expectHeaderCellValueMatch( 'grid1', 3, 'Employed' );
+    });
+
+    it('first row cell values should be as expected', function () {
+      // checking individual cells usually gives a better stack trace when there are errors
+      gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Cox' );
+      gridTestUtils.expectCellValueMatch( 'grid1', 0, 1, 'Carney' );
+      gridTestUtils.expectCellValueMatch( 'grid1', 0, 2, 'Enormo' );
+      gridTestUtils.expectCellValueMatch( 'grid1', 0, 3, 'true' );
+    });
+
+    it('next two row cell values should be as expected', function () {
+      // checking in bulk is convenient to write, but can be less informative with errors
+      gridTestUtils.expectRowValuesMatch( 'grid1', 1, [ 'Lorraine', 'Wise', 'Comveyer', 'false' ] );
+      gridTestUtils.expectRowValuesMatch( 'grid1', 2, [ 'Nancy', 'Waters', 'Fuelton', 'false' ] );
+    });
   </file>
 </example>

--- a/misc/tutorial/102_sorting.ngdoc
+++ b/misc/tutorial/102_sorting.ngdoc
@@ -37,7 +37,7 @@ Multiple columns can be sorted by shift-clicking on the 2-n columns.  To see it 
       Click on a column header to sort by that column. (The third column has sorting disabled.)
       <br>
       <br>
-      <div ui-grid="gridOptions" class="grid"></div>
+      <div id="grid1" ui-grid="gridOptions" class="grid"></div>
     </div>
   </file>
   <file name="main.css">
@@ -86,7 +86,7 @@ You can set an initial sort state for the grid by defining the `sort` property o
   </file>
   <file name="index2.html">
     <div ng-controller="MainCtrl">
-      <div ui-grid="gridOptions" class="grid"></div>
+      <div id="grid2" ui-grid="gridOptions" class="grid"></div>
     </div>
   </file>
   <file name="main2.css">
@@ -95,4 +95,94 @@ You can set an initial sort state for the grid by defining the `sort` property o
       height: 200px;
     }
   </file>
+  
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    
+    describe('first grid on the page, no default sort', function() {
+      it('grid should have three visible columns', function () {
+        gridTestUtils.expectHeaderColumnCount( 'grid1', 3 );
+      });
+  
+      it('header values should be as expected', function () {
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 0, 'Name' );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, 'Gender' );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 2, 'Company' );
+      });
+  
+      it('grid should be unsorted by default', function () {
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Ethel Price' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Claudine Neal' );
+      });
+
+      it('sort by name by clicking header', function () {
+        gridTestUtils.clickHeaderCell( 'grid1', 0 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Alexander Foley' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Alisha Myers' );
+      });
+
+      it('reverse sort by name by clicking header', function () {
+        gridTestUtils.clickHeaderCell( 'grid1', 0 );
+        gridTestUtils.clickHeaderCell( 'grid1', 0 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Yvonne Parsons' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Woods Key' );
+      });
+      
+      it('return to original sort by name by clicking header', function () {
+        gridTestUtils.clickHeaderCell( 'grid1', 0 );
+        gridTestUtils.clickHeaderCell( 'grid1', 0 );
+        gridTestUtils.clickHeaderCell( 'grid1', 0 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Ethel Price' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Claudine Neal' );
+      });
+      
+      it('sort asc by clicking menu', function() {
+        gridTestUtils.clickColumnMenuSortAsc( 'grid1', 0 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Alexander Foley' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Alisha Myers' );        
+      });
+
+      it('sort desc by clicking menu, then remove sort', function() {
+        gridTestUtils.clickColumnMenuSortDesc( 'grid1', 0 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Yvonne Parsons' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Woods Key' );
+
+        gridTestUtils.clickColumnMenuRemoveSort( 'grid1', 0 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Ethel Price' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Claudine Neal' );
+      });
+      
+      it('sort two columns, gender then name, by shift clicking', function() {
+        gridTestUtils.clickHeaderCell( 'grid1', 1 );
+        gridTestUtils.shiftClickHeaderCell( 'grid1', 0 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Alisha Myers' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Beryl Rice' );
+      });
+
+      it('sort disabled on last column', function() {
+        gridTestUtils.clickHeaderCell( 'grid1', 2 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Ethel Price' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Claudine Neal' );
+      });
+    });
+
+
+    describe('second grid on the page, has default sort', function() {
+      it('grid should have three visible columns', function () {
+        gridTestUtils.expectHeaderColumnCount( 'grid2', 3 );
+      });
+  
+      it('header values should be as expected', function () {
+        gridTestUtils.expectHeaderCellValueMatch( 'grid2', 0, 'Name' );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid2', 1, 'Gender' );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid2', 2, 'Company' );
+      });
+  
+      it('grid should be sorted by default', function () {
+        gridTestUtils.expectCellValueMatch( 'grid2', 0, 0, 'Yvonne Parsons' );
+        gridTestUtils.expectCellValueMatch( 'grid2', 1, 0, 'Velma Fry' );
+      });
+    });
+
+  </file>  
 </example>

--- a/misc/tutorial/103_filtering.ngdoc
+++ b/misc/tutorial/103_filtering.ngdoc
@@ -106,7 +106,7 @@ for `filters: [{ term: 'xxx' }]`. See the "age" column below for an example.
       <strong>Note:</strong> The third column has filtering disabled.
       <br>
       <br>
-      <div ui-grid="gridOptions" class="grid"></div>
+      <div id="grid1" ui-grid="gridOptions" class="grid"></div>
     </div>
   </file>
   <file name="main.css">
@@ -115,4 +115,37 @@ for `filters: [{ term: 'xxx' }]`. See the "age" column below for an example.
       height: 400px;
     }
   </file>
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    
+    describe('first grid on the page, filtered by male by default', function() {
+      it('grid should have six visible columns', function () {
+        gridTestUtils.expectHeaderColumnCount( 'grid1', 6 );
+      });
+
+      it('filter on 4 columns, filter with greater than/less than on one, one with no filter', function () {
+        gridTestUtils.expectFilterBoxInColumn( 'grid1', 0, 1 );
+        gridTestUtils.expectFilterBoxInColumn( 'grid1', 1, 1 );
+        gridTestUtils.expectFilterBoxInColumn( 'grid1', 2, 0 );
+        gridTestUtils.expectFilterBoxInColumn( 'grid1', 3, 1 );
+        gridTestUtils.expectFilterBoxInColumn( 'grid1', 4, 1 );
+        gridTestUtils.expectFilterBoxInColumn( 'grid1', 5, 2 );
+      });
+
+      it('third row should be Bishop Carr - will be Terry Clay if filtering broken', function () {
+        gridTestUtils.expectCellValueMatch( 'grid1', 2, 0, 'Bishop Carr' );
+      });
+      
+      it('cancel filter on gender column, should now see Terry Clay in third row', function() {
+        gridTestUtils.cancelFilterInColumn( 'grid1', 1 );        
+        gridTestUtils.expectCellValueMatch( 'grid1', 2, 0, 'Terry Clay' );
+      });
+
+      it('filter on email column, should automatically do "ends with"', function() {
+        gridTestUtils.cancelFilterInColumn( 'grid1', 1 );        
+        gridTestUtils.enterFilterInColumn( 'grid1', 3, 'mixers.com' );        
+        gridTestUtils.expectRowCount( 'grid1', 2 );
+      });
+    });
+  </file>  
 </example>

--- a/misc/tutorial/105_footer.ngdoc
+++ b/misc/tutorial/105_footer.ngdoc
@@ -13,22 +13,16 @@ you can also pass in a function in order to create your own aggregation logic</p
   <file name="app.js">
     var app = angular.module('app', ['ui.grid']);
 
-    app.controller('MainCtrl', ['$scope','uiGridConstants', function ($scope, uiGridConstants) {
+    app.controller('MainCtrl', ['$scope','uiGridConstants', '$http', function ($scope, uiGridConstants, $http) {
     var data = [];
-    for(var i=0;i < 100;i++) {
-        data.push({
-        person: 'person ' + i,
-        balance: parseInt(Math.random() * 10000),
-        age: parseInt((Math.random() * 54) + 16),
-        });
-    }
+
     $scope.gridOptions = {
         showFooter: true,
         enableFiltering: true,
         columnDefs: [
-            { field: 'person', width: 150, aggregationType: uiGridConstants.aggregationTypes.count },
-            { field: 'balance',aggregationType: uiGridConstants.aggregationTypes.sum, width: 150 },
-            { field: 'age', aggregationType: uiGridConstants.aggregationTypes.avg, width: 80 },
+            { field: 'name', width: 150, aggregationType: uiGridConstants.aggregationTypes.count },
+            { field: 'address.street',aggregationType: uiGridConstants.aggregationTypes.sum, width: 150 },
+            { field: 'age', aggregationType: uiGridConstants.aggregationTypes.avg, width: 100 },
             { name: 'ageMin', field: 'age', aggregationType: uiGridConstants.aggregationTypes.min, width: 130, displayName: 'Age for min' },
             { name: 'ageMax', field: 'age', aggregationType: uiGridConstants.aggregationTypes.max, width: 130, displayName: 'Age for max' },
             { name: 'customCellTemplate', field: 'age', width: 150, footerCellTemplate: '<div class="ui-grid-cell-contents" style="background-color: Red;color: White">custom template</div>' }
@@ -36,11 +30,15 @@ you can also pass in a function in order to create your own aggregation logic</p
         data: data
     }
 
+    $http.get('/data/500_complex.json')
+      .success(function(data) {
+        $scope.gridOptions.data = data;
+      });
     }]);
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl">
-      <div ui-grid="gridOptions" class="grid"></div>
+      <div id="grid1" ui-grid="gridOptions" class="grid"></div>
     </div>
   </file>
   <file name="main.css">
@@ -48,6 +46,36 @@ you can also pass in a function in order to create your own aggregation logic</p
       width: 100%;
       height: 250px;
     }
+  </file>
+
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    it('grid should have six visible columns', function () {
+      gridTestUtils.expectHeaderColumnCount( 'grid1', 6 );
+    });
+
+    it('grid should have six visible columns in footer', function () {
+      gridTestUtils.expectFooterColumnCount( 'grid1', 6 );
+    });
+
+    it('grid should have footers with specific values', function () {
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 0, 'total rows: 500' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 1, 'total: 281568' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 2, 'avg: 30.196' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 3, 'min: 20' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 4, 'max: 40' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 5, 'custom template' );
+    });
+
+    it('filter and expect recalculate', function () {
+      gridTestUtils.enterFilterInColumn( 'grid1', 1, '3' );        
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 0, 'total rows: 56' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 1, 'total: 19805' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 2, 'avg: 29.375' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 3, 'min: 20' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 4, 'max: 39' );
+      gridTestUtils.expectFooterCellValueMatch( 'grid1', 5, 'custom template' );
+    });
   </file>
 </example>
 

--- a/misc/tutorial/106_binding.ngdoc
+++ b/misc/tutorial/106_binding.ngdoc
@@ -18,7 +18,7 @@ Note that a function can not be edited.
     $scope.gridOptions = {
             enableSorting: true,
             columnDefs: [
-              { name:'fistName', field: 'first-name' },
+              { name:'firstName', field: 'first-name' },
               { name:'1stFriend', field: 'friends[0]' },
               { name:'city', field: 'address.city'},
               { name:'getZip', field: 'getZip()', enableCellEdit:false}
@@ -36,7 +36,7 @@ Note that a function can not be edited.
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl">
-      <div ui-grid="gridOptions" ui-grid-edit class="grid"></div>
+      <div id="grid1" ui-grid="gridOptions" ui-grid-edit class="grid"></div>
     </div>
   </file>
   <file name="main.css">
@@ -45,4 +45,22 @@ Note that a function can not be edited.
       height: 250px;
     }
   </file>
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    it('grid should have one visible row and four columns', function () {
+      gridTestUtils.expectRowCount( 'grid1', 1 );
+      gridTestUtils.expectHeaderColumnCount( 'grid1', 4 );
+    });
+
+    it('headers as specified', function () {
+      gridTestUtils.expectHeaderCellValueMatch( 'grid1', 0, 'First Name' );
+      gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, '1st Friend' );
+      gridTestUtils.expectHeaderCellValueMatch( 'grid1', 2, 'City' );
+      gridTestUtils.expectHeaderCellValueMatch( 'grid1', 3, 'Get Zip' );
+    });
+
+    it('row values should be as expected', function () {
+      gridTestUtils.expectRowValuesMatch( 'grid1', 0, [ 'Cox', 'friend0', 'Laurel', '39565' ]);
+    });
+  </file>  
 </example>

--- a/misc/tutorial/109_multiple_grids.ngdoc
+++ b/misc/tutorial/109_multiple_grids.ngdoc
@@ -28,11 +28,11 @@ Using multiple grids on a single page
     <div ng-controller="MainCtrl">
       <div class="row">
         <div class="span4">
-          <div ui-grid="gridOptions1" class="grid"></div>
+          <div id="grid1" ui-grid="gridOptions1" class="grid"></div>
         </div>
         
         <div class="span4">
-          <div ui-grid="gridOptions2" class="grid"></div>
+          <div id="grid2" ui-grid="gridOptions2" class="grid"></div>
         </div>
       </div>
     </div>
@@ -43,4 +43,30 @@ Using multiple grids on a single page
       height: 150px;
     }
   </file>
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    it('grid1 should have three visible columns, grid2 has four', function () {
+      gridTestUtils.expectHeaderColumnCount( 'grid1', 3 );
+      gridTestUtils.expectHeaderColumnCount( 'grid2', 4 );
+    });
+
+    it('menus should show over correct grid', function () {
+      // click on menu in grid 1
+      var headerCell = gridTestUtils.headerCell( 'grid1', 0 );
+      headerCell.element( by.css( '.ui-grid-column-menu-button' ) ).click();
+      
+      // check a menu list is showing somewhere in grid1, and has at least 2 items
+      var columnMenu = element( by.id( 'grid1' ) ).element( by.css( '.ui-grid-column-menu' ));
+      expect( columnMenu.all( by.repeater('item in menuItems') ).count() ).toBeGreaterThan(2);
+
+      // click on menu in grid 2
+      var headerCell = gridTestUtils.headerCell( 'grid2', 0 );
+      headerCell.element( by.css( '.ui-grid-column-menu-button' ) ).click();
+      
+      // check a menu list is showing somewhere in grid2, and has at least 2 items
+      var columnMenu = element( by.id( 'grid2' ) ).element( by.css( '.ui-grid-column-menu' ));
+      expect( columnMenu.all( by.repeater('item in menuItems') ).count() ).toBeGreaterThan(2);
+    });
+
+  </file>  
 </example>

--- a/misc/tutorial/110_grid_in_modal.ngdoc
+++ b/misc/tutorial/110_grid_in_modal.ngdoc
@@ -31,7 +31,7 @@ Using a grid in a modal popup
         var elm;
         var modal = {
           open: function() {
-            var html = '<div class="modal"><a class="modal-close" href ng-click="close()">X</a><div ui-grid="gridOptions" class="grid"></div></div>';
+            var html = '<div class="modal"><a class="modal-close" href ng-click="close()">X</a><div id="grid1" ui-grid="gridOptions" class="grid"></div></div>';
 
             elm = angular.element(html);
             angular.element(document.body).prepend(elm);
@@ -55,7 +55,7 @@ Using a grid in a modal popup
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl">
-      <button class="btn btn-success" ng-click="showModal()">Show Modal</button>
+      <button id="showButton" class="btn btn-success" ng-click="showModal()">Show Modal</button>
     </div>
   </file>
   <file name="main.css">
@@ -91,5 +91,14 @@ Using a grid in a modal popup
       width: 300px;
       height: 250px;
     }
+  </file>
+    <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    it('click modal button, grid should show with three columns and some data', function () {
+      element( by.id ( 'showButton' ) ).click();
+      gridTestUtils.expectHeaderColumnCount( 'grid1', 3 );
+      gridTestUtils.expectRowValuesMatch( 'grid1', 0, [ 'Ethel Price', 'female', 'Enersol' ]);
+      element( by.css ( '.modal-close' ) ).click();
+    });
   </file>
 </example>

--- a/misc/tutorial/111_cellClass.ngdoc
+++ b/misc/tutorial/111_cellClass.ngdoc
@@ -34,10 +34,9 @@ In this example, we will override the color and background for the first column 
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl">
-      Click on a column header to sort by that column. (The third column has sorting disabled.)
       <br>
       <br>
-      <div ui-grid="gridOptions" class="grid"></div>
+      <div id="grid1" ui-grid="gridOptions" class="grid"></div>
     </div>
   </file>
   <file name="main.css">
@@ -47,6 +46,22 @@ In this example, we will override the color and background for the first column 
     }
     .red { color: red;  background-color: yellow !important; }
     .blue { color: blue;  }
+  </file>
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    it('grid should have two visible columns', function () {
+      gridTestUtils.expectHeaderColumnCount( 'grid1', 2 );
+    });
+
+    it('column one formatted color red, background yellow', function () {
+      // red on yellow background for 0,0
+      expect( gridTestUtils.dataCell( 'grid1', 0, 0 ).getCssValue('background-color')).toEqual('rgba(255, 255, 0, 1)');
+      expect( gridTestUtils.dataCell( 'grid1', 0, 0 ).getCssValue('color')).toEqual('rgba(255, 0, 0, 1)');
+      
+      // color blue for 2,1, which has company name 'Velity'
+      gridTestUtils.expectCellValueMatch( 'grid1', 2, 1, 'Velity' );
+      expect( gridTestUtils.dataCell( 'grid1', 2, 1 ).getCssValue('color')).toEqual('rgba(0, 0, 255, 1)');
+    });
   </file>
 </example>
 

--- a/misc/tutorial/403_end_to_end_testing.ngdoc
+++ b/misc/tutorial/403_end_to_end_testing.ngdoc
@@ -1,0 +1,25 @@
+@ngdoc overview
+@name Tutorial: 403 End to End Testing
+@description
+
+Testing the grid with protractor can be complex.  In order to assist the project provides a 
+`gridTestUtil.scenario.js` helper library that abstracts some of the key functions, such as
+checking the value of a specified cell in the grid, counting the rows in the grid, or
+clicking specific elements of the grid.
+
+The latest version of this is held in git, and there is potential it could get out of 
+synch with this tutorial, it is therefore worthwhile to check that file itself at
+{@link https://github.com/angular-ui/ng-grid/tree/master/test/e2e github e2e test folder}
+
+The use of this library involves declaring it at the top of each scenario that requires
+grid test functions:
+<pre>
+  var gridTestUtils = require( './gridTestUtils.scenario.js');
+</pre>
+
+Within your tests you can then use the helper methods that are provided:
+<pre>
+  gridTestUtils.expectRowCount( 'myGrid', 3 );
+</pre>
+
+For documentation of the available methods, refer to {@link api/ui.grid.e2eTestLibrary.api:gridTest gridTest}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "semver": "~2.2.1",
     "shelljs": "~0.2.6",
     "grunt-contrib-copy": "~0.4.1",
-    "protractor": "~0.14.0",
+    "protractor": "~1.0.0",
     "grunt-protractor-runner": "0.2.0",
     "grunt-shell-spawn": "~0.3.0",
     "selenium-webdriver": "~2.39.0",

--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -25,12 +25,6 @@
  </div>
  </doc:source>
  <doc:scenario>
- it('should apply the right class to the element', function () {
-      element(by.css('.blah')).getCssValue('border')
-        .then(function(c) {
-          expect(c).toContain('1px solid');
-        });
-    });
  </doc:scenario>
  </doc:example>
  */

--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -1,0 +1,471 @@
+/* globals protractor, element, by */
+/**
+ * @ngdoc overview
+ * @name ui.grid.e2eTestLibrary
+ * @description
+ * End to end test functions.  Whenever these are updated, it may also be necessary
+ * to update the associated tutorial.
+ * 
+ */
+
+/**
+ * @ngdoc service
+ * @name ui.grid.e2eTestLibrary.api:gridTest
+ * @description
+ * End to end test functions.  Whenever these are updated, it may also be necessary
+ * to update the associated tutorial.
+ * 
+ */
+module.exports = {
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name expectRowCount
+     * @description Checks that a grid has the specified number of rows. Note
+     * that this only returns the number of rendered rows, and the grid does
+     * row virtualisation - that is that the browser can only see the rendered
+     * rows, not all the rows in the dataset.  This method is useful when doing
+     * functional tests with small numbers of data, but typically with numbers
+     * greater than about 10 you'll find that some of the rows are not rendered
+     * and therefore an error is given.
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} expectedNumRows the number of visible rows you expect the
+     * grid to have
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.expectRowCount('myGrid', 2);
+     * </pre>
+     * 
+     */
+    expectRowCount: function( gridId, expectedNumRows ) {
+
+      var rows = element( by.id( gridId ) ).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid') );
+      expect(rows.count()).toEqual(expectedNumRows);
+    },
+    
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name expectHeaderColumnCount
+     * @description Checks that a grid header has the specified number of columns.
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} expectedNumCols the number of visible columns you expect the
+     * grid to have
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.expectHeaderColumnCount('myGrid', 2);
+     * </pre>
+     * 
+     */
+    expectHeaderColumnCount: function( gridId, expectedNumCols ) {
+      var headerCols = element( by.id( gridId ) ).element( by.css('.ui-grid-header') ).all( by.repeater('col in colContainer.renderedColumns track by col.colDef.name') );
+      expect(headerCols.count()).toEqual(expectedNumCols);
+    },
+
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name expectFooterColumnCount
+     * @description Checks that a grid footer has the specified number of rows.
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} expectedNumCols the number of visible columns you expect the
+     * grid to have
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.expectColumnCount('myGrid', 2);
+     * </pre>
+     * 
+     */
+    expectFooterColumnCount: function( gridId, expectedNumCols ) {
+      var footerCols = element( by.id( gridId ) ).element( by.css('.ui-grid-footer') ).all( by.repeater('col in colContainer.renderedColumns track by col.colDef.name') );
+      expect(footerCols.count()).toEqual(expectedNumCols);
+    },
+    
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name headerCell
+     * @description Internal method used to return a headerCell element
+     * given the grid and column
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} col the number of the column (within the visible columns)
+     * that you want to return
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.headerCell('myGrid', 2);
+     * </pre>
+     * 
+     */
+    headerCell: function( gridId, expectedCol, expectedValue ) {
+      return element( by.id( gridId ) ).element( by.css('.ui-grid-header') ).element( by.repeater('col in colContainer.renderedColumns track by col.colDef.name').row( expectedCol)  );
+    },
+
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name footerCell
+     * @description Internal method used to return a footerCell element
+     * given the grid and column
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} col the number of the column (within the visible columns)
+     * that you want to return
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.headerCell('myGrid', 2);
+     * </pre>
+     * 
+     */
+    footerCell: function( gridId, expectedCol, expectedValue ) {
+      return element( by.id( gridId ) ).element( by.css('.ui-grid-footer') ).element( by.repeater('col in colContainer.renderedColumns track by col.colDef.name').row( expectedCol)  );
+    },
+
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name dataCell
+     * @description Internal method used to return a dataCell element
+     * given the grid and column
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} fetchRow the number of the row (within the visible rows)
+     * that you want to return
+     * @param {integer} fetchCol the number of the col (within the visible cols)
+     * that you want to return
+     * 
+     * @example 
+     * <pre>
+     *   myElement = gridTestUtils.dataCell('myGrid', 2, 2);
+     * </pre>
+     * 
+     */
+    dataCell: function( gridId, fetchRow, fetchCol ) {
+      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid').row( fetchRow )  );
+      return row.element( by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.colDef.name').row( fetchCol ));
+    },
+
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name expectHeaderCellValueMatch
+     * @description Checks that a header cell matches the specified value,
+     * takes a regEx or a simple string.  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} expectedCol the number of the column (within the visible columns)
+     * that you want to check the value of
+     * @param {string} expectedValue a regex or string of the value you expect in that header
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.expectHeaderCellValueMatch('myGrid', 2, 'HeaderValue');
+     * </pre>
+     * 
+     */
+    expectHeaderCellValueMatch: function( gridId, expectedCol, expectedValue ) {
+      var headerCell = this.headerCell( gridId, expectedCol);
+      expect(headerCell.getText()).toMatch(expectedValue);
+    },
+
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name expectFooterCellValueMatch
+     * @description Checks that a footer cell matches the specified value,
+     * takes a regEx or a simple string.  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} expectedCol the number of the column (within the visible columns)
+     * that you want to check the value of
+     * @param {string} expectedValue a regex or string of the value you expect in that footer
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.expectFooterCellValueMatch('myGrid', 2, 'FooterValue');
+     * </pre>
+     * 
+     */
+    expectFooterCellValueMatch: function( gridId, expectedCol, expectedValue ) {
+      var footerCell = this.footerCell( gridId, expectedCol);
+      expect(footerCell.getText()).toMatch(expectedValue);
+    },
+    
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name expectCellValueMatch
+     * @description Checks that a cell matches the specified value,
+     * takes a regEx or a simple string.  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} expectedRow the number of the row (within the visible rows)
+     * that you want to check the value of
+     * @param {integer} expectedCol the number of the column (within the visible columns)
+     * that you want to check the value of
+     * @param {string} expectedValue a regex or string of the value you expect in that cell
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.expectCellValueMatch('myGrid', 0, 2, 'CellValue');
+     * </pre>
+     * 
+     */
+    expectCellValueMatch: function( gridId, expectedRow, expectedCol, expectedValue ) {
+      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid').row( expectedRow )  );
+      expect(row.element( by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.colDef.name').row(expectedCol)).getText()).toMatch(expectedValue);
+    },
+    
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name expectRowValuesMatch
+     * @description Checks that a row matches the specified values,
+     * takes an array of regExes or simple strings.  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} expectedRow the number of the row (within the visible rows)
+     * that you want to check the value of
+     * @param {array} expectedValueArray an array of regexes or strings of the values you expect in that row
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.expectRowValuesMatch('myGrid', 0, [ 'CellValue1', '^cellvalue2', 'cellValue3$' ]);
+     * </pre>
+     * 
+     */
+    expectRowValuesMatch: function( gridId, expectedRow, expectedValueArray ) {
+      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid').row( expectedRow )  );
+
+      for ( var i=0; i<expectedValueArray.length; i++){
+        expect(row.element( by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.colDef.name').row(i)).getText()).toMatch(expectedValueArray[i], 'Expected to match: ' + expectedValueArray[i] + ' in column: ' + i);
+      }
+    },
+
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name clickHeaderCell
+     * @description Clicks on the header of the specified column,
+     * which would usually result in a sort 
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to click on
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.clickHeaderCell('myGrid', 0);
+     * </pre>
+     * 
+     */
+    clickHeaderCell: function( gridId, colNumber ) {
+      var headerCell = this.headerCell( gridId, colNumber);
+      
+      headerCell.click();
+    },
+
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name shiftClickHeaderCell
+     * @description Shift-clicks on the header of the specified column,
+     * which would usually result in adding a second column to the sort 
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to click on
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.shiftClickHeaderCell('myGrid', 0);
+     * </pre>
+     * 
+     */
+    shiftClickHeaderCell: function( gridId, colNumber ) {
+      var headerCell = this.headerCell( gridId, colNumber);
+      
+      protractor.getInstance().actions()
+        .keyDown(protractor.Key.SHIFT)
+        .click(headerCell)
+        .keyUp(protractor.Key.SHIFT)
+        .perform();
+    },    
+ 
+     /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name clickColumnMenu
+     * @description Clicks on the specified option in the specified column
+     * menu.  Using this method is fragile, as any change to menu ordering
+     * will break all the tests.  For this reason it is recommended to wrap
+     * this into "clickColumnMenu<ItemName>" methods, each with a constant
+     * for the item you want to click on.  You could alternatively develop
+     * a method that finds a menu item by text value, but given that
+     * ui-grid has i18n, the text values could also change easily
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to sort on
+     * @param {integer} menuItemNumber the number of the item in the menu that
+     * you want to click on
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.clickColumnMenu('myGrid', 0, 0);
+     * </pre>
+     * 
+     */
+    clickColumnMenu: function( gridId, colNumber, menuItemNumber ) {
+      var headerCell = this.headerCell( gridId, colNumber);
+      
+      headerCell.element( by.css( '.ui-grid-column-menu-button' ) ).click();
+      
+      var columnMenu = element( by.id( gridId ) ).element( by.css( '.ui-grid-column-menu' ));
+      columnMenu.element( by.repeater('item in menuItems').row(menuItemNumber) ).click();
+    },
+    
+    
+     /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name clickColumnMenuSortAsc
+     * @description Clicks on the sort ascending item within the specified
+     * column menu.  Although it feels cumbersome to write lots of individual
+     * "click this menu item" helpers, it is quite useful if the column menus are
+     * changed to not have to go to every test script and change the menu item number  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to sort on
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.clickColumnMenuSortAsc('myGrid', 0);
+     * </pre>
+     * 
+     */
+    clickColumnMenuSortAsc: function( gridId, colNumber ) {
+      this.clickColumnMenu( gridId, colNumber, 0);
+    },
+
+
+     /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name clickColumnMenuSortDesc
+     * @description Clicks on the sort descending item within the specified
+     * column menu.  Although it feels cumbersome to write lots of individual
+     * "click this menu item" helpers, it is quite useful if the column menus are
+     * changed to not have to go to every test script and change the menu item number  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to sort on
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.clickColumnMenuSortDesc('myGrid', 0);
+     * </pre>
+     * 
+     */
+    clickColumnMenuSortDesc: function( gridId, colNumber ) {
+      this.clickColumnMenu( gridId, colNumber, 1);
+    },
+
+
+     /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name clickColumnMenuRemoveSort
+     * @description Clicks on the remove sort item within the specified
+     * column menu.  Although it feels cumbersome to write lots of individual
+     * "click this menu item" helpers, it is quite useful if the column menus are
+     * changed to not have to go to every test script and change the menu item number  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to remove the sort from
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.clickColumnMenuRemoveSort('myGrid', 0);
+     * </pre>
+     * 
+     */
+    clickColumnMenuRemoveSort: function( gridId, colNumber ) {
+      this.clickColumnMenu( gridId, colNumber, 2);
+    },
+    
+     /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name expectFilterBoxInColumn
+     * @description Checks that a filter box exists in the specified column  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to verify the filter box is in
+     * @param {integer} count the number filter boxes you expect - 0 meaning none, 1 meaning
+     * a standard filter, 2 meaning a numerical filter with greater than / less than.
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.expectFilterBoxInColumn('myGrid', 0, 0);
+     * </pre>
+     * 
+     */
+    expectFilterBoxInColumn: function( gridId, colNumber, count ) {
+      var headerCell = this.headerCell( gridId, colNumber);
+      
+      expect( headerCell.all( by.css( '.ui-grid-filter-input' ) ).count() ).toEqual(count);
+    },
+
+
+     /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name cancelFilterInColumn
+     * @description Cancels the filter in a column  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to cancel the filter in
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.cancelFilterInColumn('myGrid', 0);
+     * </pre>
+     * 
+     */
+    cancelFilterInColumn: function( gridId, colNumber ) {
+      var headerCell = this.headerCell( gridId, colNumber);
+      
+      headerCell.element( by.css( '.ui-grid-icon-cancel' ) ).click();
+    },
+    
+
+     /**
+     * @ngdoc method
+     * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+     * @name enterFilterInColumn
+     * @description Enters a filter in a column  
+     * @param {string} gridId the id of the grid that you want to inspect
+     * @param {integer} colNumber the number of the column (within the visible columns)
+     * that you want to enter the filter in
+     * @param {string} filterValue the value you want to enter into the filter
+     * 
+     * @example 
+     * <pre>
+     *   gridTestUtils.cancelFilterInColumn('myGrid', 0);
+     * </pre>
+     * 
+     */
+    enterFilterInColumn: function( gridId, colNumber, filterValue ) {
+      var headerCell = this.headerCell( gridId, colNumber);
+      
+      headerCell.element( by.css( '.ui-grid-filter-input' ) ).sendKeys(filterValue);
+    }
+};
+

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -2,8 +2,8 @@
 exports.config = {
   // The address of a running selenium server.
 
-  // seleniumAddress: 'http://localhost:4444/wd/hub',
-  seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.37.0.jar',
+  //seleniumAddress: 'http://localhost:4444/wd/hub',
+  seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.42.2.jar',
   seleniumPort: 4444,
 
   // Capabilities to be passed to the webdriver instance.


### PR DESCRIPTION
I've done the first set of e2e tests, but won't have time again for this for a few days.  I know that @novice3030 had expressed interest in how these were done and the test library itself, so pushing to give him access to that and to allow others to build more tests if they wish.

Failing someone else doing them beforehand, I'll extend this early next week, hopefully to complete tests across all tutorials.
# 

Provides an e2e test library of helpers for interacting with the grid
and a pattern for applying tests to tutorials.

Also includes upgrade of protractor to 1.0 and associated selenium/
webdriver upgrade.  As such will require `npm update` and potentially
`grunt install` before the tests can be executed with:
  `grunt dev`
