### PR TITLE
Fix #1643 (expandable): missing plus sign

### DIFF
--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -139,6 +139,21 @@
                   return ret;
                 };
 
+                  function updateRowContainerWidth() {
+                      var grid = $scope.grid;
+                      var colWidth = grid.getColumn('expandableButtons').width;
+                      return '.grid' + grid.id + ' .ui-grid-pinned-container-' + $scope.colContainer.name + ', .grid' + grid.id +
+                          ' .ui-grid-pinned-container-' + $scope.colContainer.name + ' .ui-grid-render-container-' + $scope.colContainer.name +
+                          ' .ui-grid-viewport .ui-grid-canvas .ui-grid-row { width: ' + colWidth + 'px; }';
+                  }
+
+                  if ($scope.colContainer.name === 'left') {
+                      $scope.grid.registerStyleComputation({
+                          priority: 15,
+                          func: updateRowContainerWidth
+                      });
+                  }
+
               },
               post: function ($scope, $elm, $attrs, controllers) {
               }


### PR DESCRIPTION
The width of the rows in the left container extended that of it's container. In contrast to my other pull request #1696, the width is now set via the registerStyleComputation method to that of the 'expandableButtons' column.

I've run the e2e tests and manually checked the pinning tutorial and couldn't identify any faults.
