### PR TITLE
Fixed bug with handling of column width where explicitly set to asterisk

### DIFF
--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -358,7 +358,11 @@ angular.module('ui.grid')
             self.width = parseInt(colDef.width.match(/^(\d+)$/)[1], 10);
           }
           // Otherwise it should be a string of asterisks
-          else if (!colDef.width.match(/^\*+$/)) {
+          else if (colDef.width.match(/^\*+$/)) {
+            self.width = colDef.width;
+          }
+          // If it's not any of those, it's an error
+          else
             throw new Error(parseErrorMsg);
           }
         }


### PR DESCRIPTION
I encountered a bug where if you explicitly set a column width to asterisk(s) in columnDefs, it didn't actually set the width property on the GridColumn object. Fixed by this PR.
