### PR TITLE
Fix #1685: Remove col.index from most code, add col.uid

### DIFF
--- a/misc/tutorial/303_customizing_column_menu.ngdoc
+++ b/misc/tutorial/303_customizing_column_menu.ngdoc
@@ -12,7 +12,8 @@ The column menu will add the column's `GridColumn` object to the context as `thi
 You can then show/hide the the menu item based on conditions that use the grid and column.  You could 
 also use a custom column builder to add some item to the every column definition.
 
-You can remove the column hide option using the `disableHiding` columnDef option.  You can disable
+You can remove the column hide option using the `disableHiding` columnDef option, which will also prevent
+this column being hidden in the gridMenu (once it is finished and merged).  You can disable
 the column menu entirely using the `disableColumnMenu` columnDef option.
 
 You can supply an icon class with the `icon` property.

--- a/src/features/cellnav/test/uiGridCellNavService.spec.js
+++ b/src/features/cellnav/test/uiGridCellNavService.spec.js
@@ -182,7 +182,7 @@ describe('ui.grid.edit uiGridCellNavService', function () {
     it('should request scroll to row and column', function () {
       uiGridCellNavService.scrollTo( grid, $scope, grid.options.data[2], grid.columns[1].colDef);
       
-      expect(args).toEqual( { y : { percentage : 2/3 }, x : { percentage :  300/600 } });
+      expect(args).toEqual( { y : { percentage : 2/3 }, x : { percentage :  (100 + 2/3 * 200)/600 } });
     });
 
     it('should request scroll to row only', function () {
@@ -192,9 +192,9 @@ describe('ui.grid.edit uiGridCellNavService', function () {
     });
 
     it('should request scroll to column only', function () {
-      uiGridCellNavService.scrollTo( grid, $scope, null, grid.columns[1].colDef);
+      uiGridCellNavService.scrollTo( grid, $scope, null, grid.columns[0].colDef);
       
-      expect(args).toEqual( { x : { percentage :  300/600 } });
+      expect(args).toEqual( { x : { percentage :  0 } });
     });
 
     it('should request no scroll as no row or column', function () {

--- a/src/features/edit/templates/cellEditor.html
+++ b/src/features/edit/templates/cellEditor.html
@@ -1,5 +1,5 @@
 <div>
     <form name="inputForm">
-        <input type="{{inputType}}" ng-class="'colt' + col.index" ui-grid-editor ng-model="MODEL_COL_FIELD" />
+        <input type="{{inputType}}" ng-class="'colt' + col.uid" ui-grid-editor ng-model="MODEL_COL_FIELD" />
     </form>
 </div>

--- a/src/features/edit/templates/dropdownEditor.html
+++ b/src/features/edit/templates/dropdownEditor.html
@@ -1,5 +1,5 @@
 <div>
   <form name="inputForm">
-    <select ng-class="'colt' + col.index" ui-grid-edit-dropdown ng-model="MODEL_COL_FIELD" ng-options="field[editDropdownIdLabel] as field[editDropdownValueLabel] CUSTOM_FILTERS for field in editDropdownOptionsArray"></select>
+    <select ng-class="'colt' + col.uid" ui-grid-edit-dropdown ng-model="MODEL_COL_FIELD" ng-options="field[editDropdownIdLabel] as field[editDropdownValueLabel] CUSTOM_FILTERS for field in editDropdownOptionsArray"></select>
   </form>
 </div>

--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -167,12 +167,11 @@
                 var otherCol = renderContainer.renderedColumns[$scope.renderIndex - 1];
 
                 // Don't append the left resizer if this is the first column or the column to the left of this one has resizing disabled
-                if (otherCol && $scope.col.index !== 0 && otherCol.colDef.enableColumnResizing !== false) {
+                if (otherCol && renderContainer.visibleColumnCache.indexOf($scope.col) !== 0 && otherCol.colDef.enableColumnResizing !== false) {
                   $elm.prepend(resizerLeft);
                 }
                 
                 // Don't append the right resizer if this column has resizing disabled
-                //if ($scope.col.index !== $scope.grid.renderedColumns.length - 1 && $scope.col.colDef.enableColumnResizing !== false) {
                 if ($scope.col.colDef.enableColumnResizing !== false) {
                   $elm.append(resizerRight);
                 }
@@ -259,7 +258,7 @@
 
           renderContainer.visibleColumnCache.forEach(function (column) {
             // Skip the column we just resized
-            if (column.index === col.index) { return; }
+            if (column === col) { return; }
             
             var colDef = column.colDef;
             if (!colDef.width || (angular.isString(colDef.width) && (colDef.width.indexOf('*') !== -1 || colDef.width.indexOf('%') !== -1))) {
@@ -446,7 +445,7 @@
           var renderContainerElm = gridUtil.closestElm($elm, '.ui-grid-render-container');
 
           // Get the cell contents so we measure correctly. For the header cell we have to account for the sort icon and the menu buttons, if present
-          var cells = renderContainerElm.querySelectorAll('.' + uiGridConstants.COL_CLASS_PREFIX + col.index + ' .ui-grid-cell-contents');
+          var cells = renderContainerElm.querySelectorAll('.' + uiGridConstants.COL_CLASS_PREFIX + col.uid + ' .ui-grid-cell-contents');
           Array.prototype.forEach.call(cells, function (cell) {
               // Get the cell width
               // $log.debug('width', gridUtil.elementWidth(cell));

--- a/src/features/resize-columns/test/resizeColumns.spec.js
+++ b/src/features/resize-columns/test/resizeColumns.spec.js
@@ -18,7 +18,8 @@ describe('ui.grid.resizeColumns', function () {
 
     $scope.gridOpts = {
       enableColumnResizing: true,
-      data: data
+      data: data,
+      onRegisterApi: function(gridApi){ $scope.gridApi = gridApi; }
     };
 
     recompile = function () {
@@ -100,7 +101,7 @@ describe('ui.grid.resizeColumns', function () {
     xit('should resize the column to the maximum width of the rendered columns', function (done) {
       var firstResizer = $(grid).find('[ui-grid-column-resizer]').first();
 
-      var colWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + '0').first().width();
+      var colWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + $scope.gridApi.grid.columns[0].uid).first().width();
 
       expect(colWidth === 166 || colWidth === 167).toBe(true); // allow for column widths that don't equally divide 
 
@@ -108,7 +109,7 @@ describe('ui.grid.resizeColumns', function () {
 
       $scope.$digest();
 
-      var newColWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + '0').first().width();
+      var newColWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + $scope.gridApi.grid.columns[0].uid).first().width();
 
       // Can't really tell how big the columns SHOULD be, we'll just expect them to be different in width now
       expect(newColWidth).not.toEqual(colWidth);
@@ -137,7 +138,7 @@ describe('ui.grid.resizeColumns', function () {
         var firstResizer = $(grid).find('[ui-grid-column-resizer]').first();
 
         // Get the initial width of the column
-        initialWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + '0').first().width();
+        initialWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + $scope.gridApi.grid.columns[0].uid).first().width();
 
         initialX = firstResizer.position().left;
 
@@ -176,7 +177,7 @@ describe('ui.grid.resizeColumns', function () {
         });
 
         it('should cause the column to resize by the amount change in the X axis', function () {
-          var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + '0').first().width();
+          var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + $scope.gridApi.grid.columns[0].uid ).first().width();
 
           expect(newWidth - initialWidth).toEqual(xDiff);
         });
@@ -212,7 +213,7 @@ describe('ui.grid.resizeColumns', function () {
         $(firstResizer).simulate('dblclick');
         $scope.$digest();
 
-        var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + '0').first().width();
+        var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + $scope.gridApi.grid.columns[0].uid).first().width();
 
         expect(newWidth >= minWidth).toEqual(true);
       });
@@ -233,7 +234,7 @@ describe('ui.grid.resizeColumns', function () {
       });
 
       it('should not go below the minWidth', function () {
-        var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + '0').first().width();
+        var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + $scope.gridApi.grid.columns[0].uid).first().width();
 
         expect(newWidth >= minWidth).toEqual(true);
       });
@@ -262,7 +263,7 @@ describe('ui.grid.resizeColumns', function () {
         $(firstResizer).simulate('dblclick');
         $scope.$digest();
 
-        var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + '0').first().width();
+        var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + $scope.gridApi.grid.columns[0].uid).first().width();
 
         expect(newWidth <= maxWidth).toEqual(true);
       });
@@ -283,7 +284,7 @@ describe('ui.grid.resizeColumns', function () {
       });
 
       it('should not go above the maxWidth', function () {
-        var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + '0').first().width();
+        var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + $scope.gridApi.grid.columns[0].uid).first().width();
 
         expect(newWidth <= maxWidth).toEqual(true);
       });

--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -89,8 +89,8 @@ angular.module('ui.grid').directive('uiGridColumnMenu', ['$log', '$timeout', '$w
        * @ngdoc boolean
        * @name disableHiding
        * @propertyOf ui.grid.class:GridOptions.columnDef
-       * @description (optional) True by default. When enabled, this setting allows a user to hide the column
-       * using the column menu.
+       * @description (optional) False by default. When enabled, this setting prevents a user from hiding the column
+       * using the column menu or the grid menu.
        */
       $scope.hideable = function() {
         if (typeof($scope.col) !== 'undefined' && $scope.col && $scope.col.colDef && $scope.col.colDef.disableHiding) {

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -41,13 +41,6 @@
                         
     
             $elm.addClass($scope.col.getColClass(false));
-    // shane - No need for watch now that we trackby col name
-    //        $scope.$watch('col.index', function (newValue, oldValue) {
-    //          if (newValue === oldValue) { return; }
-    //          var className = $elm.attr('class');
-    //          className = className.replace(uiGridConstants.COL_CLASS_PREFIX + oldValue, uiGridConstants.COL_CLASS_PREFIX + newValue);
-    //          $elm.attr('class', className);
-    //        });
     
             // Hide the menu by default
             $scope.menuShown = false;

--- a/src/js/core/directives/ui-grid-header.js
+++ b/src/js/core/directives/ui-grid-header.js
@@ -129,7 +129,6 @@
 
                   column.drawnWidth = column.width;
 
-                  // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + column.width + 'px; }';
                 }
               });
 
@@ -155,8 +154,6 @@
                     canvasWidth += colWidth;
                     column.drawnWidth = colWidth;
 
-                    // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
-
                     // Remove this element from the percent array so it's not processed below
                     percentArray.splice(i, 1);
                   }
@@ -167,8 +164,6 @@
 
                     canvasWidth += colWidth;
                     column.drawnWidth = colWidth;
-
-                    // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
 
                     // Remove this element from the percent array so it's not processed below
                     percentArray.splice(i, 1);
@@ -182,8 +177,6 @@
                   canvasWidth += colWidth;
 
                   column.drawnWidth = colWidth;
-
-                  // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
                 });
               }
 
@@ -205,8 +198,6 @@
                     canvasWidth += colWidth;
                     column.drawnWidth = colWidth;
 
-                    // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
-
                     lastColumn = column;
 
                     // Remove this element from the percent array so it's not processed below
@@ -220,8 +211,6 @@
 
                     canvasWidth += colWidth;
                     column.drawnWidth = colWidth;
-
-                    // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
 
                     // Remove this element from the percent array so it's not processed below
                     asterisksArray.splice(i, 1);
@@ -237,8 +226,6 @@
                   canvasWidth += colWidth;
 
                   column.drawnWidth = colWidth;
-
-                  // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
                 });
               }
 

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -110,16 +110,35 @@ angular.module('ui.grid')
     *
     */
     
-   
-  function GridColumn(colDef, index, grid) {
+  /**
+   * @ngdoc method
+   * @methodOf ui.grid.class:GridColumn
+   * @name GridColumn
+   * @description Initializes a gridColumn
+   * @param {ColumnDef} colDef the column def to associate with this column
+   * @param {number} uid the unique and immutable uid we'd like to allocate to this column
+   * @param {Grid} grid the grid we'd like to create this column in
+   */ 
+  function GridColumn(colDef, uid, grid) {
     var self = this;
 
     self.grid = grid;
-    colDef.index = index;
+    self.uid = uid;
 
     self.updateColumnDef(colDef);
   }
 
+
+  /**
+   * @ngdoc method
+   * @methodOf ui.grid.class:GridColumn
+   * @name setPropertyOrDefault
+   * @description Sets a property on the column using the passed in columnDef, and
+   * setting the defaultValue if the value cannot be found on the colDef
+   * @param {ColumnDef} colDef the column def to look in for the property value
+   * @param {string} propName the property name we'd like to set
+   * @param {object} defaultValue the value to use if the colDef doesn't provide the setting
+   */ 
   GridColumn.prototype.setPropertyOrDefault = function (colDef, propName, defaultValue) {
     var self = this;
 
@@ -296,16 +315,22 @@ angular.module('ui.grid')
     *   ] }]; </pre>
     *
     */   
