### PR TITLE
ng-input hold $viewValue instead of $modelValue

### DIFF
--- a/src/directives/ng-input.js
+++ b/src/directives/ng-input.js
@@ -5,7 +5,7 @@ ngGridDirectives.directive('ngInput', [function() {
             // Store the initial cell value so we can reset to it if need be
             var oldCellValue;
             var dereg = scope.$watch('ngModel', function() {
-                oldCellValue = ngModel.$modelValue;
+                oldCellValue = ngModel.$viewValue;
                 dereg(); // only run this watch once, we don't want to overwrite our stored value when the input changes
             });
 


### PR DESCRIPTION
I had some trouble using ng-input for resetting to old value when user press ESC.

I found out that ng-input was storing the initial $modelValue and calling $setViewValue with it when user pressed ESC. This was causing trouble with my input validation, since my view value is different from my model value.

So I changed the ng-input to store the $viewValue instead of $modelValue.

Hope it helps.
