### PR TITLE
Fix #1665 (Grid.js): refresh rather than refreshCanvas columnDef watch

### DIFF
--- a/misc/tutorial/113_adding_and_removing_columns.ngdoc
+++ b/misc/tutorial/113_adding_and_removing_columns.ngdoc
@@ -1,0 +1,93 @@
+@ngdoc overview
+@name Tutorial: 113 Adding and removing columns
+@description 
+
+You can dynamically add and remove columns, the grid watches the column defs and
+updates appropriately.
+
+@example
+<example module="app">
+  <file name="app.js">
+    var app = angular.module('app', ['ngAnimate', 'ui.grid']);
+    
+    app.controller('MainCtrl', ['$scope', '$http', function ($scope, $http) {
+      $scope.columns = [{ field: 'name' }, { field: 'gender' }];
+      $scope.gridOptions = {
+        enableSorting: true,
+        columnDefs: $scope.columns
+      };
+      
+      $scope.remove = function() {
+          $scope.columns.splice($scope.columns.length-1, 1);
+      }
+      
+      $scope.add = function() {
+          $scope.columns.push({ field: 'company', enableSorting: false });
+      }
+
+      $scope.splice = function() {
+          $scope.columns.splice(1, 0, { field: 'company', enableSorting: false });
+      }
+    
+      $scope.unsplice = function() {
+          $scope.columns.splice(1, 1);
+      }
+    
+      $http.get('/data/100.json')
+        .success(function(data) {
+          $scope.gridOptions.data = data;
+          console.log(data)
+        });
+    }]);
+  </file>
+  <file name="index.html">
+    <div ng-controller="MainCtrl">
+      Try clicking the Add button to add the company column.
+      Try clicking the Remove button to remove the last column.
+      Try clicking the Splice button to insert a column in the middle.
+      <br>
+      <br>
+      <button id="button_add" class="btn" ng-click="add()">Add</button>
+      <button id="button_remove" class="btn" ng-click="remove()">Remove Last</button>
+      <button id="button_splice" class="btn" ng-click="splice()">Splice</button>
+      <button id="button_unsplice" class="btn" ng-click="unsplice()">Remove Middle</button>
+      <div id="grid1" ui-grid="gridOptions" class="grid"></div>
+    </div>
+  </file>
+  <file name="main.css">
+    .grid {
+      width: 500px;
+      height: 250px;
+    }
+  </file>
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    describe( '113 dynamically changing columns', function() {
+      it('grid should have two visible columns', function () {
+        gridTestUtils.expectHeaderColumnCount( 'grid1', 2 );
+      });
+  
+      it('add and remove columns from end, grid updates accordingly', function () {
+        element(by.id('button_add')).click();
+        gridTestUtils.expectHeaderColumnCount( 'grid1', 3 );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, 'Gender' );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 2, 'Company' );
+
+        element(by.id('button_remove')).click();
+        gridTestUtils.expectHeaderColumnCount( 'grid1', 2 );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, 'Gender' );
+      });      
+
+      it('add and remove columns in middle, grid updates accordingly', function () {
+        element(by.id('button_splice')).click();
+        gridTestUtils.expectHeaderColumnCount( 'grid1', 3 );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, 'Company' );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 2, 'Gender' );
+
+        element(by.id('button_unsplice')).click();
+        gridTestUtils.expectHeaderColumnCount( 'grid1', 2 );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, 'Gender' );
+      });      
+    });    
+  </file>
+</example>

--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -55,7 +55,7 @@
 
               self.grid.preCompileCellTemplates();
 
