### PR TITLE
added primary key in docs

### DIFF
--- a/jsonFiles/gridOptions.json
+++ b/jsonFiles/gridOptions.json
@@ -1,4 +1,10 @@
 ﻿[
+﻿	{
+﻿		"id": "primaryKey"
+﻿		"defaultValue": "undefined",
+﻿		"definition": "Field of user's data that should be unique. Allows you automatically update selections state for previously loaded data.",
+﻿		"plunker": "Link"
+﻿	},
 	{	
 		"id": "aggregateTemplate",
 		"defaultValue": "<div ng-click=\"row.toggleExpand()\" ng-style=\"{'left': row.offsetleft}\" class=\"ngAggregate\"><span class=\"ngAggregateText\">{{row.label CUSTOM_FILTERS}} ({{row.totalChildren()}} {{AggItemsLabel}})</span><div class=\"{{row.aggClass()}}\"></div></div>",


### PR DESCRIPTION
I've spent a lot of fucking time playing with rows selecting for correct ng-grid rendering until I found this field in _source code_. This field MUST be in docs.
