### PR TITLE
Fix #1828 enh(importer): move to csv-js library, fix apply

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -456,6 +456,7 @@ module.exports = function(grunt) {
           '//ajax.googleapis.com/ajax/libs/angularjs/1.2.16/angular.js',
           '//ajax.googleapis.com/ajax/libs/angularjs/1.2.16/angular-touch.js',
           '//ajax.googleapis.com/ajax/libs/angularjs/1.2.16/angular-animate.js',
+          'bower_components/csv-js/csv.js',
           'bower_components/pdfmake/build/pdfmake.js',
           'bower_components/pdfmake/build/vfs_fonts.js'
         ],

--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "google-code-prettify": "~1.0.2",
     "jquery": "~1.8.0",
     "lodash": "~2.4.1",
-    "pdfmake": "~0.1.8"
+    "pdfmake": "~0.1.8",
+    "csv-js": "*"
   }
 }

--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -10,7 +10,7 @@ var cachedAngularFiles = grunt.file.readJSON('lib/test/angular/files.json');
 var util = module.exports = {
 
   testDependencies: {
-    unit: ['bower_components/jquery/jquery.min.js', 'lib/test/jquery.simulate.js', 'dist/release/ui-grid.css', 'bower_components/lodash/dist/lodash.min.js']
+    unit: ['bower_components/jquery/jquery.min.js', 'lib/test/jquery.simulate.js', 'dist/release/ui-grid.css', 'bower_components/lodash/dist/lodash.min.js', 'bower_components/csv-js/csv.js']
   },
 
   testFiles: {

--- a/misc/tutorial/207_importing_data.ngdoc
+++ b/misc/tutorial/207_importing_data.ngdoc
@@ -25,7 +25,10 @@ imported, refer the documentation for `importerObjectCallback`.
 
 To use the importer you need to include the ui-grid-importer directive on
 your grid, and you must provide a `gridOptions.importerDataAddCallback` function that adds
-the created objects into your data array. 
+the created objects into your data array.  You also need to have installed the csv-js library,
+`bower install --savedev csv-js`.  You can configure the csv-js library through use of globals,
+for example `CSV.DETECT_TYPES = false;`, refer to the {https://github.com/gkindel/CSV-JS csv-js documentation} 
+for more information. 
 
 The options and API for importer can be found at {@link api/ui.grid.importer ui.grid.importer}.
 

--- a/src/features/importer/js/importer.js
+++ b/src/features/importer/js/importer.js
@@ -1,3 +1,5 @@
+/* global CSV */
+
 (function () {
   'use strict';
 
@@ -470,34 +472,8 @@
         parseCsv: function( importFile ) {
           var csv = importFile.target.result;
           
-          var reviver = function(r, c, v) { return v; };
-          var chars = csv.split(''), c = 0, cc = chars.length, start, end, table = [], row;
-          while (c < cc) {
-            table.push(row = []);
-            while (c < cc && chars[c] !== '\r' && chars[c] !== '\n' ) {
-              start = end = c;
-              if ( chars[c] === '"'){
-                start = end = ++c;
-                while (c < cc) {
-                  if ( chars[c] === '"' ) {
-                    if ( chars[c+1] !== '"') { break; }
-                    else { chars[++c] = ''; } // unescape ""
-                  }
-                  end = ++c;
-                }
-                if ( chars[c] === '"' ) { ++c; }
-                while (c < cc && chars[c] !== '\r' && chars[c] !== '\n' && chars[c] !== ',') { ++c; }
-              } else {
-                while (c < cc && chars[c] !== '\r' && chars[c] !== '\n' && chars[c] !== ',') { end = ++c; }
-              }
-              end = reviver(table.length-1, row.length, chars.slice(start, end).join(''));
-              row.push(isNaN(end) ? end : +end);
-              if (chars[c] === ',') { ++c; }
-            }
-            if (chars[c] === '\r') { ++c; }
-            if (chars[c] === '\n') { ++c; }
-          }
-          return table;
+          // use the CSV-JS library to parse
+          return CSV.parse(csv);
         },
         
 
@@ -639,7 +615,7 @@
          * @param {array} newObjects the objects we want to insert into the grid data
          * @returns {object} the new object
          */
-        addObjects: function( grid, newObjects ){
+        addObjects: function( grid, newObjects, $scope ){
           if ( grid.api.rowEdit ){
             var callbackId = grid.registerDataChangeCallback( function() {
               grid.api.rowEdit.setRowsDirty( grid, newObjects );
@@ -653,7 +629,7 @@
             grid.importer.$scope.$on( '$destroy', deregisterClosure );
           }
 
-          grid.options.importerDataAddCallback( grid, newObjects );
+          grid.importer.$scope.$apply( grid.options.importerDataAddCallback( grid, newObjects ) );
           
         },
         


### PR DESCRIPTION
Move to csv-js library, more standards compliant and configurable.
Requires bower install before can be used, noted in tutorial.

Fix #1828, wasn't rendering as needed $scope.$apply.
