### PR TITLE
Ensure minWidth and maxWidth are applied correctly

### DIFF
--- a/src/js/core/directives/ui-grid-header.js
+++ b/src/js/core/directives/ui-grid-header.js
@@ -163,6 +163,7 @@
 
                     // Remove this element from the percent array so it's not processed below
                     percentArray.splice(i, 1);
+					i--;
                   }
                   else if (column.colDef.maxWidth && colWidth > column.colDef.maxWidth) {
                     colWidth = column.colDef.maxWidth;
@@ -174,6 +175,7 @@
 
                     // Remove this element from the percent array so it's not processed below
                     percentArray.splice(i, 1);
+					i--;
                   }
                 }
 
@@ -209,6 +211,7 @@
 
                     // Remove this element from the percent array so it's not processed below
                     asterisksArray.splice(i, 1);
+					i--;
                   }
                   else if (column.colDef.maxWidth && colWidth > column.colDef.maxWidth) {
                     colWidth = column.colDef.maxWidth;
@@ -221,6 +224,7 @@
 
                     // Remove this element from the percent array so it's not processed below
                     asterisksArray.splice(i, 1);
+					i--;
                   }
                 }
 

--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -525,6 +525,7 @@ angular.module('ui.grid')
 
           // Remove this element from the percent array so it's not processed below
           percentArray.splice(i, 1);
+		  i--;
         }
         else if (column.colDef.maxWidth && colWidth > column.colDef.maxWidth) {
           colWidth = column.colDef.maxWidth;
@@ -536,6 +537,7 @@ angular.module('ui.grid')
 
           // Remove this element from the percent array so it's not processed below
           percentArray.splice(i, 1);
+		  i--;
         }
       }
 
@@ -571,6 +573,7 @@ angular.module('ui.grid')
 
           // Remove this element from the percent array so it's not processed below
           asterisksArray.splice(i, 1);
+		  i--;
         }
         else if (column.colDef.maxWidth && colWidth > column.colDef.maxWidth) {
           colWidth = column.colDef.maxWidth;
@@ -583,6 +586,7 @@ angular.module('ui.grid')
 
           // Remove this element from the percent array so it's not processed below
           asterisksArray.splice(i, 1);
+		  i--;
         }
       }
 


### PR DESCRIPTION
When splicing an element of the percentArray or asteriksArray within a
loop certain array elements would be skipped during processing if the
counter is not decremented.
