### PR TITLE
Fixed tutorial & docs dropdown on ui-grid page

### DIFF
--- a/misc/site/index.html
+++ b/misc/site/index.html
@@ -143,7 +143,7 @@
   </div>
  
 
-  <!--<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>-->
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 
   <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.21/angular.js"></script>


### PR DESCRIPTION
Re-included jquery for ui-grid page as is required for bootstrap dropdown. Verified that jquery is not present on tutorial or docs pages so no impact on e2e tests.
