### PR TITLE
Fix #1595 row_header sometimes not adding correctly

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -145,6 +145,18 @@ angular.module('ui.grid')
    */
   self.api.registerMethod( 'core', 'refreshRows', this.refreshRows );
 
+  /**
+   * @ngdoc function
+   * @name handleWindowResize
+   * @methodOf ui.grid.core.api:PublicApi
+   * @description Trigger a grid resize, normally this would be picked
+   * up by a watch on window size, but in some circumstances it is necessary
+   * to call this manually
+   * @returns {promise} promise that is resolved when render completes?
+   * 
+   */
+  self.api.registerMethod( 'core', 'handleWindowResize', this.handleWindowResize );
+
 
   /**
    * @ngdoc function
@@ -297,11 +309,18 @@ angular.module('ui.grid')
       rowHeaderCol.renderContainer = 'left';
     }
 
-    self.columnBuilders[0](colDef,rowHeaderCol,self.gridOptions)
+    // relies on the default column builder being first in array, as it is instantiated
+    // as part of grid creation
+    self.columnBuilders[0](colDef,rowHeaderCol,self.options)
       .then(function(){
         rowHeaderCol.enableFiltering = false;
         rowHeaderCol.enableSorting = false;
         self.rowHeaderColumns.push(rowHeaderCol);
+        self.buildColumns()
+          .then( function() {
+            self.preCompileCellTemplates();
+            self.handleWindowResize();
+          });
       });
   };
 
@@ -319,12 +338,6 @@ angular.module('ui.grid')
     var builderPromises = [];
     var offset = self.rowHeaderColumns.length;
 
-    //add row header columns to the grid columns array
-    angular.forEach(self.rowHeaderColumns, function (rowHeaderColumn) {
-      offset++;
-      self.columns.push(rowHeaderColumn);
-    });
-
     // Synchronize self.columns with self.options.columnDefs so that columns can also be removed.
     if (self.columns.length > self.options.columnDefs.length) {
       self.columns.forEach(function (column, index) {
@@ -333,6 +346,13 @@ angular.module('ui.grid')
         }
       });
     }
+
+    //add row header columns to the grid columns array _after_ columns without columnDefs have been removed
+    angular.forEach(self.rowHeaderColumns, function (rowHeaderColumn) {
+      offset++;
+      self.columns.unshift(rowHeaderColumn);
+    });
+
 
     self.options.columnDefs.forEach(function (colDef, index) {
       self.preprocessColDef(colDef);

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -343,6 +343,7 @@ angular.module('ui.grid')
 
     //use field if it is defined; name if it is not
     self.field = (colDef.field === undefined) ? colDef.name : colDef.field;
+    self.name = colDef.name;
 
     // Use colDef.displayName as long as it's not undefined, otherwise default to the field name
     self.displayName = (colDef.displayName === undefined) ? gridUtil.readableColumnName(colDef.name) : colDef.displayName;

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -321,11 +321,13 @@ describe('Grid factory', function () {
 
 
     it('should create left container for left row header', inject(function(gridClassFactory, $timeout) {
-
       var colDefs = [
         {name:'col1'}
       ];
       var grid = new gridClassFactory.createGrid({ columnDefs:colDefs });
+
+      spyOn( grid, "preCompileCellTemplates").andCallFake(function() {});
+      spyOn( grid, "handleWindowResize").andCallFake(function() {});
 
       $timeout(function () {
         grid.addRowHeaderColumn({name: 'rowHeader', cellTemplate: "<div/>"});
@@ -347,6 +349,9 @@ describe('Grid factory', function () {
       ];
       var grid = new gridClassFactory.createGrid({columnDefs:colDefs });
       grid.rtl = true;
+
+      spyOn( grid, "preCompileCellTemplates").andCallFake(function() {});
+      spyOn( grid, "handleWindowResize").andCallFake(function() {});
 
       $timeout(function () {
         grid.addRowHeaderColumn({name: 'rowHeader', cellTemplate: "<div/>"});


### PR DESCRIPTION
Introduces a new call to `buildColumns`, and adds a name to all
gridColumns (was expected to be present within `buildColumns`)

Also made handleWindowResize a publicApi method, as part of this
same issue I was getting issues with column widths that I think
can be resolved by calling this.  Better to have it as a public
method.
