### PR TITLE
Allow override of font-path

### DIFF
--- a/src/less/icons.less
+++ b/src/less/icons.less
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'ui-grid';
-  src: url('ui-grid.eot');
-  src: url('ui-grid.eot#iefix') format('embedded-opentype'),
-       url('ui-grid.woff') format('woff'),
-       url('ui-grid.ttf?') format('truetype'),
-       url('ui-grid.svg?#ui-grid') format('svg');
+  src: url('{@font-path}ui-grid.eot');
+  src: url('{@font-path}ui-grid.eot#iefix') format('embedded-opentype'),
+       url('{@font-path}ui-grid.woff') format('woff'),
+       url('{@font-path}ui-grid.ttf?') format('truetype'),
+       url('{@font-path}ui-grid.svg?#ui-grid') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -69,4 +69,9 @@
 @invalidValueBorder: 1px solid rgb(252, 143, 143);
 @validValueBorder: 1px solid @borderColor;
 
+/**
+* @section font library path
+*/
+@font-path: '';
+
 /*-- END VARIABLES (DO NOT REMOVE THESE COMMENTS) --*/


### PR DESCRIPTION
When pulling in LESS files directly (for example, using gulp), it is useful to be able to override the path used to lookup font files.

For our build, I am pulling in the less via an
    @import (less)

Then copying the .svg, etc files to our output directory.
See https://github.com/twbs/bootstrap/blob/master/less/glyphicons.less
