### PR TITLE
Fix #1691 (grid): generate column defs even if rowHeader already present

### DIFF
--- a/misc/tutorial/191_horizontal_scrolling.ngdoc
+++ b/misc/tutorial/191_horizontal_scrolling.ngdoc
@@ -43,7 +43,7 @@ Demonstrating scrolling with large amount of columns
       <strong>{{ gridOptions.columnDefs.length | number }} Columns with Random Widths</strong>
       <br>
       <br>
-      <div ui-grid="gridOptions" class="grid"></div>
+      <div id="grid1" ui-grid="gridOptions" class="grid"></div>
     </div>
   </file>
   <file name="main.css">
@@ -52,4 +52,24 @@ Demonstrating scrolling with large amount of columns
       height: 400px;
     }
   </file>
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    describe( '191 horizontal scrolling', function() {
+      it('check first couple of headers and cells - make sure grid has rendered', function () {
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 0, 'Col0' );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, 'Col1' );
+        gridTestUtils.expectHeaderCellValueMatch( 'grid1', 2, 'Col2' );
+        
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'r0c0' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'r1c0' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 2, 0, 'r2c0' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 1, 'r0c1' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 1, 'r1c1' );
+      });
+  
+//      it('scroll right', function () {
+        // still working out how to get protractor to scroll an element
+//      });
+    });
+  </file>  
 </example>

--- a/misc/tutorial/211_two_grids.ngdoc
+++ b/misc/tutorial/211_two_grids.ngdoc
@@ -44,4 +44,20 @@ each other.
       height: 300px;
     }
   </file>
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    describe( '211 two grids', function() {
+      it('check first grid has rendered', function () {
+        gridTestUtils.expectHeaderColumnCount( 'firstGrid', 3 );
+      });
+
+      it('check second grid has rendered', function () {
+        gridTestUtils.expectHeaderColumnCount( 'secondGrid', 3 );
+      });
+  
+//      it('check that menus display over the correct grid', function () {
+        // still working out how to get protractor to scroll an element
+//      });
+    });    
+  </file>  
 </example>

--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -65,7 +65,7 @@
         var promises = [];
 
         if (n) {
-          if (self.grid.columns.length === 0) {
+          if (self.grid.columns.length === ( self.grid.rowHeaderColumns ? self.grid.rowHeaderColumns.length : 0 ) ) {
             $log.debug('loading cols in dataWatchFunction');
             if (!$attrs.uiGridColumns && self.grid.options.columnDefs.length === 0) {
               self.grid.buildColumnDefsFromData(n);

--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -61,7 +61,7 @@ module.exports = {
      * 
      */
     expectHeaderColumnCount: function( gridId, expectedNumCols ) {
-      var headerCols = element( by.id( gridId ) ).element( by.css('.ui-grid-header') ).all( by.repeater('col in colContainer.renderedColumns track by col.colDef.name') );
+      var headerCols = element( by.id( gridId ) ).element( by.css('.ui-grid-render-container-body')).element( by.css('.ui-grid-header') ).all( by.repeater('col in colContainer.renderedColumns track by col.colDef.name') );
       expect(headerCols.count()).toEqual(expectedNumCols);
     },
 
@@ -104,7 +104,7 @@ module.exports = {
      * 
      */
     headerCell: function( gridId, expectedCol, expectedValue ) {
-      return element( by.id( gridId ) ).element( by.css('.ui-grid-header') ).element( by.repeater('col in colContainer.renderedColumns track by col.colDef.name').row( expectedCol)  );
+      return element( by.id( gridId ) ).element( by.css('.ui-grid-render-container-body')).element( by.css('.ui-grid-header') ).element( by.repeater('col in colContainer.renderedColumns track by col.colDef.name').row( expectedCol)  );
     },
 
 


### PR DESCRIPTION
The data watch only generated column defs if there were no columns.  But
if the selection feature was enabled then there would be a rowHeader column
in place, and therefore it wouldn't generate column defs.
