### PR TITLE
Add missing calls to fire rowSelectionChanged events.

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -119,6 +119,7 @@
 
                   grid.rows.forEach(function (row) {
                     row.isSelected = true;
+                    grid.api.selection.raise.rowSelectionChanged(row);
                   });
                 },
                 /**
@@ -133,11 +134,15 @@
                   }
 
                   grid.rows.forEach(function (row) {
-                    if (row.visible) {
+                    if (row.visible === row.isSelected) {
+                      return;
+                    } else if (row.visible) {
                       row.isSelected = true;
                     } else {
                       row.isSelected = false;
                     }
+
+                    grid.api.selection.raise.rowSelectionChanged(row);
                   });
                 },
                 /**


### PR DESCRIPTION
I spotted two instances of missing to fire the `rowSelectionChanged` event.

I didn't find any tests for events, and I'm not that fluent in the code base (nor angular) yet to feel comfortable adding it. Let me know if those tests are else where, and you want me to add a test case for this.
