### PR TITLE
Fix #1685: Remove col.index from most code

### DIFF
--- a/misc/tutorial/303_customizing_column_menu.ngdoc
+++ b/misc/tutorial/303_customizing_column_menu.ngdoc
@@ -12,7 +12,8 @@ The column menu will add the column's `GridColumn` object to the context as `thi
 You can then show/hide the the menu item based on conditions that use the grid and column.  You could 
 also use a custom column builder to add some item to the every column definition.
 
-You can remove the column hide option using the `disableHiding` columnDef option.  You can disable
+You can remove the column hide option using the `disableHiding` columnDef option, which will also prevent
+this column being hidden in the gridMenu (once it is finished and merged).  You can disable
 the column menu entirely using the `disableColumnMenu` columnDef option.
 
 You can supply an icon class with the `icon` property.

--- a/src/features/cellnav/test/uiGridCellNavService.spec.js
+++ b/src/features/cellnav/test/uiGridCellNavService.spec.js
@@ -182,7 +182,7 @@ describe('ui.grid.edit uiGridCellNavService', function () {
     it('should request scroll to row and column', function () {
       uiGridCellNavService.scrollTo( grid, $scope, grid.options.data[2], grid.columns[1].colDef);
       
-      expect(args).toEqual( { y : { percentage : 2/3 }, x : { percentage :  300/600 } });
+      expect(args).toEqual( { y : { percentage : 2/3 }, x : { percentage :  (100 + 2/3 * 200)/600 } });
     });
 
     it('should request scroll to row only', function () {
@@ -192,9 +192,9 @@ describe('ui.grid.edit uiGridCellNavService', function () {
     });
 
     it('should request scroll to column only', function () {
-      uiGridCellNavService.scrollTo( grid, $scope, null, grid.columns[1].colDef);
+      uiGridCellNavService.scrollTo( grid, $scope, null, grid.columns[0].colDef);
       
-      expect(args).toEqual( { x : { percentage :  300/600 } });
+      expect(args).toEqual( { x : { percentage :  (1/3 * 100)/600 } });
     });
 
     it('should request no scroll as no row or column', function () {

--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -167,12 +167,11 @@
                 var otherCol = renderContainer.renderedColumns[$scope.renderIndex - 1];
 
                 // Don't append the left resizer if this is the first column or the column to the left of this one has resizing disabled
-                if (otherCol && $scope.col.index !== 0 && otherCol.colDef.enableColumnResizing !== false) {
+                if (otherCol && renderContainer.visibleColumnCache.indexOf($scope.col) !== 0 && otherCol.colDef.enableColumnResizing !== false) {
                   $elm.prepend(resizerLeft);
                 }
                 
                 // Don't append the right resizer if this column has resizing disabled
-                //if ($scope.col.index !== $scope.grid.renderedColumns.length - 1 && $scope.col.colDef.enableColumnResizing !== false) {
                 if ($scope.col.colDef.enableColumnResizing !== false) {
                   $elm.append(resizerRight);
                 }
@@ -259,7 +258,7 @@
 
           renderContainer.visibleColumnCache.forEach(function (column) {
             // Skip the column we just resized
-            if (column.index === col.index) { return; }
+            if (column === col) { return; }
             
             var colDef = column.colDef;
             if (!colDef.width || (angular.isString(colDef.width) && (colDef.width.indexOf('*') !== -1 || colDef.width.indexOf('%') !== -1))) {

--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -89,8 +89,8 @@ angular.module('ui.grid').directive('uiGridColumnMenu', ['$log', '$timeout', '$w
        * @ngdoc boolean
        * @name disableHiding
        * @propertyOf ui.grid.class:GridOptions.columnDef
-       * @description (optional) True by default. When enabled, this setting allows a user to hide the column
-       * using the column menu.
+       * @description (optional) False by default. When enabled, this setting prevents a user from hiding the column
+       * using the column menu or the grid menu.
        */
       $scope.hideable = function() {
         if (typeof($scope.col) !== 'undefined' && $scope.col && $scope.col.colDef && $scope.col.colDef.disableHiding) {

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -41,13 +41,6 @@
                         
     
             $elm.addClass($scope.col.getColClass(false));
-    // shane - No need for watch now that we trackby col name
-    //        $scope.$watch('col.index', function (newValue, oldValue) {
-    //          if (newValue === oldValue) { return; }
-    //          var className = $elm.attr('class');
-    //          className = className.replace(uiGridConstants.COL_CLASS_PREFIX + oldValue, uiGridConstants.COL_CLASS_PREFIX + newValue);
-    //          $elm.attr('class', className);
-    //        });
     
             // Hide the menu by default
             $scope.menuShown = false;

--- a/src/js/core/directives/ui-grid-header.js
+++ b/src/js/core/directives/ui-grid-header.js
@@ -129,7 +129,6 @@
 
                   column.drawnWidth = column.width;
 
-                  // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + column.width + 'px; }';
                 }
               });
 
@@ -155,8 +154,6 @@
                     canvasWidth += colWidth;
                     column.drawnWidth = colWidth;
 
-                    // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
-
                     // Remove this element from the percent array so it's not processed below
                     percentArray.splice(i, 1);
                   }
@@ -167,8 +164,6 @@
 
                     canvasWidth += colWidth;
                     column.drawnWidth = colWidth;
-
-                    // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
 
                     // Remove this element from the percent array so it's not processed below
                     percentArray.splice(i, 1);
@@ -182,8 +177,6 @@
                   canvasWidth += colWidth;
 
                   column.drawnWidth = colWidth;
-
-                  // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
                 });
               }
 
@@ -205,8 +198,6 @@
                     canvasWidth += colWidth;
                     column.drawnWidth = colWidth;
 
-                    // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
-
                     lastColumn = column;
 
                     // Remove this element from the percent array so it's not processed below
@@ -220,8 +211,6 @@
 
                     canvasWidth += colWidth;
                     column.drawnWidth = colWidth;
-
-                    // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
 
                     // Remove this element from the percent array so it's not processed below
                     asterisksArray.splice(i, 1);
@@ -237,8 +226,6 @@
                   canvasWidth += colWidth;
 
                   column.drawnWidth = colWidth;
-
-                  // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
                 });
               }
 

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -110,16 +110,34 @@ angular.module('ui.grid')
     *
     */
     
-   
+  /**
+   * @ngdoc method
+   * @methodOf ui.grid.class:GridColumn
+   * @name GridColumn
+   * @description Initializes a gridColumn
+   * @param {ColumnDef} colDef the column def to associate with this column
+   * @param {number} index deprecated, but not yet removed from signature - null can be passed
+   * @param {Grid} grid the grid we'd like to create this column in
+   */ 
   function GridColumn(colDef, index, grid) {
     var self = this;
 
     self.grid = grid;
-    colDef.index = index;
 
     self.updateColumnDef(colDef);
   }
 
+
+  /**
+   * @ngdoc method
+   * @methodOf ui.grid.class:GridColumn
+   * @name setPropertyOrDefault
+   * @description Sets a property on the column using the passed in columnDef, and
+   * setting the defaultValue if the value cannot be found on the colDef
+   * @param {ColumnDef} colDef the column def to look in for the property value
+   * @param {string} propName the property name we'd like to set
+   * @param {object} defaultValue the value to use if the colDef doesn't provide the setting
+   */ 
   GridColumn.prototype.setPropertyOrDefault = function (colDef, propName, defaultValue) {
     var self = this;
 
@@ -296,16 +314,23 @@ angular.module('ui.grid')
     *   ] }]; </pre>
     *
     */   
+
+  /**
+   * @ngdoc method
+   * @methodOf ui.grid.class:GridColumn
+   * @name updateColumnDef
+   * @description Moves settings from the columnDef down onto the column,
+   * and sets properties as appropriate
+   * @param {ColumnDef} colDef the column def to look in for the property value
+   * @param {number} index deprecated but not yet removed from method signature.  Null is valid.
+   */ 
   GridColumn.prototype.updateColumnDef = function(colDef, index) {
     var self = this;
 
     self.colDef = colDef;
 
-    //position of column
-    self.index = (typeof(index) === 'undefined') ? colDef.index : index;
-
     if (colDef.name === undefined) {
-      throw new Error('colDef.name is required for column at index ' + self.index);
+      throw new Error('colDef.name is required for column at index ' + self.grid.options.columnDefs.indexOf(colDef));
     }
 
     var parseErrorMsg = "Cannot parse column width '" + colDef.width + "' for column named '" + colDef.name + "'";

--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -498,8 +498,6 @@ angular.module('ui.grid')
         canvasWidth = parseInt(canvasWidth, 10) + parseInt(column.width, 10);
 
         column.drawnWidth = column.width;
-
-        // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + column.width + 'px; }';
       }
     });
 
