### PR TITLE
Fix #1594, dependency between rowEdit and Selection features

### DIFF
--- a/misc/tutorial/205_row_editable.ngdoc
+++ b/misc/tutorial/205_row_editable.ngdoc
@@ -47,6 +47,9 @@ Methods and properties are provided to operate with this regime:
 
 
 @example
+In this example rows are saved 2 seconds after moving off, and the save is faked using a timeout of 3 seconds, so 
+each save will take 3 seconds to complete.  Any row saved with a gender of "male" will error.
+
 <example module="app">
   <file name="app.js">
     var app = angular.module('app', ['ui.grid', 'ui.grid.edit', 'ui.grid.rowEdit', 'ui.grid.cellNav', 'addressFormatter']);

--- a/src/features/row-edit/js/gridRowEdit.js
+++ b/src/features/row-edit/js/gridRowEdit.js
@@ -529,7 +529,16 @@
           scope: false,
           compile: function ($elm, $attrs) {
             var rowRepeatDiv = angular.element($elm.children().children()[0]);
-            rowRepeatDiv.attr("ng-class", "{'ui-grid-row-saving': row.isSaving, 'ui-grid-row-error': row.isError}");
+            
+            var existingNgClass = rowRepeatDiv.attr("ng-class");
+            var newNgClass = '';
+            if ( existingNgClass ) {
+              newNgClass = existingNgClass.slice(0, -1) + ",'ui-grid-row-saving': row.isSaving, 'ui-grid-row-error': row.isError}";
+            } else {
+              newNgClass = "{'ui-grid-row-saving': row.isSaving, 'ui-grid-row-error': row.isError}";
+            }
+            rowRepeatDiv.attr("ng-class", newNgClass);
+
             return {
               pre: function ($scope, $elm, $attrs, controllers) {
 

--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -406,7 +406,16 @@
           scope: false,
           compile: function ($elm, $attrs) {
             var rowRepeatDiv = angular.element($elm.children().children()[0]);
-            rowRepeatDiv.attr("ng-class", "{'ui-grid-row-selected': row.isSelected}");
+
+            var existingNgClass = rowRepeatDiv.attr("ng-class");
+            var newNgClass = '';
+            if ( existingNgClass ) {
+              newNgClass = existingNgClass.slice(0, -1) + ",'ui-grid-row-selected': row.isSelected}";
+            } else {
+              newNgClass = "{'ui-grid-row-selected': row.isSelected}";
+            }
+            rowRepeatDiv.attr("ng-class", newNgClass);
+
             return {
               pre: function ($scope, $elm, $attrs, controllers) {
 


### PR DESCRIPTION
Each of rowEdit and selection now check for pre-existing ng-class
attribute and append to it if already there.
