### PR TITLE
Issue #1781: Fix modifier key to keep selected item selected

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -266,11 +266,18 @@
          */
         toggleRowSelection: function (grid, row, multiSelect, noUnselect) {
           var selected = row.isSelected;
+
           if (!multiSelect && !selected) {
             service.clearSelectedRows(grid);
+          } else if (!multiSelect && selected) {
+            var selectedRows = service.getSelectedRows(grid);
+            if (selectedRows.length > 1) {
+              selected = false; // Enable reselect of the row
+              service.clearSelectedRows(grid);
+            }
           }
           
-          if (row.isSelected && noUnselect){
+          if (selected && noUnselect){
             // don't deselect the row 
           } else {
             row.isSelected = !selected;

--- a/src/features/selection/test/uiGridSelectionService.spec.js
+++ b/src/features/selection/test/uiGridSelectionService.spec.js
@@ -59,6 +59,17 @@ describe('ui.grid.selection uiGridSelectionService', function () {
             expect(grid.rows[1].isSelected).toBe(true, 'new row should be selected');
         });
 
+        it('should remain selected', function () {
+            uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true);
+            uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true);
+            expect(grid.rows[0].isSelected).toBe(true);
+            expect(grid.rows[1].isSelected).toBe(true);
+
+            uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], false);
+            expect(grid.rows[0].isSelected).toBe(false, 'row should not be selected, last row selection was not a multiselect selection');
+            expect(grid.rows[1].isSelected).toBe(true, 'row should be selected, multiple rows was selected before the selection');
+        });
+
         it('should clear selected', function () {
             uiGridSelectionService.toggleRowSelection(grid, grid.rows[0]);
             expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(1);


### PR DESCRIPTION
Fixed issue #1781 

Function toggleRowSelection changes:
If multiple rows are selected together with the clicked row, all other rows are now deselected, but keeps the clicked row selected.

Note that switching between `multiSelect=true` and `multiSelect=false` inherits this behavior as well.