-  GridColumn.prototype.updateColumnDef = function(colDef, index) {
+
+  /**
+   * @ngdoc method
+   * @methodOf ui.grid.class:GridColumn
+   * @name updateColumnDef
+   * @description Moves settings from the columnDef down onto the column,
+   * and sets properties as appropriate
+   * @param {ColumnDef} colDef the column def to look in for the property value
+   */ 
+  GridColumn.prototype.updateColumnDef = function(colDef) {
     var self = this;
 
     self.colDef = colDef;
 
-    //position of column
-    self.index = (typeof(index) === 'undefined') ? colDef.index : index;
-
     if (colDef.name === undefined) {
-      throw new Error('colDef.name is required for column at index ' + self.index);
+      throw new Error('colDef.name is required for column at index ' + self.grid.options.columnDefs.indexOf(colDef));
     }
 
     var parseErrorMsg = "Cannot parse column width '" + colDef.width + "' for column named '" + colDef.name + "'";
@@ -500,7 +525,7 @@ angular.module('ui.grid')
      * @param {bool} prefixDot  if true, will return .className instead of className
      */
     GridColumn.prototype.getColClass = function (prefixDot) {
-      var cls = uiGridConstants.COL_CLASS_PREFIX + this.index;
+      var cls = uiGridConstants.COL_CLASS_PREFIX + this.uid;
 
       return prefixDot ? '.' + cls : cls;
     };

--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -498,8 +498,6 @@ angular.module('ui.grid')
         canvasWidth = parseInt(canvasWidth, 10) + parseInt(column.width, 10);
 
         column.drawnWidth = column.width;
-
-        // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + column.width + 'px; }';
       }
     });
 