@@ -525,8 +523,6 @@ angular.module('ui.grid')
           canvasWidth += colWidth;
           column.drawnWidth = colWidth;
 
-          // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
-
           // Remove this element from the percent array so it's not processed below
           percentArray.splice(i, 1);
         }
@@ -537,8 +533,6 @@ angular.module('ui.grid')
 
           canvasWidth += colWidth;
           column.drawnWidth = colWidth;
-
-          // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
 
           // Remove this element from the percent array so it's not processed below
           percentArray.splice(i, 1);
@@ -552,8 +546,6 @@ angular.module('ui.grid')
         canvasWidth += colWidth;
 
         column.drawnWidth = colWidth;
-
-        // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
       });
     }
 
@@ -575,8 +567,6 @@ angular.module('ui.grid')
           canvasWidth += colWidth;
           column.drawnWidth = colWidth;
 
-          // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
-
           lastColumn = column;
 
           // Remove this element from the percent array so it's not processed below
@@ -590,8 +580,6 @@ angular.module('ui.grid')
 
           canvasWidth += colWidth;
           column.drawnWidth = colWidth;
-
-          // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
 
           // Remove this element from the percent array so it's not processed below
           asterisksArray.splice(i, 1);
@@ -607,8 +595,6 @@ angular.module('ui.grid')
         canvasWidth += colWidth;
 
         column.drawnWidth = colWidth;
-
-        // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
       });
     }
 

--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -32,15 +32,6 @@ angular.module('ui.grid')
 
      /**
       *  @ngdoc object
-      *  @name index
-      *  @propertyOf  ui.grid.class:GridRow
-      *  @description the index of the GridRow. It should always be unique and immutable
-      */
-    this.index = index;
-
-
-     /**
-      *  @ngdoc object
       *  @name uid
       *  @propertyOf  ui.grid.class:GridRow
       *  @description  UniqueId of row


### PR DESCRIPTION
Removed col.index everywhere it appears, except for in the cell content
templates, which appear to use col.index in creating the cell class.

Added a column renumber to buildColumns to always give every column an
index starting at zero.

Reviewed every tutorial to see if there was breakage.  Found breakage, but only one item that related to this change (the rest was pre-existing).

One outstanding defect that I couldn't resolve (nor see how this change caused it, although it clearly did) is that tutorial 113 - adding and removing columns - doesn't correctly splice a new column in the middle.  The data turns up, but the header widths appear to be slightly off, and therefore everything is wrapping.  Upon scrolling the data fixes itself, the headers don't.

Looking for a review and suggestions on what could be causing that, rather than expecting this to be merged.
