### PR TITLE
Fix width calculation problems when maxWidth and minWidth are used

### DIFF
--- a/src/js/core/directives/ui-grid-header.js
+++ b/src/js/core/directives/ui-grid-header.js
@@ -146,7 +146,7 @@
 
               if (percentArray.length > 0) {
                 // Pre-process to make sure they're all within any min/max values
-                for (i = 0; i < percentArray.length; i++) {
+                for (i = percentArray.length - 1; i >= 0; i--) {
                   column = percentArray[i];
 
                   var percent = parseInt(column.width.replace(/%/g, ''), 10) / 100;
@@ -191,7 +191,7 @@
                 var asteriskVal = parseInt(remainingWidth / asteriskNum, 10);
 
                  // Pre-process to make sure they're all within any min/max values
-                for (i = 0; i < asterisksArray.length; i++) {
+                for (i = asterisksArray.length - 1; i >= 0; i--) {
                   column = asterisksArray[i];
 
                   colWidth = parseInt(asteriskVal * column.width.length, 10);


### PR DESCRIPTION
There are errors when using `minWidth` to determine the width of columns. Some columns are skipped and given a `drawnWidth` of undefined due to splicing elements from the array while iterating over it. Iterating backwards is the simplest fix for this (as far as I could tell).

As in, the problem was due to the following logic being used:

```
for(var i = 0; i < arr.length; i++){
    arr.splice(i, 1); // next iteration, when i is 1, we'll actually be looking at the element at position 2
}
```

Plunker showing the problem (minimally changed from tutorial 190): http://plnkr.co/edit/tSnDqn0gmBvoCJUpQnaX?p=preview

Plunker showing the fix: http://plnkr.co/edit/wZKuN2fFd30hVMhp0NeS?p=preview