@@ -525,8 +523,6 @@ angular.module('ui.grid')
           canvasWidth += colWidth;
           column.drawnWidth = colWidth;
 
-          // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
-
           // Remove this element from the percent array so it's not processed below
           percentArray.splice(i, 1);
         }
@@ -537,8 +533,6 @@ angular.module('ui.grid')
 
           canvasWidth += colWidth;
           column.drawnWidth = colWidth;
-
-          // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
 
           // Remove this element from the percent array so it's not processed below
           percentArray.splice(i, 1);
@@ -552,8 +546,6 @@ angular.module('ui.grid')
         canvasWidth += colWidth;
 
         column.drawnWidth = colWidth;
-
-        // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
       });
     }
 
@@ -575,8 +567,6 @@ angular.module('ui.grid')
           canvasWidth += colWidth;
           column.drawnWidth = colWidth;
 
-          // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
-
           lastColumn = column;
 
           // Remove this element from the percent array so it's not processed below
@@ -590,8 +580,6 @@ angular.module('ui.grid')
 
           canvasWidth += colWidth;
           column.drawnWidth = colWidth;
-
-          // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
 
           // Remove this element from the percent array so it's not processed below
           asterisksArray.splice(i, 1);
@@ -607,8 +595,6 @@ angular.module('ui.grid')
         canvasWidth += colWidth;
 
         column.drawnWidth = colWidth;
-
-        // ret = ret + ' .grid' + uiGridCtrl.grid.id + ' .col' + column.index + ' { width: ' + colWidth + 'px; }';
       });
     }
 

--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -32,15 +32,6 @@ angular.module('ui.grid')
 
      /**
       *  @ngdoc object
-      *  @name index
-      *  @propertyOf  ui.grid.class:GridRow
-      *  @description the index of the GridRow. It should always be unique and immutable
-      */
-    this.index = index;
-
-
-     /**
-      *  @ngdoc object
       *  @name uid
       *  @propertyOf  ui.grid.class:GridRow
       *  @description  UniqueId of row


### PR DESCRIPTION
Tidies up much of the column behaviour.

Removed col.index everywhere it appears, except for in the cell content
templates.  For the cell content, replace with col.uid, which is now
uniquely generated when the column is created, and never changed again.

Should also fix #1694, but need to push to be sure.
