### PR TITLE
Fix(importer): changes to handling of data watch

### DIFF
--- a/misc/tutorial/207_importing_data.ngdoc
+++ b/misc/tutorial/207_importing_data.ngdoc
@@ -16,7 +16,8 @@ csv needing to match either the column.name or column.displayName.  Optionally y
 provide a custom function that maps headings to column.name, and this will be used instead.
 
 To use the importer you need to include the ui-grid-importer directive on
-your grid.  
+your grid, and you must provide a `gridOptions.importerDataAddCallback` function that adds
+the created objects into your data array. 
 
 The options and API for importer can be found at {@link api/ui.grid.importer ui.grid.importer}.
 
@@ -38,8 +39,13 @@ illustrates that doing so is not mandatory).
     var app = angular.module('app', ['ngAnimate', 'ui.grid', 'ui.grid.importer']);
 
     app.controller('MainCtrl', ['$scope', '$http', '$interval', function ($scope, $http, $interval) {
+      $scope.data = [];
       $scope.gridOptions = {
         enableGridMenu: true,
+        data: 'data',
+        importerDataAddCallback: function ( grid, newObjects ) {
+          $scope.data = $scope.data.concat( newObjects );
+        },
         onRegisterApi: function(gridApi){ 
           $scope.gridApi = gridApi;
         }

--- a/misc/tutorial/311_importing_data_with_rowedit.ngdoc
+++ b/misc/tutorial/311_importing_data_with_rowedit.ngdoc
@@ -1,5 +1,5 @@
 @ngdoc overview
-@name Tutorial: 310 Importing Data With Row Edit
+@name Tutorial: 311 Importing Data With Row Edit
 @description The importer feature allows data to be imported into the grid in 
 csv or json format.  The importer can use the native grid menu, or can accept a 
 file from a custom file picker implemented by the user.
@@ -23,12 +23,17 @@ and can be edited to save without error.
     var app = angular.module('app', ['ngAnimate', 'ui.grid', 'ui.grid.importer', 'ui.grid.rowEdit', 'ui.grid.edit']);
 
     app.controller('MainCtrl', ['$scope', '$http', '$interval', '$q', function ($scope, $http, $interval, $q) {
+      $scope.data = [];
       $scope.gridOptions = {
         enableGridMenu: true,
+        importerDataAddCallback: function( grid, newObjects ) {
+          $scope.data = $scope.data.concat( newObjects );
+        },
         onRegisterApi: function(gridApi){ 
           $scope.gridApi = gridApi;
           gridApi.rowEdit.on.saveRow($scope, $scope.saveRow);
-        }
+        },
+        data: 'data'
       };
 
       $scope.saveRow = function( rowEntity ) {

--- a/misc/tutorial/312_exporting_data_complex.ngdoc
+++ b/misc/tutorial/312_exporting_data_complex.ngdoc
@@ -1,5 +1,5 @@
 @ngdoc overview
-@name Tutorial: 306 Exporting Data With Custom UI
+@name Tutorial: 312 Exporting Data With Custom UI
 @description The exporter feature allows data to be exported from the grid in 
 csv or pdf format.  The exporter can export all data, visible data or selected data.
 

--- a/src/features/row-edit/js/gridRowEdit.js
+++ b/src/features/row-edit/js/gridRowEdit.js
@@ -298,7 +298,9 @@
             if (!grid.rowEditErrorRows){
               grid.rowEditErrorRows = [];
             }
-            grid.rowEditErrorRows.push( gridRow );
+            if (!service.isRowPresent( grid.rowEditErrorRows, gridRow ) ){
+              grid.rowEditErrorRows.push( gridRow );
+            }
           };
         },
         
@@ -321,6 +323,26 @@
           });
         },
         
+        
+        /**
+         * @ngdoc method
+         * @methodOf ui.grid.rowEdit.service:uiGridRowEditService
+         * @name isRowPresent
+         * @description  Checks whether a row is already present
+         * in the given array 
+         * @param {array} rowArray the array in which to look for the row
+         * @param {GridRow} gridRow the row that should be looked for
+         */
+        isRowPresent: function( rowArray, removeGridRow ){
+          var present = false;
+          angular.forEach( rowArray, function( gridRow, index ){
+            if ( gridRow.uid === removeGridRow.uid ){
+              present = true;
+            }
+          });
+          return present;
+        },
+
         
         /**
          * @ngdoc method

--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -63,7 +63,7 @@
       function dataWatchFunction(n) {
         // $log.debug('dataWatch fired');
         var promises = [];
-
+        
         if (n) {
           if (self.grid.columns.length === ( self.grid.rowHeaderColumns ? self.grid.rowHeaderColumns.length : 0 ) ) {
             $log.debug('loading cols in dataWatchFunction');
@@ -84,6 +84,9 @@
 
                 $scope.$evalAsync(function() {
                   self.grid.refreshCanvas(true);
+                  angular.forEach( self.grid.dataChangeCallbacks, function( callback, uid ){
+                    callback( self.grid );
+                  });
                 });
               });
           });

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -53,6 +53,7 @@ angular.module('ui.grid')
   self.styleComputations = [];
   self.viewportAdjusters = [];
   self.rowHeaderColumns = [];
+  self.dataChangeCallbacks = {};
 
   // self.visibleRowCache = [];
 
@@ -259,6 +260,32 @@ angular.module('ui.grid')
    */
   Grid.prototype.registerRowBuilder = function registerRowBuilder(rowBuilder) {
     this.rowBuilders.push(rowBuilder);
+  };
+
+  /**
+   * @ngdoc function
+   * @name registerDataChangeCallback
+   * @methodOf ui.grid.class:Grid
+   * @description When the data watch notices a change in the data, all the callbacks
+   * in the dataWatchCallback array will be called.
+   * @param {function(grid)} callback function to be called
+   * @returns {string} uid of the callback, can be used to deregister it again
+   */
+  Grid.prototype.registerDataChangeCallback = function registerDataChangeCallback(callback) {
+    var uid = gridUtil.nextUid();
+    this.dataChangeCallbacks[uid] = callback;
+    return uid;
+  };
+
+  /**
+   * @ngdoc function
+   * @name deregisterDataChangeCallback
+   * @methodOf ui.grid.class:Grid
+   * @description Delete the callback identified by the id.
+   * @param {string} uid uid of the callback to be deregistered
+   */
+  Grid.prototype.deregisterDataChangeCallback = function deregisterDataChangeCallback(uid) {
+    delete this.dataChangeCallbacks[uid];
   };
 
   /**

--- a/src/less/menu.less
+++ b/src/less/menu.less
@@ -19,7 +19,7 @@
 
 .ui-grid-menu {
   z-index: 2; // So it shows up over grid canvas
-  position: absolute;
+  position: fixed;
   overflow: hidden;
   padding: 0 10px 20px 10px;
   cursor: pointer;

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -594,4 +594,15 @@ describe('Grid factory', function () {
       expect( column.sort.direction ).toEqual(uiGridConstants.ASC);
     });
   });
+  
+  
+  describe( 'register and deregister data change callbacks', function() {
+    it( 'register then deregister data change callback', function() {
+      var uid = grid.registerDataChangeCallback( function() {});
+      expect( grid.dataChangeCallbacks[uid]).toEqual( jasmine.any(Function));
+      
+      grid.deregisterDataChangeCallback( uid );
+      expect( grid.dataChangeCallbacks ).toEqual( {} );
+    });
+  });
 });


### PR DESCRIPTION
Add a dataChangeCallback capability to grid, which is called
by the data watch function.  Make use of this for importer to
know when the data change has occurred.  Refer #1819 for the
concept here.

Fix rowEdit so that error rows aren't duplicate entered into
rowEditRowsDirty if they error twice.

Update tutorial numbering - newer tutorials have conflicted with
older.

Change importer to require an explicit callback to be provided
by the user - change the data from userspace rather than in the
grid itself.

Fix grid menu so that it displays correctly on Chrome, it had
started only partially rendering.  Fixed by changing position from
absolute to fixed.
