### PR TITLE
Fix #1559: offsetWidth is rounded to whole pixel, use style['width'] instead

### DIFF
--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -82,7 +82,7 @@ function augmentWidthOrHeight( elem, name, extra, isBorderBox, styles ) {
 function getWidthOrHeight( elem, name, extra ) {
   // Start with offset property, which is equivalent to the border-box value
   var valueIsBorderBox = true,
-          val = name === 'width' ? elem.offsetWidth : elem.offsetHeight,
+          val,
           styles = getStyles(elem),
           isBorderBox = styles['boxSizing'] === 'border-box';
 


### PR DESCRIPTION
All unit tests passing, so appears that padding and borders are still
calculated correctly.
