### PR TITLE
Enhancement(rowEdit): allow suppression of timers, fix getRowsDirty

### DIFF
--- a/misc/tutorial/205_row_editable.ngdoc
+++ b/misc/tutorial/205_row_editable.ngdoc
@@ -35,7 +35,8 @@ If the promise is successfully resolved then the row is set back to clean.  If t
 row is set to a status of `isError`.
 
 Optionally, the calling application can request `flushDirtyRows`, which will trigger the save event for all
-currently dirty rows.
+currently dirty rows.  If the `rowEditWaitInterval` grid option is set to -1, then saves will never be triggered
+by timer, and only be triggered when manually called.
 
 Methods and properties are provided to operate with this regime:
 
@@ -44,6 +45,7 @@ Methods and properties are provided to operate with this regime:
 - `flushDirtyRows()`: flushes all currently dirty rows to the server, might be used 
   on a page navigation request or pressing of a save button
 - `saveRow( rowEntity )`: event called when a row is ready for saving
+- `rowEditWaitInterval`: grid option that controls how long a wait will be before a save is triggered (in ms)
 
 
 @example

--- a/src/features/row-edit/js/gridRowEdit.js
+++ b/src/features/row-edit/js/gridRowEdit.js
@@ -113,7 +113,7 @@
                  * 
                  */
                 getDirtyRows: function (grid) {
-                  return grid.rowEditDirtyRows;
+                  return grid.rowEditDirtyRows ? grid.rowEditDirtyRows : [];
                 },
                 /**
                  * @ngdoc method
@@ -128,7 +128,7 @@
                  * 
                  */
                 getErrorRows: function (grid) {
-                  return grid.rowEditErrorRows;
+                  return grid.rowEditErrorRows ? grid.rowEditErrorRows : [];
                 },
                 /**
                  * @ngdoc method
@@ -326,20 +326,6 @@
         
         
         /**
-         * @ngdoc property
-         * @propertyOf ui.grid.rowEdit.api:GridOptions
-         * @name rowEditWaitInterval
-         * @description How long the grid should wait for another change on this row
-         * before triggering a save (in milliseconds)
-         * 
-         * @example
-         * Setting the wait interval to 4 seconds
-         * <pre>
-         *   $scope.gridOptions = { rowEditWaitInterval: 4000 }
-         * </pre>
-         * 
-         */
-        /**
          * @ngdoc method
          * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
          * @name endEditCell
@@ -442,6 +428,22 @@
         
         
         /**
+         * @ngdoc property
+         * @propertyOf ui.grid.rowEdit.api:GridOptions
+         * @name rowEditWaitInterval
+         * @description How long the grid should wait for another change on this row
+         * before triggering a save (in milliseconds).  If set to -1, then saves are 
+         * never triggered by timer (implying that the user will call flushDirtyRows() 
+         * manually)
+         * 
+         * @example
+         * Setting the wait interval to 4 seconds
+         * <pre>
+         *   $scope.gridOptions = { rowEditWaitInterval: 4000 }
+         * </pre>
+         * 
+         */
+        /**
          * @ngdoc method
          * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
          * @name considerSetTimer
@@ -456,8 +458,10 @@
           service.cancelTimer( grid, gridRow );
           
           if ( gridRow.isDirty && !gridRow.isSaving ){
-            var waitTime = grid.options.rowEditWaitInterval ? grid.options.rowEditWaitInterval : 2000;
-            gridRow.rowEditSaveTimer = $interval( service.saveRow( grid, gridRow ), waitTime, 1);
+            if ( grid.options.rowEditWaitInterval !== -1 ){
+              var waitTime = grid.options.rowEditWaitInterval ? grid.options.rowEditWaitInterval : 2000;
+              gridRow.rowEditSaveTimer = $interval( service.saveRow( grid, gridRow ), waitTime, 1);
+            }
           }
         },
         

--- a/src/features/row-edit/test/uiGridRowEditService.spec.js
+++ b/src/features/row-edit/test/uiGridRowEditService.spec.js
@@ -158,7 +158,7 @@ describe('ui.grid.edit uiGridRowEditService', function () {
       $interval.flush(200);
       expect( called ).toEqual(true);
     });
-    
+
     it( 'row already dirty so even though value not changed, interval triggered at 2000ms', function() {
       var called = false;
       spyOn( uiGridRowEditService, 'saveRow' ).andCallFake( function() {
@@ -183,6 +183,29 @@ describe('ui.grid.edit uiGridRowEditService', function () {
       expect( called ).toEqual(true);
     });    
 
+    it( 'timer is not present beforehand, timer interval set to -1 so not created', function() {
+      var called = false;
+      grid.options.rowEditWaitInterval = -1;
+      spyOn( uiGridRowEditService, 'saveRow' ).andCallFake( function() {
+        return function() { called = true;};
+      });
+      
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+      
+      grid.api.edit.raise.afterCellEdit( grid.options.data[0], grid.options.columnDefs[0], '1', '2' );
+      expect( uiGridRowEditService.saveRow ).not.toHaveBeenCalled();
+      expect( grid.rows[0].isDirty ).toEqual( true );
+      expect( grid.rowEditDirtyRows.length ).toEqual( 1 );
+      
+      expect( grid.rows[0].rowEditSaveTimer ).toEqual( undefined );
+      
+      $interval.flush(1900);
+      expect( called ).toEqual(false);
+
+      $interval.flush(200);
+      expect( called ).toEqual(false);
+    });
+    
     it( 'edit timer is in place beforehand and is cancelled, a new one is created and triggered at non-standard 4000ms', function() {
       var called = false;
       spyOn( uiGridRowEditService, 'saveRow' ).andCallFake( function() {


### PR DESCRIPTION
Timers can be suppressed by setting `rowEditWaitInterval` to -1, which
means user must manually call `flushDirtyRows()`.

getRowsDirty and getRowsError now return `[]` if there are no rows,
rather than undefined, allowing users to call `getRowsDirty().length > 0`
without doing a null check.
