### PR TITLE
Fix #1023 (rowSort): allow nulls to propagate to sort functions

### DIFF
--- a/misc/tutorial/102_sorting.ngdoc
+++ b/misc/tutorial/102_sorting.ngdoc
@@ -50,7 +50,9 @@ Multiple columns can be sorted by shift-clicking on the 2-n columns.  To see it 
 
 <h1 id="inital-sort">Initial Sort State</h1>
 
-You can set an initial sort state for the grid by defining the `sort` property on your column definitions. The `direction` sub-property says which way to sort, and the `priority` says what order to sort the columns in (lower priority gets sorted first).
+You can set an initial sort state for the grid by defining the `sort` property on your column definitions. 
+The `direction` sub-property says which way to sort, and the `priority` says what order to sort the columns 
+in (lower priority gets sorted first).
 
 <example module="app2">
   <file name="app2.js">
@@ -59,6 +61,9 @@ You can set an initial sort state for the grid by defining the `sort` property o
     app.controller('MainCtrl', ['$scope', '$http', function ($scope, $http) {
       $scope.gridOptions = {
         enableSorting: true,
+        onRegisterApi: function( gridApi ) {
+          $scope.gridApi = gridApi;
+        },
         columnDefs: [
           {
             field: 'name',
@@ -71,7 +76,30 @@ You can set an initial sort state for the grid by defining the `sort` property o
             field: 'gender',
             sort: {
               direction: 'asc',
-              priority: 0
+              priority: 0,
+              sortingAlgorithm: function(a, b) {
+                var nulls = $scope.gridApi.core.sortHandleNulls(a, b);
+                if( nulls !== null ) {
+                  return nulls;
+                } else {
+                  if( a === b ) {
+                    return 0;
+                  }
+                  if( a === 'male' ) {
+                    return -1;
+                  }
+                  if( b === 'male' ) {
+                    return 1;
+                  }
+                  if( a == 'female' ) {
+                    return -1;
+                  }
+                  if( b === 'female' ) {
+                    return 1;
+                  }
+                  return 0;
+                }
+              }
             }
           },
           { field: 'company', enableSorting: false  }

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -160,6 +160,31 @@ angular.module('ui.grid')
 
   /**
    * @ngdoc function
+   * @name sortHandleNulls
+   * @methodOf ui.grid.core.api:PublicApi
+   * @description A null handling method that can be used when building custom sort
+   * functions
+   * @example
+   * <pre>
+   *   mySortFn = function(a, b) {
+   *   var nulls = $scope.gridApi.core.sortHandleNulls(a, b);
+   *   if ( nulls !== null ){
+   *     return nulls;
+   *   } else {
+   *     // your code for sorting here
+   *   };
+   * </pre>
+   * @param {object} a sort value a
+   * @param {object} b sort value b
+   * @returns {number} null if there were no nulls/undefineds, otherwise returns
+   * a sort value that should be passed back from the sort function
+   * 
+   */
+  self.api.registerMethod( 'core', 'sortHandleNulls', rowSorter.handleNulls );
+
+
+  /**
+   * @ngdoc function
    * @name sortChanged
    * @methodOf  ui.grid.core.api:PublicApi
    * @description The sort criteria on one or more columns has

--- a/test/unit/core/row-sorting.spec.js
+++ b/test/unit/core/row-sorting.spec.js
@@ -235,5 +235,27 @@ describe('rowSorter', function() {
       });
     });
   });
+  
+  ddescribe( 'test each sort routine and null/undefined handling', function () {
+    it( 'each function sorts as expected', function() {
+      var sortValues = {
+        basicSort: [ undefined, null, 'a', 'b' ],
+        sortNumber: [ undefined, null, 1, 2 ],
+        sortNumberStr: [ undefined, null, '3.a5', '5.b7' ],
+        sortAlpha: [ undefined, null, 'a', 'b' ],
+        sortDate: [ undefined, null, new Date('2009-12-12'), new Date('2010-11-11') ],
+        sortBool: [ undefined, null, false, true ]
+      };
+      
+      angular.forEach( sortValues, function( values, sortFnName ) {
+        expect( rowSorter[sortFnName] (values[0], values[1])).toEqual(0, sortFnName + ': expected undefined to equal null');
+        expect( rowSorter[sortFnName] (values[0], values[2])).toBeGreaterThan(0, sortFnName + ': expected undefined to be greater than value');
+        expect( rowSorter[sortFnName] (values[3], values[1])).toBeLessThan(0, sortFnName + ': expected value to be less than null');
+        expect( rowSorter[sortFnName] (values[2], values[2])).toEqual(0, sortFnName + ': expected value to equal value');
+        expect( rowSorter[sortFnName] (values[2], values[3])).toBeLessThan(0, sortFnName + ': expected value to be less than value');
+        expect( rowSorter[sortFnName] (values[3], values[2])).toBeGreaterThan(0, sortFnName + ': expected value to be greater than value');
+      });
+    });
+  });
 
 });


### PR DESCRIPTION
Add a new core.api of sortHandleNulls, and use this same method in
each of the sorters.  Add unit tests to sorters.  Minor fixes along with
that to allow false values to be sorted, and to not accidentally fail to
sort 0 and false values.

Extend tutorial to demonstrate sort function.
