### PR TITLE
Fix #1787(logging): create gridUtil.logDebug, comment out all debug

### DIFF
--- a/src/features/auto-resize-grid/js/auto-resize.js
+++ b/src/features/auto-resize-grid/js/auto-resize.js
@@ -13,7 +13,7 @@
   var module = angular.module('ui.grid.autoResize', ['ui.grid']);
   
 
-  module.directive('uiGridAutoResize', ['$log', '$timeout', 'gridUtil', function ($log, $timeout, gridUtil) {
+  module.directive('uiGridAutoResize', ['$timeout', 'gridUtil', function ($timeout, gridUtil) {
     return {
       require: 'uiGrid',
       scope: false,

--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -20,8 +20,8 @@
   });
 
 
-  module.factory('uiGridCellNavFactory', ['$log', 'uiGridConstants', 'uiGridCellNavConstants', '$q',
-    function ($log, uiGridConstants, uiGridCellNavConstants, $q) {
+  module.factory('uiGridCellNavFactory', ['gridUtil', 'uiGridConstants', 'uiGridCellNavConstants', '$q',
+    function (gridUtil, uiGridConstants, uiGridCellNavConstants, $q) {
       /**
        *  @ngdoc object
        *  @name ui.grid.cellNav.object:CellNav
@@ -161,8 +161,8 @@
    *  @description Services for cell navigation features. If you don't like the key maps we use,
    *  or the direction cells navigation, override with a service decorator (see angular docs)
    */
-  module.service('uiGridCellNavService', ['$log', 'uiGridConstants', 'uiGridCellNavConstants', '$q', 'uiGridCellNavFactory',
-    function ($log, uiGridConstants, uiGridCellNavConstants, $q, UiGridCellNav) {
+  module.service('uiGridCellNavService', ['gridUtil', 'uiGridConstants', 'uiGridCellNavConstants', '$q', 'uiGridCellNavFactory',
+    function (gridUtil, uiGridConstants, uiGridCellNavConstants, $q, UiGridCellNav) {
 
       var service = {
 
@@ -439,8 +439,8 @@
    </file>
    </example>
    */
-  module.directive('uiGridCellnav', ['$log', 'uiGridCellNavService', 'uiGridCellNavConstants',
-    function ($log, uiGridCellNavService, uiGridCellNavConstants) {
+  module.directive('uiGridCellnav', ['gridUtil', 'uiGridCellNavService', 'uiGridCellNavConstants',
+    function (gridUtil, uiGridCellNavService, uiGridCellNavConstants) {
       return {
         replace: true,
         priority: -150,
@@ -455,7 +455,7 @@
 
               uiGridCtrl.cellNav = {};
 
-              //  $log.debug('uiGridEdit preLink');
+              //  gridUtil.logDebug('uiGridEdit preLink');
               uiGridCtrl.cellNav.broadcastCellNav = function (newRowCol) {
                 $scope.$broadcast(uiGridCellNavConstants.CELL_NAV_EVENT, newRowCol);
                 uiGridCtrl.cellNav.broadcastFocus(newRowCol.row, newRowCol.col);
@@ -477,8 +477,8 @@
       };
     }]);
 
-  module.directive('uiGridRenderContainer', ['$log', 'uiGridCellNavService', 'uiGridCellNavConstants',
-    function ($log, uiGridCellNavService, uiGridCellNavConstants) {
+  module.directive('uiGridRenderContainer', ['gridUtil', 'uiGridCellNavService', 'uiGridCellNavConstants',
+    function (gridUtil, uiGridCellNavService, uiGridCellNavConstants) {
       return {
         replace: true,
         priority: -99999, //this needs to run very last
@@ -505,8 +505,8 @@
    *  @restrict A
    *  @description Stacks on top of ui.grid.uiGridCell to provide cell navigation
    */
-  module.directive('uiGridCell', ['uiGridCellNavService', '$log', 'uiGridCellNavConstants',
-    function (uiGridCellNavService, $log, uiGridCellNavConstants) {
+  module.directive('uiGridCell', ['uiGridCellNavService', 'gridUtil', 'uiGridCellNavConstants',
+    function (uiGridCellNavService, gridUtil, uiGridCellNavConstants) {
       return {
         priority: -150, // run after default uiGridCell directive and ui.grid.edit uiGridCell
         restrict: 'A',

--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -42,8 +42,8 @@
    *
    *  @description Services for editing features
    */
-  module.service('uiGridEditService', ['$log', '$q', '$templateCache', 'uiGridConstants', 'gridUtil',
-    function ($log, $q, $templateCache, uiGridConstants, gridUtil) {
+  module.service('uiGridEditService', ['$q', '$templateCache', 'uiGridConstants', 'gridUtil',
+    function ($q, $templateCache, uiGridConstants, gridUtil) {
 
       var service = {
 
@@ -312,7 +312,7 @@
    </file>
    </example>
    */
-  module.directive('uiGridEdit', ['$log', 'uiGridEditService', function ($log, uiGridEditService) {
+  module.directive('uiGridEdit', ['gridUtil', 'uiGridEditService', function (gridUtil, uiGridEditService) {
     return {
       replace: true,
       priority: 0,
@@ -369,8 +369,8 @@
    *
    */
   module.directive('uiGridCell',
-    ['$compile', 'uiGridConstants', 'uiGridEditConstants', '$log', '$parse', 'uiGridEditService',
-      function ($compile, uiGridConstants, uiGridEditConstants, $log, $parse, uiGridEditService) {
+    ['$compile', 'uiGridConstants', 'uiGridEditConstants', 'gridUtil', '$parse', 'uiGridEditService',
+      function ($compile, uiGridConstants, uiGridEditConstants, gridUtil, $parse, uiGridEditService) {
         return {
           priority: -100, // run after default uiGridCell directive
           restrict: 'A',

--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -3,7 +3,7 @@
 
   var module = angular.module('ui.grid.expandable', ['ui.grid']);
 
-  module.service('uiGridExpandableService', ['gridUtil', '$log', '$compile', function (gridUtil, $log, $compile) {
+  module.service('uiGridExpandableService', ['gridUtil', '$compile', function (gridUtil, $compile) {
     var service = {
       initializeGrid: function (grid) {
         var publicApi = {
@@ -65,8 +65,8 @@
     return service;
   }]);
 
-  module.directive('uiGridExpandable', ['$log', 'uiGridExpandableService', '$templateCache',
-    function ($log, uiGridExpandableService, $templateCache) {
+  module.directive('uiGridExpandable', ['uiGridExpandableService', '$templateCache',
+    function (uiGridExpandableService, $templateCache) {
       return {
         replace: true,
         priority: 0,
@@ -88,8 +88,8 @@
     }]);
 
   module.directive('uiGridExpandableRow',
-  ['uiGridExpandableService', '$timeout', '$log', '$compile', 'uiGridConstants','gridUtil','$interval',
-    function (uiGridExpandableService, $timeout, $log, $compile, uiGridConstants, gridUtil, $interval) {
+  ['uiGridExpandableService', '$timeout', '$compile', 'uiGridConstants','gridUtil','$interval',
+    function (uiGridExpandableService, $timeout, $compile, uiGridConstants, gridUtil, $interval) {
 
       return {
         replace: false,
@@ -118,8 +118,8 @@
     }]);
 
   module.directive('uiGridRow',
-    ['$compile', '$log', '$templateCache',
-      function ($compile, $log, $templateCache) {
+    ['$compile', 'gridUtil', '$templateCache',
+      function ($compile, gridUtil, $templateCache) {
         return {
           priority: -200,
           scope: false,
@@ -148,8 +148,8 @@
       }]);
 
   module.directive('uiGridViewport',
-    ['$compile', '$log', '$templateCache',
-      function ($compile, $log, $templateCache) {
+    ['$compile', 'gridUtil', '$templateCache',
+      function ($compile, gridUtil, $templateCache) {
         return {
           priority: -200,
           scope: false,

--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -70,8 +70,8 @@
    *
    *  @description Services for exporter feature
    */
-  module.service('uiGridExporterService', ['$log', '$q', 'uiGridExporterConstants', 'gridUtil', '$compile', '$interval', 'i18nService',
-    function ($log, $q, uiGridExporterConstants, gridUtil, $compile, $interval, i18nService) {
+  module.service('uiGridExporterService', ['$q', 'uiGridExporterConstants', 'gridUtil', '$compile', '$interval', 'i18nService',
+    function ($q, uiGridExporterConstants, gridUtil, $compile, $interval, i18nService) {
 
       var service = {
 
@@ -412,7 +412,7 @@
           if ( $elm ){
             this.renderCsvLink(grid, csvContent, $elm);
           } else {
-            $log.error( 'Exporter asked to export as csv, but no element provided.  Perhaps you should set gridOptions.exporterCsvLinkElement?')
+            gridUtil.logError( 'Exporter asked to export as csv, but no element provided.  Perhaps you should set gridOptions.exporterCsvLinkElement?')
 ;          }
         },
         
@@ -485,7 +485,7 @@
               if ( grid.api.selection ){
                 rows = grid.api.selection.getSelectedGridRows();
               } else {
-                $log.error('selection feature must be enabled to allow selected rows to be exported');
+                gridUtil.logError('selection feature must be enabled to allow selected rows to be exported');
               }
               break;
           }
@@ -824,8 +824,8 @@
    </file>
    </example>
    */
-  module.directive('uiGridExporter', ['$log', 'uiGridExporterConstants', 'uiGridExporterService', 'gridUtil', '$compile',
-    function ($log, uiGridExporterConstants, uiGridExporterService, gridUtil, $compile) {
+  module.directive('uiGridExporter', ['uiGridExporterConstants', 'uiGridExporterService', 'gridUtil', '$compile',
+    function (uiGridExporterConstants, uiGridExporterService, gridUtil, $compile) {
       return {
         replace: true,
         priority: 0,

--- a/src/features/importer/js/importer.js
+++ b/src/features/importer/js/importer.js
@@ -52,8 +52,8 @@
    *
    *  @description Services for importer feature
    */
-  module.service('uiGridImporterService', ['$log', '$q', 'uiGridImporterConstants', 'gridUtil', '$compile', '$interval', 'i18nService', '$window',
-    function ($log, $q, uiGridImporterConstants, gridUtil, $compile, $interval, i18nService, $window) {
+  module.service('uiGridImporterService', ['$q', 'uiGridImporterConstants', 'gridUtil', '$compile', '$interval', 'i18nService', '$window',
+    function ($q, uiGridImporterConstants, gridUtil, $compile, $interval, i18nService, $window) {
 
       var service = {
 
@@ -132,7 +132,7 @@
            */
           if (gridOptions.enableImporter  || gridOptions.enableImporter === undefined) {
             if ( !($window.hasOwnProperty('File') && $window.hasOwnProperty('FileReader') && $window.hasOwnProperty('FileList') && $window.hasOwnProperty('Blob')) ) {
-              $log.error('The File APIs are not fully supported in this browser, grid importer cannot be used.');
+              gridUtil.logError('The File APIs are not fully supported in this browser, grid importer cannot be used.');
               gridOptions.enableImporter = false;
             } else {
               gridOptions.enableImporter = true;
@@ -276,7 +276,7 @@
          */
         importThisFile: function ( grid, fileObject ) {
           if (!fileObject){
-            $log.error( 'No file object provided to importThisFile, should be impossible, aborting');
+            gridUtil.logError( 'No file object provided to importThisFile, should be impossible, aborting');
             return;
           }
           
@@ -607,7 +607,7 @@
             grid.options.importerErrorCallback( grid, alertI18nToken, consoleMessage, context );
           } else {
             $window.alert(i18nService.getSafeText( alertI18nToken )); 
-            $log.error(consoleMessage + context ); 
+            gridUtil.logError(consoleMessage + context ); 
           }
         }
       };
@@ -626,8 +626,8 @@
    *  @description Adds importer features to grid
    *
    */
-  module.directive('uiGridImporter', ['$log', 'uiGridImporterConstants', 'uiGridImporterService', 'gridUtil', '$compile',
-    function ($log, uiGridImporterConstants, uiGridImporterService, gridUtil, $compile) {
+  module.directive('uiGridImporter', ['uiGridImporterConstants', 'uiGridImporterService', 'gridUtil', '$compile',
+    function (uiGridImporterConstants, uiGridImporterService, gridUtil, $compile) {
       return {
         replace: true,
         priority: 0,
@@ -650,8 +650,8 @@
    *  selected
    *
    */
-  module.directive('uiGridImporterMenuItem', ['$log', 'uiGridImporterConstants', 'uiGridImporterService', 'gridUtil', '$compile',
-    function ($log, uiGridImporterConstants, uiGridImporterService, gridUtil, $compile) {
+  module.directive('uiGridImporterMenuItem', ['uiGridImporterConstants', 'uiGridImporterService', 'gridUtil', '$compile',
+    function (uiGridImporterConstants, uiGridImporterService, gridUtil, $compile) {
       return {
         replace: true,
         priority: 0,
@@ -671,7 +671,7 @@
           var grid = uiGridCtrl.grid;
           
           if ( fileChooser.length !== 1 ){
-            $log.error('Found > 1 or < 1 file choosers within the menu item, error, cannot continue');
+            gridUtil.logError('Found > 1 or < 1 file choosers within the menu item, error, cannot continue');
           } else {
             fileChooser[0].addEventListener('change', handleFileSelect, false);  // TODO: why the false on the end?  Google  
           }

--- a/src/features/importer/test/importer.spec.js
+++ b/src/features/importer/test/importer.spec.js
@@ -10,14 +10,14 @@ describe('ui.grid.importer uiGridImporterService', function () {
   var $window;
   var $interval;
   var $compile;
-  var $log;
+  var gridUtil;
 
   beforeEach(module('ui.grid.importer', 'ui.grid.rowEdit'));
 
 
   beforeEach(inject(function (_uiGridImporterService_, _gridClassFactory_, _uiGridImporterConstants_,
                               _uiGridRowEditService_, _uiGridEditService_, _$interval_,
-                               _$rootScope_, _$window_, _$compile_, _$log_ ) {
+                               _$rootScope_, _$window_, _$compile_, _gridUtil_ ) {
     uiGridImporterService = _uiGridImporterService_;
     uiGridRowEditService = _uiGridRowEditService_;
     uiGridEditService = _uiGridEditService_;
@@ -27,7 +27,7 @@ describe('ui.grid.importer uiGridImporterService', function () {
     $window = _$window_;
     $interval = _$interval_;
     $compile = _$compile_;
-    $log = _$log_;
+    gridUtil = _gridUtil_;
 
     grid = gridClassFactory.createGrid({});
     grid.ptions = {};
@@ -388,14 +388,14 @@ describe('ui.grid.importer uiGridImporterService', function () {
     describe( 'alertError', function() {
       it( 'raises an alert and writes a console log', function() {
         spyOn( $window, "alert" ).andCallFake( function() {});
-        spyOn( $log, "error" ).andCallFake( function() {});
+        spyOn( gridUtil, "logError" ).andCallFake( function() {});
 
         uiGridImporterService.alertError( grid, 'importer.noHeaders', 'A message', ["test", "test2"]);
 
         // this will need adjusting whenever the En translation for this element changes, but is needed to 
         // check i18n is working
         expect($window.alert).toHaveBeenCalledWith( 'Column names were unable to be derived, does the file have a header?' );
-        expect($log.error).toHaveBeenCalledWith( 'A message' + ["test", "test2"]);
+        expect(gridUtil.logError).toHaveBeenCalledWith( 'A message' + ["test", "test2"]);
       });
       
       it( 'calls custom error logging function if available', function() {

--- a/src/features/infinite-scroll/js/infinite-scroll.js
+++ b/src/features/infinite-scroll/js/infinite-scroll.js
@@ -17,7 +17,7 @@
    *
    *  @description Service for infinite scroll features
    */
-  module.service('uiGridInfiniteScrollService', ['gridUtil', '$log', '$compile', '$timeout', function (gridUtil, $log, $compile, $timeout) {
+  module.service('uiGridInfiniteScrollService', ['gridUtil', '$compile', '$timeout', function (gridUtil, $compile, $timeout) {
 
     var service = {
 
@@ -169,8 +169,8 @@
    </example>
    */
 
-  module.directive('uiGridInfiniteScroll', ['$log', 'uiGridInfiniteScrollService',
-    function ($log, uiGridInfiniteScrollService) {
+  module.directive('uiGridInfiniteScroll', ['uiGridInfiniteScrollService',
+    function (uiGridInfiniteScrollService) {
       return {
         priority: -200,
         scope: false,
@@ -188,8 +188,8 @@
     }]);
 
   module.directive('uiGridViewport',
-    ['$compile', '$log', 'uiGridInfiniteScrollService', 'uiGridConstants',
-      function ($compile, $log, uiGridInfiniteScrollService, uiGridConstants) {
+    ['$compile', 'gridUtil', 'uiGridInfiniteScrollService', 'uiGridConstants',
+      function ($compile, gridUtil, uiGridInfiniteScrollService, uiGridConstants) {
         return {
           priority: -200,
           scope: false,

--- a/src/features/pinning/js/pinning.js
+++ b/src/features/pinning/js/pinning.js
@@ -16,7 +16,7 @@
 
   var module = angular.module('ui.grid.pinning', ['ui.grid']);
 
-  module.service('uiGridPinningService', ['$log', 'GridRenderContainer', 'i18nService', function ($log, GridRenderContainer, i18nService) {
+  module.service('uiGridPinningService', ['gridUtil', 'GridRenderContainer', 'i18nService', function (gridUtil, GridRenderContainer, i18nService) {
     var service = {
 
       initializeGrid: function (grid) {
@@ -164,8 +164,8 @@
     return service;
   }]);
 
-  module.directive('uiGridPinning', ['$log', 'uiGridPinningService',
-    function ($log, uiGridPinningService) {
+  module.directive('uiGridPinning', ['gridUtil', 'uiGridPinningService',
+    function (gridUtil, uiGridPinningService) {
       return {
         require: 'uiGrid',
         scope: false,

--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -8,8 +8,8 @@
   });
 
 
-  module.service('uiGridResizeColumnsService', ['$log','$q',
-    function ($log,$q) {
+  module.service('uiGridResizeColumnsService', ['gridUtil','$q',
+    function (gridUtil,$q) {
 
       var service = {
         defaultGridOptions: function(gridOptions){
@@ -110,7 +110,7 @@
    </doc:scenario>
    </doc:example>
    */
-  module.directive('uiGridResizeColumns', ['$log', 'uiGridResizeColumnsService', function ($log, uiGridResizeColumnsService) {
+  module.directive('uiGridResizeColumns', ['gridUtil', 'uiGridResizeColumnsService', function (gridUtil, uiGridResizeColumnsService) {
     return {
       replace: true,
       priority: 0,
@@ -132,7 +132,7 @@
   }]);
 
   // Extend the uiGridHeaderCell directive
-  module.directive('uiGridHeaderCell', ['$log', '$templateCache', '$compile', '$q', function ($log, $templateCache, $compile, $q) {
+  module.directive('uiGridHeaderCell', ['gridUtil', '$templateCache', '$compile', '$q', function (gridUtil, $templateCache, $compile, $q) {
     return {
       // Run after the original uiGridHeaderCell
       priority: -10,
@@ -227,7 +227,7 @@
      </doc:scenario>
    </doc:example>
    */  
-  module.directive('uiGridColumnResizer', ['$log', '$document', 'gridUtil', 'uiGridConstants', 'columnBounds', function ($log, $document, gridUtil, uiGridConstants, columnBounds) {
+  module.directive('uiGridColumnResizer', ['$document', 'gridUtil', 'uiGridConstants', 'columnBounds', function ($document, gridUtil, uiGridConstants, columnBounds) {
     var resizeOverlay = angular.element('<div class="ui-grid-resize-overlay"></div>');
 
     var resizer = {
@@ -447,7 +447,7 @@
           var cells = renderContainerElm.querySelectorAll('.' + uiGridConstants.COL_CLASS_PREFIX + col.uid + ' .ui-grid-cell-contents');
           Array.prototype.forEach.call(cells, function (cell) {
               // Get the cell width
-              // $log.debug('width', gridUtil.elementWidth(cell));
+              // gridUtil.logDebug('width', gridUtil.elementWidth(cell));
 
               // Account for the menu button if it exists
               var menuButton;

--- a/src/features/row-edit/js/gridRowEdit.js
+++ b/src/features/row-edit/js/gridRowEdit.js
@@ -34,8 +34,8 @@
    *
    *  @description Services for row editing features
    */
-  module.service('uiGridRowEditService', ['$interval', '$log', '$q', 'uiGridConstants', 'uiGridRowEditConstants', 'gridUtil', 
-    function ($interval, $log, $q, uiGridConstants, uiGridRowEditConstants, gridUtil) {
+  module.service('uiGridRowEditService', ['$interval', '$q', 'uiGridConstants', 'uiGridRowEditConstants', 'gridUtil', 
+    function ($interval, $q, uiGridConstants, uiGridRowEditConstants, gridUtil) {
 
       var service = {
 
@@ -225,7 +225,7 @@
             if ( gridRow.rowEditSavePromise ){
               gridRow.rowEditSavePromise.then( self.processSuccessPromise( grid, gridRow ), self.processErrorPromise( grid, gridRow ));
             } else {
-              $log.log( 'A promise was not returned when saveRow event was raised, either nobody is listening to event, or event handler did not return a promise' );
+              gridUtil.logError( 'A promise was not returned when saveRow event was raised, either nobody is listening to event, or event handler did not return a promise' );
             }
             return promise;
           };
@@ -362,7 +362,7 @@
         endEditCell: function( rowEntity, colDef, newValue, previousValue ){
           var grid = this.grid;
           var gridRow = grid.getRow( rowEntity );
-          if ( !gridRow ){ $log.log( 'Unable to find rowEntity in grid data, dirty flag cannot be set' ); return; }
+          if ( !gridRow ){ gridUtil.logError( 'Unable to find rowEntity in grid data, dirty flag cannot be set' ); return; }
 
           if ( newValue !== previousValue || gridRow.isDirty ){
             if ( !grid.rowEditDirtyRows ){
@@ -396,7 +396,7 @@
         beginEditCell: function( rowEntity, colDef ){
           var grid = this.grid;
           var gridRow = grid.getRow( rowEntity );
-          if ( !gridRow ){ $log.log( 'Unable to find rowEntity in grid data, timer cannot be cancelled' ); return; }
+          if ( !gridRow ){ gridUtil.logError( 'Unable to find rowEntity in grid data, timer cannot be cancelled' ); return; }
           
           service.cancelTimer( grid, gridRow );
         },
@@ -420,7 +420,7 @@
         cancelEditCell: function( rowEntity, colDef ){
           var grid = this.grid;
           var gridRow = grid.getRow( rowEntity );
-          if ( !gridRow ){ $log.log( 'Unable to find rowEntity in grid data, timer cannot be set' ); return; }
+          if ( !gridRow ){ gridUtil.logError( 'Unable to find rowEntity in grid data, timer cannot be set' ); return; }
           
           service.considerSetTimer( grid, gridRow );
         },
@@ -544,7 +544,7 @@
               
               service.considerSetTimer( grid, gridRow );
             } else {
-              $log.error( "requested row not found in rowEdit.setRowsDirty, row was: " + value );
+              gridUtil.logError( "requested row not found in rowEdit.setRowsDirty, row was: " + value );
             }
           });
         }
@@ -565,8 +565,8 @@
    *  @description Adds row editing features to the ui-grid-edit directive.
    *
    */
-  module.directive('uiGridRowEdit', ['$log', 'uiGridRowEditService', 'uiGridEditConstants', 
-  function ($log, uiGridRowEditService, uiGridEditConstants) {
+  module.directive('uiGridRowEdit', ['gridUtil', 'uiGridRowEditService', 'uiGridEditConstants', 
+  function (gridUtil, uiGridRowEditService, uiGridEditConstants) {
     return {
       replace: true,
       priority: 0,
@@ -594,8 +594,8 @@
    *  for the grid row to allow coloring of saving and error rows
    */
   module.directive('uiGridViewport',
-    ['$compile', 'uiGridConstants', '$log', '$parse',
-      function ($compile, uiGridConstants, $log, $parse) {
+    ['$compile', 'uiGridConstants', 'gridUtil', '$parse',
+      function ($compile, uiGridConstants, gridUtil, $parse) {
         return {
           priority: -200, // run after default  directive
           scope: false,

--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -32,8 +32,8 @@
    *
    *  @description Services for selection features
    */
-  module.service('uiGridSelectionService', ['$log', '$q', '$templateCache', 'uiGridSelectionConstants', 'gridUtil',
-    function ($log, $q, $templateCache, uiGridSelectionConstants, gridUtil) {
+  module.service('uiGridSelectionService', ['$q', '$templateCache', 'uiGridSelectionConstants', 'gridUtil',
+    function ($q, $templateCache, uiGridSelectionConstants, gridUtil) {
 
       var service = {
 
@@ -426,8 +426,8 @@
    </file>
    </example>
    */
-  module.directive('uiGridSelection', ['$log', 'uiGridSelectionConstants', 'uiGridSelectionService', '$templateCache',
-    function ($log, uiGridSelectionConstants, uiGridSelectionService, $templateCache) {
+  module.directive('uiGridSelection', ['uiGridSelectionConstants', 'uiGridSelectionService', '$templateCache',
+    function (uiGridSelectionConstants, uiGridSelectionService, $templateCache) {
       return {
         replace: true,
         priority: 0,
@@ -458,8 +458,8 @@
       };
     }]);
 
-  module.directive('uiGridSelectionRowHeaderButtons', ['$log', '$templateCache', 'uiGridSelectionService',
-    function ($log, $templateCache, uiGridSelectionService) {
+  module.directive('uiGridSelectionRowHeaderButtons', ['$templateCache', 'uiGridSelectionService',
+    function ($templateCache, uiGridSelectionService) {
       return {
         replace: true,
         restrict: 'E',
@@ -483,8 +483,8 @@
       };
     }]);
 
-  module.directive('uiGridSelectionSelectAllButtons', ['$log', '$templateCache', 'uiGridSelectionService',
-    function ($log, $templateCache, uiGridSelectionService) {
+  module.directive('uiGridSelectionSelectAllButtons', ['$templateCache', 'uiGridSelectionService',
+    function ($templateCache, uiGridSelectionService) {
       return {
         replace: true,
         restrict: 'E',
@@ -520,8 +520,8 @@
    *  for the grid row
    */
   module.directive('uiGridViewport',
-    ['$compile', 'uiGridConstants', 'uiGridSelectionConstants', '$log', '$parse', 'uiGridSelectionService',
-      function ($compile, uiGridConstants, uiGridSelectionConstants, $log, $parse, uiGridSelectionService) {
+    ['$compile', 'uiGridConstants', 'uiGridSelectionConstants', 'gridUtil', '$parse', 'uiGridSelectionService',
+      function ($compile, uiGridConstants, uiGridSelectionConstants, gridUtil, $parse, uiGridSelectionService) {
         return {
           priority: -200, // run after default  directive
           scope: false,
@@ -557,8 +557,8 @@
    *  @description Stacks on top of ui.grid.uiGridCell to provide selection feature
    */
   module.directive('uiGridCell',
-    ['$compile', 'uiGridConstants', 'uiGridSelectionConstants', '$log', '$parse', 'uiGridSelectionService',
-      function ($compile, uiGridConstants, uiGridSelectionConstants, $log, $parse, uiGridSelectionService) {
+    ['$compile', 'uiGridConstants', 'uiGridSelectionConstants', 'gridUtil', '$parse', 'uiGridSelectionService',
+      function ($compile, uiGridConstants, uiGridSelectionConstants, gridUtil, $parse, uiGridSelectionService) {
         return {
           priority: -200, // run after default uiGridCell directive
           restrict: 'A',

--- a/src/js/core/constants.js
+++ b/src/js/core/constants.js
@@ -1,6 +1,9 @@
 (function () {
   'use strict';
   angular.module('ui.grid').constant('uiGridConstants', {
+    LOG_DEBUG_MESSAGES: true,
+    LOG_WARN_MESSAGES: true,
+    LOG_ERROR_MESSAGES: true,
     CUSTOM_FILTERS: /CUSTOM_FILTERS/g,
     COL_FIELD: /COL_FIELD/g,
     MODEL_COL_FIELD: /MODEL_COL_FIELD/g,

--- a/src/js/core/directives/ui-grid-cell.js
+++ b/src/js/core/directives/ui-grid-cell.js
@@ -1,4 +1,4 @@
-angular.module('ui.grid').directive('uiGridCell', ['$compile', '$log', '$parse', 'gridUtil', 'uiGridConstants', function ($compile, $log, $parse, gridUtil, uiGridConstants) {
+angular.module('ui.grid').directive('uiGridCell', ['$compile', '$parse', 'gridUtil', 'uiGridConstants', function ($compile, $parse, gridUtil, uiGridConstants) {
   var uiGridCell = {
     priority: 0,
     scope: false,
@@ -21,7 +21,7 @@ angular.module('ui.grid').directive('uiGridCell', ['$compile', '$log', '$parse',
           // No controller, compile the element manually (for unit tests)
           else {
             if ( uiGridCtrl && !$scope.col.compiledElementFn ){
-              // $log.error('Render has been called before precompile.  Please log a ui-grid issue');  
+              // gridUtil.logError('Render has been called before precompile.  Please log a ui-grid issue');  
 
               $scope.col.getCompiledElementFn()
                 .then(function (compiledElementFn) {

--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -316,8 +316,8 @@ function ( i18nService, uiGridConstants, gridUtil ) {
 }])
 
 
-.directive('uiGridColumnMenu', ['$log', '$timeout', 'gridUtil', 'uiGridConstants', 'uiGridColumnMenuService', 
-function ($log, $timeout, gridUtil, uiGridConstants, uiGridColumnMenuService) {
+.directive('uiGridColumnMenu', ['$timeout', 'gridUtil', 'uiGridConstants', 'uiGridColumnMenuService', 
+function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService) {
 /**
  * @ngdoc directive
  * @name ui.grid.directive:uiGridColumnMenu

--- a/src/js/core/directives/ui-grid-footer-cell.js
+++ b/src/js/core/directives/ui-grid-footer-cell.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict';
 
-  angular.module('ui.grid').directive('uiGridFooterCell', ['$log', '$timeout', 'gridUtil', '$compile', function ($log, $timeout, gridUtil, $compile) {
+  angular.module('ui.grid').directive('uiGridFooterCell', ['$timeout', 'gridUtil', '$compile', function ($timeout, gridUtil, $compile) {
     var uiGridFooterCell = {
       priority: 0,
       scope: {

--- a/src/js/core/directives/ui-grid-footer.js
+++ b/src/js/core/directives/ui-grid-footer.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict';
 
-  angular.module('ui.grid').directive('uiGridFooter', ['$log', '$templateCache', '$compile', 'uiGridConstants', 'gridUtil', '$timeout', function ($log, $templateCache, $compile, uiGridConstants, gridUtil, $timeout) {
+  angular.module('ui.grid').directive('uiGridFooter', ['$templateCache', '$compile', 'uiGridConstants', 'gridUtil', '$timeout', function ($templateCache, $compile, uiGridConstants, gridUtil, $timeout) {
     var defaultTemplate = 'ui-grid/ui-grid-footer';
 
     return {
@@ -44,7 +44,7 @@
             var uiGridCtrl = controllers[0];
             var containerCtrl = controllers[1];
 
-            $log.debug('ui-grid-footer link');
+            // gridUtil.logDebug('ui-grid-footer link');
 
             var grid = uiGridCtrl.grid;
 

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -1,8 +1,8 @@
 (function(){
   'use strict';
 
-  angular.module('ui.grid').directive('uiGridHeaderCell', ['$log', '$compile', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', 
-  function ($log, $compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
+  angular.module('ui.grid').directive('uiGridHeaderCell', ['$compile', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', 
+  function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
     // Do stuff after mouse has been down this many ms on the header cell
     var mousedownTimeout = 500;
 

--- a/src/js/core/directives/ui-grid-header.js
+++ b/src/js/core/directives/ui-grid-header.js
@@ -1,7 +1,7 @@
 (function(){
   'use strict';
 
-  angular.module('ui.grid').directive('uiGridHeader', ['$log', '$templateCache', '$compile', 'uiGridConstants', 'gridUtil', '$timeout', function($log, $templateCache, $compile, uiGridConstants, gridUtil, $timeout) {
+  angular.module('ui.grid').directive('uiGridHeader', ['$templateCache', '$compile', 'uiGridConstants', 'gridUtil', '$timeout', function($templateCache, $compile, uiGridConstants, gridUtil, $timeout) {
     var defaultTemplate = 'ui-grid/ui-grid-header';
     var emptyTemplate = 'ui-grid/ui-grid-no-header';
 
@@ -68,7 +68,7 @@
             var uiGridCtrl = controllers[0];
             var containerCtrl = controllers[1];
 
-            $log.debug('ui-grid-header link');
+            // gridUtil.logDebug('ui-grid-header link');
 
             var grid = uiGridCtrl.grid;
 

--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -1,7 +1,7 @@
 (function(){
 
 angular.module('ui.grid')
-.service('uiGridGridMenuService', [ '$log', 'i18nService', function( $log, i18nService ) {
+.service('uiGridGridMenuService', [ 'gridUtil', 'i18nService', function( gridUtil, i18nService ) {
   /**
    *  @ngdoc service
    *  @name ui.grid.gridMenuService
@@ -93,13 +93,13 @@ angular.module('ui.grid')
      */
     addToGridMenu: function( grid, menuItems ) {
       if ( !angular.isArray( menuItems ) ) {
-        $log.error( 'addToGridMenu: menuItems must be an array, and is not, not adding any items');
+        gridUtil.logError( 'addToGridMenu: menuItems must be an array, and is not, not adding any items');
       } else {
         if ( grid.gridMenuScope ){
           grid.gridMenuScope.registeredMenuItems = grid.gridMenuScope.registeredMenuItems ? grid.gridMenuScope.registeredMenuItems : [];
           grid.gridMenuScope.registeredMenuItems = grid.gridMenuScope.registeredMenuItems.concat( menuItems );
         } else {
-          $log.error( 'Asked to addToGridMenu, but gridMenuScope not present.  Timing issue?  Please log issue with ui-grid');
+          gridUtil.logError( 'Asked to addToGridMenu, but gridMenuScope not present.  Timing issue?  Please log issue with ui-grid');
         }
       }  
     },
@@ -125,7 +125,7 @@ angular.module('ui.grid')
         grid.gridMenuScope.registeredMenuItems.forEach( function( value, index ) {
           if ( value.id === id ){
             if (foundIndex > -1) {
-              $log.error( 'removeFromGridMenu: found multiple items with the same id, removing only the last' );
+              gridUtil.logError( 'removeFromGridMenu: found multiple items with the same id, removing only the last' );
             } else {
               
               foundIndex = index;
@@ -184,7 +184,7 @@ angular.module('ui.grid')
       
       if ( $scope.grid.options.gridMenuCustomItems ){
         if ( !angular.isArray( $scope.grid.options.gridMenuCustomItems ) ){ 
-          $log.error( 'gridOptions.gridMenuCustomItems must be an array, and is not'); 
+          gridUtil.logError( 'gridOptions.gridMenuCustomItems must be an array, and is not'); 
         } else {
           menuItems = menuItems.concat( $scope.grid.options.gridMenuCustomItems );
         }
@@ -304,7 +304,7 @@ angular.module('ui.grid')
           menuItem.title = errorValue;
         });
       } else {
-        $log.error('Expected gridMenuTitleFilter to return a string or a promise, it has returned neither, bad config');
+        gridUtil.logError('Expected gridMenuTitleFilter to return a string or a promise, it has returned neither, bad config');
         menuItem.title = 'badconfig';
       }
     },
@@ -331,8 +331,8 @@ angular.module('ui.grid')
 
 
 
-.directive('uiGridMenuButton', ['$log', 'gridUtil', 'uiGridConstants', 'uiGridGridMenuService', 
-function ($log, gridUtil, uiGridConstants, uiGridGridMenuService) {
+.directive('uiGridMenuButton', ['gridUtil', 'uiGridConstants', 'uiGridGridMenuService', 
+function (gridUtil, uiGridConstants, uiGridGridMenuService) {
 
   return {
     priority: 0,

--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -30,8 +30,8 @@
  */
 angular.module('ui.grid')
 
-.directive('uiGridMenu', ['$log', '$compile', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', 
-function ($log, $compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
+.directive('uiGridMenu', ['$compile', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', 
+function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
   var uiGridMenu = {
     priority: 0,
     scope: {
@@ -185,7 +185,7 @@ function ($log, $compile, $timeout, $window, $document, gridUtil, uiGridConstant
   return uiGridMenu;
 }])
 
-.directive('uiGridMenuItem', ['$log', 'gridUtil', '$compile', 'i18nService', function ($log, gridUtil, $compile, i18nService) {
+.directive('uiGridMenuItem', ['gridUtil', '$compile', 'i18nService', function (gridUtil, $compile, i18nService) {
   var uiGridMenuItem = {
     priority: 0,
     scope: {
@@ -242,7 +242,7 @@ function ($log, $compile, $timeout, $window, $document, gridUtil, uiGridConstant
           };
 
           $scope.itemAction = function($event,title) {
-            $log.debug('itemAction');
+            // gridUtil.logDebug('itemAction');
             $event.stopPropagation();
 
             if (typeof($scope.action) === 'function') {

--- a/src/js/core/directives/ui-grid-native-scrollbar.js
+++ b/src/js/core/directives/ui-grid-native-scrollbar.js
@@ -1,8 +1,8 @@
 (function () {
 // 'use strict';
 
-  angular.module('ui.grid').directive('uiGridNativeScrollbar', ['$log', '$timeout', '$document', 'uiGridConstants', 'gridUtil',
-    function ($log, $timeout, $document, uiGridConstants, gridUtil) {
+  angular.module('ui.grid').directive('uiGridNativeScrollbar', ['$timeout', '$document', 'uiGridConstants', 'gridUtil',
+    function ($timeout, $document, uiGridConstants, gridUtil) {
     var scrollBarWidth = gridUtil.getScrollbarWidth();
 
     // scrollBarWidth = scrollBarWidth > 0 ? scrollBarWidth : 17;
@@ -84,7 +84,7 @@
           // var headerHeight = gridUtil.outerElementHeight(containerCtrl.header);
           var headerHeight = colContainer.headerHeight ? colContainer.headerHeight : grid.headerHeight;
 
-          // $log.debug('headerHeight in scrollbar', headerHeight);
+          // gridUtil.logDebug('headerHeight in scrollbar', headerHeight);
 
           // var ret = '.grid' + uiGridCtrl.grid.id + ' .ui-grid-native-scrollbar.vertical .contents { height: ' + h + 'px; }';
           var ret = '.grid' + grid.id + ' .ui-grid-render-container-' + containerCtrl.containerId + ' .ui-grid-native-scrollbar.vertical .contents { height: ' + contentHeight + 'px; }';

--- a/src/js/core/directives/ui-grid-render-container.js
+++ b/src/js/core/directives/ui-grid-render-container.js
@@ -3,8 +3,8 @@
 
   var module = angular.module('ui.grid');
   
-  module.directive('uiGridRenderContainer', ['$log', '$timeout', '$document', 'uiGridConstants', 'gridUtil',
-    function($log, $timeout, $document, uiGridConstants, GridUtil) {
+  module.directive('uiGridRenderContainer', ['$timeout', '$document', 'uiGridConstants', 'gridUtil',
+    function($timeout, $document, uiGridConstants, GridUtil) {
     return {
       replace: true,
       transclude: true,
@@ -22,7 +22,7 @@
       compile: function () {
         return {
           pre: function prelink($scope, $elm, $attrs, controllers) {
-            $log.debug('render container ' + $scope.containerId + ' pre-link');
+            // gridUtil.logDebug('render container ' + $scope.containerId + ' pre-link');
 
             var uiGridCtrl = controllers[0];
             var containerCtrl = controllers[1];
@@ -52,7 +52,7 @@
             containerCtrl.colContainer = colContainer;
           },
           post: function postlink($scope, $elm, $attrs, controllers) {
-            $log.debug('render container ' + $scope.containerId + ' post-link');
+            // gridUtil.logDebug('render container ' + $scope.containerId + ' post-link');
 
             var uiGridCtrl = controllers[0];
             var containerCtrl = controllers[1];
@@ -92,7 +92,7 @@
                 }
                 else if (typeof(args.y.pixels) !== 'undefined' && args.y.pixels !== undefined) {
                   scrollYPercentage = args.y.percentage = (oldScrollTop + args.y.pixels) / scrollLength;
-                  // $log.debug('y.percentage', args.y.percentage);
+                  // gridUtil.logDebug('y.percentage', args.y.percentage);
                 }
                 else {
                   throw new Error("No percentage or pixel value provided for scroll event Y axis");
@@ -384,7 +384,7 @@
 
   }]);
 
-  module.controller('uiGridRenderContainer', ['$scope', '$log', function ($scope, $log) {
+  module.controller('uiGridRenderContainer', ['$scope', 'gridUtil', function ($scope, gridUtil) {
     var self = this;
 
     self.rowStyle = function (index) {

--- a/src/js/core/directives/ui-grid-row.js
+++ b/src/js/core/directives/ui-grid-row.js
@@ -1,7 +1,7 @@
 (function(){
   'use strict';
 
-  angular.module('ui.grid').directive('uiGridRow', ['$log', function($log) {
+  angular.module('ui.grid').directive('uiGridRow', ['gridUtil', function(gridUtil) {
     return {
       replace: true,
       // priority: 2001,

--- a/src/js/core/directives/ui-grid-style.js
+++ b/src/js/core/directives/ui-grid-style.js
@@ -38,15 +38,15 @@
    */
 
 
-  angular.module('ui.grid').directive('uiGridStyle', ['$log', '$interpolate', function($log, $interpolate) {
+  angular.module('ui.grid').directive('uiGridStyle', ['gridUtil', '$interpolate', function(gridUtil, $interpolate) {
     return {
       // restrict: 'A',
       // priority: 1000,
       // require: '?^uiGrid',
       link: function($scope, $elm, $attrs, uiGridCtrl) {
-        $log.debug('ui-grid-style link');
+        // gridUtil.logDebug('ui-grid-style link');
         // if (uiGridCtrl === undefined) {
-        //    $log.warn('[ui-grid-style link] uiGridCtrl is undefined!');
+        //    gridUtil.logWarn('[ui-grid-style link] uiGridCtrl is undefined!');
         // }
 
         var interpolateFn = $interpolate($elm.text(), true);

--- a/src/js/core/directives/ui-grid-viewport.js
+++ b/src/js/core/directives/ui-grid-viewport.js
@@ -1,15 +1,15 @@
 (function(){
   'use strict';
 
-  angular.module('ui.grid').directive('uiGridViewport', ['$log', 'gridUtil',
-    function($log, gridUtil) {
+  angular.module('ui.grid').directive('uiGridViewport', ['gridUtil',
+    function(gridUtil) {
       return {
         replace: true,
         scope: {},
         templateUrl: 'ui-grid/uiGridViewport',
         require: ['^uiGrid', '^uiGridRenderContainer'],
         link: function($scope, $elm, $attrs, controllers) {
-          $log.debug('viewport post-link');
+          // gridUtil.logDebug('viewport post-link');
 
           var uiGridCtrl = controllers[0];
           var containerCtrl = controllers[1];

--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -1,11 +1,11 @@
 (function () {
   'use strict';
 
-  angular.module('ui.grid').controller('uiGridController', ['$scope', '$element', '$attrs', '$log', 'gridUtil', '$q', 'uiGridConstants',
+  angular.module('ui.grid').controller('uiGridController', ['$scope', '$element', '$attrs', 'gridUtil', '$q', 'uiGridConstants',
                     '$templateCache', 'gridClassFactory', '$timeout', '$parse', '$compile',
-    function ($scope, $elm, $attrs, $log, gridUtil, $q, uiGridConstants,
+    function ($scope, $elm, $attrs, gridUtil, $q, uiGridConstants,
               $templateCache, gridClassFactory, $timeout, $parse, $compile) {
-      $log.debug('ui-grid controller');
+      // gridUtil.logDebug('ui-grid controller');
 
       var self = this;
 
@@ -61,12 +61,12 @@
       }
 
       function dataWatchFunction(n) {
-        // $log.debug('dataWatch fired');
+        // gridUtil.logDebug('dataWatch fired');
         var promises = [];
 
         if (n) {
           if (self.grid.columns.length === ( self.grid.rowHeaderColumns ? self.grid.rowHeaderColumns.length : 0 ) ) {
-            $log.debug('loading cols in dataWatchFunction');
+            // gridUil.logDebug('loading cols in dataWatchFunction');
             if (!$attrs.uiGridColumns && self.grid.options.columnDefs.length === 0) {
               self.grid.buildColumnDefsFromData(n);
             }
@@ -158,13 +158,11 @@
  */
 angular.module('ui.grid').directive('uiGrid',
   [
-    '$log',
     '$compile',
     '$templateCache',
     'gridUtil',
     '$window',
     function(
-      $log,
       $compile,
       $templateCache,
       gridUtil,
@@ -182,7 +180,7 @@ angular.module('ui.grid').directive('uiGrid',
         compile: function () {
           return {
             post: function ($scope, $elm, $attrs, uiGridCtrl) {
-              $log.debug('ui-grid postlink');
+              // gridUtil.logDebug('ui-grid postlink');
 
               var grid = uiGridCtrl.grid;
 

--- a/src/js/core/directives/ui-pinned-container.js
+++ b/src/js/core/directives/ui-pinned-container.js
@@ -1,7 +1,7 @@
 (function(){
   'use strict';
 
-  angular.module('ui.grid').directive('uiGridPinnedContainer', ['$log', function ($log) {
+  angular.module('ui.grid').directive('uiGridPinnedContainer', ['gridUtil', function (gridUtil) {
     return {
       restrict: 'EA',
       replace: true,
@@ -13,7 +13,7 @@
       compile: function compile() {
         return {
           post: function ($scope, $elm, $attrs, uiGridCtrl) {
-            $log.debug('ui-grid-pinned-container ' + $scope.side + ' link');
+            // gridUtil.logDebug('ui-grid-pinned-container ' + $scope.side + ' link');
 
             var grid = uiGridCtrl.grid;
 
@@ -22,7 +22,7 @@
             $elm.addClass('ui-grid-pinned-container-' + $scope.side);
 
             function updateContainerDimensions() {
-              // $log.debug('update ' + $scope.side + ' dimensions');
+              // gridUtil.logDebug('update ' + $scope.side + ' dimensions');
 
               var ret = '';
 
@@ -37,7 +37,7 @@
 
                 myWidth = width;
 
-                // $log.debug('myWidth', myWidth);
+                // gridUtil.logDebug('myWidth', myWidth);
 
                 // TODO(c0bra): Subtract sum of col widths from grid viewport width and update it
                 $elm.attr('style', null);

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1,8 +1,8 @@
 (function(){
 
 angular.module('ui.grid')
-.factory('Grid', ['$log', '$q', '$compile', '$parse', 'gridUtil', 'uiGridConstants', 'GridOptions', 'GridColumn', 'GridRow', 'GridApi', 'rowSorter', 'rowSearcher', 'GridRenderContainer', '$timeout',
-    function($log, $q, $compile, $parse, gridUtil, uiGridConstants, GridOptions, GridColumn, GridRow, GridApi, rowSorter, rowSearcher, GridRenderContainer, $timeout) {
+.factory('Grid', ['$q', '$compile', '$parse', 'gridUtil', 'uiGridConstants', 'GridOptions', 'GridColumn', 'GridRow', 'GridApi', 'rowSorter', 'rowSearcher', 'GridRenderContainer', '$timeout',
+    function($q, $compile, $parse, gridUtil, uiGridConstants, GridOptions, GridColumn, GridRow, GridApi, rowSorter, rowSearcher, GridRenderContainer, $timeout) {
 
 /**
  * @ngdoc object
@@ -317,7 +317,7 @@ angular.module('ui.grid')
           colDef.type = gridUtil.guessType(self.getCellValue(firstRow, col));
         }
         else {
-          $log.log('Unable to assign type from data, so defaulting to string');
+          gridUtil.logWarn('Unable to assign type from data, so defaulting to string');
           colDef.type = 'string';
         }
       }
@@ -370,7 +370,7 @@ angular.module('ui.grid')
    * @returns {Promise} a promise to load any needed column resources
    */
   Grid.prototype.buildColumns = function buildColumns() {
-    $log.debug('buildColumns');
+    // gridUtil.logDebug('buildColumns');
     var self = this;
     var builderPromises = [];
     var headerOffset = self.rowHeaderColumns.length;
@@ -907,7 +907,7 @@ angular.module('ui.grid')
   };
 
   Grid.prototype.setVisibleRows = function setVisibleRows(rows) {
-    // $log.debug('setVisibleRows');
+    // gridUtil.logDebug('setVisibleRows');
 
     var self = this;
 
@@ -1029,7 +1029,7 @@ angular.module('ui.grid')
   };
 
   Grid.prototype.setVisibleColumns = function setVisibleColumns(columns) {
-    // $log.debug('setVisibleColumns');
+    // gridUtil.logDebug('setVisibleColumns');
 
     var self = this;
 
@@ -1103,7 +1103,7 @@ angular.module('ui.grid')
    */
   // TODO: this used to take $scope, but couldn't see that it was used
   Grid.prototype.buildStyles = function buildStyles() {
-    // $log.debug('buildStyles');
+    // gridUtil.logDebug('buildStyles');
 
     var self = this;
     
@@ -1181,7 +1181,7 @@ angular.module('ui.grid')
     
     viewPortHeight = viewPortHeight + adjustment.height;
 
-    // $log.debug('viewPortHeight', viewPortHeight);
+    // gridUtil.logDebug('viewPortHeight', viewPortHeight);
 
     return viewPortHeight;
   };
@@ -1199,7 +1199,7 @@ angular.module('ui.grid')
     
     viewPortWidth = viewPortWidth + adjustment.width;
 
-    // $log.debug('getviewPortWidth', viewPortWidth);
+    // gridUtil.logDebug('getviewPortWidth', viewPortWidth);
 
     return viewPortWidth;
   };
@@ -1443,7 +1443,7 @@ angular.module('ui.grid')
    * 
    */
   Grid.prototype.refresh = function refresh() {
-    $log.debug('grid refresh');
+    // gridUtil.logDebug('grid refresh');
     
     var self = this;
     
@@ -1593,14 +1593,14 @@ angular.module('ui.grid')
    * 
    */
   Grid.prototype.redrawInPlace = function redrawInPlace() {
-    // $log.debug('redrawInPlace');
+    // gridUtil.logDebug('redrawInPlace');
     
     var self = this;
 
     for (var i in self.renderContainers) {
       var container = self.renderContainers[i];
 
-      // $log.debug('redrawing container', i);
+      // gridUtil.logDebug('redrawing container', i);
 
       container.adjustRows(container.prevScrollTop, null);
       container.adjustColumns(container.prevScrollLeft, null);

--- a/src/js/core/factories/GridApi.js
+++ b/src/js/core/factories/GridApi.js
@@ -1,8 +1,8 @@
 (function () {
 
   angular.module('ui.grid')
-    .factory('GridApi', ['$log', '$q', '$rootScope', 'gridUtil', 'uiGridConstants', 'GridRow', 'uiGridGridMenuService',
-      function ($log, $q, $rootScope, gridUtil, uiGridConstants, GridRow, uiGridGridMenuService) {
+    .factory('GridApi', ['$q', '$rootScope', 'gridUtil', 'uiGridConstants', 'GridRow', 'uiGridGridMenuService',
+      function ($q, $rootScope, gridUtil, uiGridConstants, GridRow, uiGridGridMenuService) {
         /**
          * @ngdoc function
          * @name ui.grid.class:GridApi
@@ -175,12 +175,12 @@
 
           var eventId = self.grid.id + featureName + eventName;
 
-          $log.log('Creating raise event method ' + featureName + '.raise.' + eventName);
+          // gridUtil.logDebug('Creating raise event method ' + featureName + '.raise.' + eventName);
           feature.raise[eventName] = function () {
             $rootScope.$broadcast.apply($rootScope, [eventId].concat(Array.prototype.slice.call(arguments)));
           };
 
-          $log.log('Creating on event method ' + featureName + '.on.' + eventName);
+          // gridUtil.logDebug('Creating on event method ' + featureName + '.on.' + eventName);
           feature.on[eventName] = function (scope, handler) {
             var dereg = registerEventWithAngular(scope, eventId, handler, self.grid);
 

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -1,7 +1,7 @@
 (function(){
 
 angular.module('ui.grid')
-.factory('GridColumn', ['gridUtil', 'uiGridConstants', 'i18nService', '$log', function(gridUtil, uiGridConstants, i18nService, $log) {
+.factory('GridColumn', ['gridUtil', 'uiGridConstants', 'i18nService', function(gridUtil, uiGridConstants, i18nService) {
 
   /**
    * @ngdoc function
@@ -382,7 +382,7 @@ angular.module('ui.grid')
     self.field = (colDef.field === undefined) ? colDef.name : colDef.field;
     
     if ( typeof( self.field ) !== 'string' ){
-      $log.error( 'Field is not a string, this is likely to break the code, Field is: ' + self.field );
+      gridUtil.logError( 'Field is not a string, this is likely to break the code, Field is: ' + self.field );
     }
     
     self.name = colDef.name;

--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -1,7 +1,7 @@
 (function(){
 
 angular.module('ui.grid')
-.factory('GridRenderContainer', ['$log', 'gridUtil', function($log, gridUtil) {
+.factory('GridRenderContainer', ['gridUtil', function(gridUtil) {
   function GridRenderContainer(name, grid, options) {
     var self = this;
 
@@ -262,7 +262,7 @@ angular.module('ui.grid')
     // scrollLeft = uiGridCtrl.canvas[0].scrollWidth * scrollPercentage;
     scrollLeft = this.getCanvasWidth() * scrollPercentage;
 
-    //$log.debug('scrollPercentage', scrollPercentage);
+    //gridUtil.logDebug('scrollPercentage', scrollPercentage);
 
     this.adjustColumns(scrollLeft, scrollPercentage);
 

--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -7,8 +7,8 @@
    *  @description factory to return dom specific instances of a grid
    *
    */
-  angular.module('ui.grid').service('gridClassFactory', ['gridUtil', '$q', '$compile', '$templateCache', 'uiGridConstants', '$log', 'Grid', 'GridColumn', 'GridRow',
-    function (gridUtil, $q, $compile, $templateCache, uiGridConstants, $log, Grid, GridColumn, GridRow) {
+  angular.module('ui.grid').service('gridClassFactory', ['gridUtil', '$q', '$compile', '$templateCache', 'uiGridConstants', 'Grid', 'GridColumn', 'GridRow',
+    function (gridUtil, $q, $compile, $templateCache, uiGridConstants, Grid, GridColumn, GridRow) {
 
       var service = {
         /**

--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -37,7 +37,7 @@ function QuickCache() {
  *
  *  @description Service for searching/filtering rows based on column value conditions.
  */
-module.service('rowSearcher', ['$log', 'uiGridConstants', function ($log, uiGridConstants) {
+module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil, uiGridConstants) {
   var defaultCondition = uiGridConstants.filter.STARTS_WITH;
 
   var rowSearcher = {};

--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -669,16 +669,56 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
 
     resetUids: function () {
       uid = ['0', '0', '0'];
+    },
+    
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.service:GridUtil
+     * @name logError
+     * @description wraps the $log method, allowing us to choose different
+     * treatment within ui-grid if we so desired.  At present we only log
+     * error messages if uiGridConstants.LOG_ERROR_MESSAGES is set to true
+     * @param {string} logMessage message to be logged to the console
+     * 
+     */
+    logError: function( logMessage ){
+      if ( uiGridConstants.LOG_ERROR_MESSAGES ){
+        $log.$error( logMessage );
+      }
+    },
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.service:GridUtil
+     * @name logWarn
+     * @description wraps the $log method, allowing us to choose different
+     * treatment within ui-grid if we so desired.  At present we only log
+     * warning messages if uiGridConstants.LOG_WARN_MESSAGES is set to true
+     * @param {string} logMessage message to be logged to the console
+     * 
+     */
+    logWarn: function( logMessage ){
+      if ( uiGridConstants.LOG_WARN_MESSAGES ){
+        $log.$warn( logMessage );
+      }
+    },
+
+    /**
+     * @ngdoc method
+     * @methodOf ui.grid.service:GridUtil
+     * @name logDebug
+     * @description wraps the $log method, allowing us to choose different
+     * treatment within ui-grid if we so desired.  At present we only log
+     * debug messages if uiGridConstants.LOG_DEBUG_MESSAGES is set to true
+     * @param {string} logMessage message to be logged to the console
+     * 
+     */
+    logDebug: function( logMessage ){
+      if ( uiGridConstants.LOG_DEBUG_MESSAGES ){
+        $log.$debug( logMessage );
+      }
     }
 
-    // setHashKey: function setHashKey(obj, h) {
-    //   if (h) {
-    //     obj.$$hashKey = h;
-    //   }
-    //   else {
-    //     delete obj.$$hashKey;
-    //   }
-    // }
   };
 
   ['width', 'height'].forEach(function (name) {

--- a/test/unit/core/directives/ui-grid-column-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-column-menu.spec.js
@@ -4,16 +4,14 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function () {
   var grid; 
   var $rootScope;
   var $scope;
-  var $log;
   
   beforeEach(module('ui.grid'));
 
-  beforeEach( inject(function (_uiGridColumnMenuService_, _gridClassFactory_, _$rootScope_, _$log_) {
+  beforeEach( inject(function (_uiGridColumnMenuService_, _gridClassFactory_, _$rootScope_) {
     uiGridColumnMenuService = _uiGridColumnMenuService_;
     gridClassFactory = _gridClassFactory_;
     $rootScope = _$rootScope_;
     $scope = $rootScope.$new();
-    $log = _$log_;
 
     grid = gridClassFactory.createGrid( { id: 1234 });
     grid.options.columnDefs = [

--- a/test/unit/core/directives/ui-grid-menu-button.spec.js
+++ b/test/unit/core/directives/ui-grid-menu-button.spec.js
@@ -4,17 +4,17 @@ describe('ui-grid-menu-button uiGridGridMenuService', function () {
   var grid; 
   var $rootScope;
   var $scope;
-  var $log;
+  var gridUtil;
   var $q;
   
   beforeEach(module('ui.grid'));
 
-  beforeEach( inject(function (_uiGridGridMenuService_, _gridClassFactory_, _$rootScope_, _$log_, _$q_) {
+  beforeEach( inject(function (_uiGridGridMenuService_, _gridClassFactory_, _$rootScope_, _gridUtil_, _$q_) {
     uiGridGridMenuService = _uiGridGridMenuService_;
     gridClassFactory = _gridClassFactory_;
     $rootScope = _$rootScope_;
     $scope = $rootScope.$new();
-    $log = _$log_;
+    gridUtil = _gridUtil_;
     $q = _$q_;
 
     grid = gridClassFactory.createGrid( { id: 1234 });
@@ -67,11 +67,11 @@ describe('ui-grid-menu-button uiGridGridMenuService', function () {
     });
     
     it('error if no array passed', function () {
-      spyOn($log, 'error').andCallFake( function() {});
+      spyOn(gridUtil, 'logError').andCallFake( function() {});
       
       uiGridGridMenuService.addToGridMenu( grid, grid );
       
-      expect( $log.error ).toHaveBeenCalled();
+      expect( gridUtil.logError ).toHaveBeenCalled();
       expect( grid.gridMenuScope.registeredMenuItems ).toEqual( [] );
     });
 

--- a/test/unit/core/directives/uiGridCell.spec.js
+++ b/test/unit/core/directives/uiGridCell.spec.js
@@ -1,14 +1,13 @@
 describe('uiGridCell', function () {
-  var gridCell, $scope, $compile, $timeout, GridColumn, recompile, $log, grid;
+  var gridCell, $scope, $compile, $timeout, GridColumn, recompile, grid;
 
   beforeEach(module('ui.grid'));
 
-  beforeEach(inject(function (_$compile_, $rootScope, _$timeout_, _GridColumn_, _$log_, gridClassFactory) {
+  beforeEach(inject(function (_$compile_, $rootScope, _$timeout_, _GridColumn_, gridClassFactory) {
     $scope = $rootScope;
     $compile = _$compile_;
     $timeout = _$timeout_;
     GridColumn = _GridColumn_;
-    $log = _$log_;
 
 
     $scope.grid = gridClassFactory.createGrid();


### PR DESCRIPTION
Refer #1787 for discussion, but essentially create a native ui-grid logging capability (`gridUtil.logDebug`, `gridUtil.logWarn`, `gridUtil.logError`), which just wraps $log.  Include in uiGridConstants variables to turn these on and off.

Ideally medium term the build process for distribution would set `LOG_DEBUG_MESSAGES` to false, but that's not critical at this time as this commit also comments out all debug messages.