-              self.grid.refreshCanvas(true);
+              self.grid.refresh();
             });
         }
       }

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -388,8 +388,8 @@ angular.module('ui.grid')
       var col = self.getColumn(colDef.name);
 
       if (!col) {
-        col = new GridColumn(colDef, index + offset, self);
-        self.columns.push(col);
+        col = new GridColumn(colDef, index, self);
+        self.columns.splice(index, 0, col);
       }
       else {
         col.updateColumnDef(colDef, col.index);

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -246,6 +246,93 @@ describe('Grid factory', function () {
       expect(grid1.getColumn('bool').colDef.type).toBe('boolean');
       expect(grid1.getColumn('obj').colDef.type).toBe('object');
     });
+    
+    it('add columns at the correct position - middle', function() {
+      var grid1 = new Grid({ id: 3 });
+
+      grid1.options.columnDefs = [
+        {name:'1'},
+        {name:'2'},
+        {name:'3'},
+        {name:'4'},
+        {name:'5'}
+      ];
+      grid1.buildColumns();
+      
+      expect(grid1.columns[0].name).toEqual('1');
+      expect(grid1.columns[1].name).toEqual('2');
+      expect(grid1.columns[2].name).toEqual('3');
+      expect(grid1.columns[3].name).toEqual('4');
+      expect(grid1.columns[4].name).toEqual('5');
+      
+      grid1.options.columnDefs.splice(3, 0, {name: '3.5'});
+      grid1.buildColumns();
+
+      expect(grid1.columns[0].name).toEqual('1');
+      expect(grid1.columns[1].name).toEqual('2');
+      expect(grid1.columns[2].name).toEqual('3');
+      expect(grid1.columns[3].name).toEqual('3.5');
+      expect(grid1.columns[4].name).toEqual('4');
+      expect(grid1.columns[5].name).toEqual('5');      
+    });
+
+    it('add columns at the correct position - start', function() {
+      var grid1 = new Grid({ id: 3 });
+
+      grid1.options.columnDefs = [
+        {name:'1'},
+        {name:'2'},
+        {name:'3'},
+        {name:'4'},
+        {name:'5'}
+      ];
+      grid1.buildColumns();
+      
+      expect(grid1.columns[0].name).toEqual('1');
+      expect(grid1.columns[1].name).toEqual('2');
+      expect(grid1.columns[2].name).toEqual('3');
+      expect(grid1.columns[3].name).toEqual('4');
+      expect(grid1.columns[4].name).toEqual('5');
+      
+      grid1.options.columnDefs.unshift({name: '0.5'});
+      grid1.buildColumns();
+
+      expect(grid1.columns[0].name).toEqual('0.5');
+      expect(grid1.columns[1].name).toEqual('1');
+      expect(grid1.columns[2].name).toEqual('2');
+      expect(grid1.columns[3].name).toEqual('3');
+      expect(grid1.columns[4].name).toEqual('4');
+      expect(grid1.columns[5].name).toEqual('5');      
+    });
+
+    it('add columns at the correct position - end', function() {
+      var grid1 = new Grid({ id: 3 });
+
+      grid1.options.columnDefs = [
+        {name:'1'},
+        {name:'2'},
+        {name:'3'},
+        {name:'4'},
+        {name:'5'}
+      ];
+      grid1.buildColumns();
+      
+      expect(grid1.columns[0].name).toEqual('1');
+      expect(grid1.columns[1].name).toEqual('2');
+      expect(grid1.columns[2].name).toEqual('3');
+      expect(grid1.columns[3].name).toEqual('4');
+      expect(grid1.columns[4].name).toEqual('5');
+      
+      grid1.options.columnDefs.push({name: '5.5'});
+      grid1.buildColumns();
+
+      expect(grid1.columns[0].name).toEqual('1');
+      expect(grid1.columns[1].name).toEqual('2');
+      expect(grid1.columns[2].name).toEqual('3');
+      expect(grid1.columns[3].name).toEqual('4');
+      expect(grid1.columns[4].name).toEqual('5');
+      expect(grid1.columns[5].name).toEqual('5.5');      
+    });
   });
 
   describe('binding', function() {


### PR DESCRIPTION
Allow dynamically adding columns by shifting to a refresh rather than
refresh canvas when the columnDef watch is triggered.

Also address #1586, ability to insert columns rather than just append.
Includes new tutorial, functional tests and unit tests, as suggested
in #1586.
