### PR TITLE
fix #1762(selection): batch events for batch selection

### DIFF
--- a/misc/tutorial/210_selection.ngdoc
+++ b/misc/tutorial/210_selection.ngdoc
@@ -6,10 +6,14 @@ This grid example uses the ui-grid-selection directive to row selection. To enab
 module and you must include the ui-grid-selection directive on your grid element.
 
 Uses the gridOptions.onRegisterApi callback to register the rowSelectionChanged event and log when the row is selected.
+By default the selection feature will divide selection changes into batch events and single events, there are
+two different events provided in the api.  By setting `enableSelectionBatchEvent: false` you can cause it to 
+instead just call the single event in a loop - which may be useful if you're doing client rather than server
+side processing of the changes.
 
 By default the module will provide a row header with checkboxes that allow selection of individual rows.  If you set
 the `enableRowHeaderSelection` gridOption to false, then the row header is hidden and a click on the row will
-result in selection of that row.
+result in selection of that row.  You can see that in this tutorial for grid1 by looking at your javascript console.
 
 Setting the `multiSelect` gridOption to true will allow selecting multiple rows, setting to false will allow selection
 of only one row at a time.
@@ -84,6 +88,11 @@ Two examples are provided, the first with rowHeaderSelection and multi-select, t
           $scope.gridApi = gridApi;
           gridApi.selection.on.rowSelectionChanged($scope,function(row){
             var msg = 'row selected ' + row.isSelected;
+            $log.log(msg);
+          });
+
+          gridApi.selection.on.rowSelectionChangedBatch($scope,function(rows){
+            var msg = 'rows changed ' + rows.length;
             $log.log(msg);
           });
         };

--- a/src/features/selection/test/uiGridSelectionService.spec.js
+++ b/src/features/selection/test/uiGridSelectionService.spec.js
@@ -1,207 +1,279 @@
 describe('ui.grid.selection uiGridSelectionService', function () {
-    var uiGridSelectionService;
-    var gridClassFactory;
-    var grid;
+  var uiGridSelectionService;
+  var gridClassFactory;
+  var grid;
+  var $rootScope;
+  var $scope;
 
-    beforeEach(module('ui.grid.selection'));
+  beforeEach(module('ui.grid.selection'));
 
-    beforeEach(inject(function (_uiGridSelectionService_,_gridClassFactory_, $templateCache, _uiGridSelectionConstants_) {
-        uiGridSelectionService = _uiGridSelectionService_;
-        gridClassFactory = _gridClassFactory_;
+  beforeEach(inject(function (_uiGridSelectionService_,_gridClassFactory_, $templateCache, _uiGridSelectionConstants_,
+                              _$rootScope_) {
+    uiGridSelectionService = _uiGridSelectionService_;
+    gridClassFactory = _gridClassFactory_;
+    $rootScope = _$rootScope_;
+    $scope = $rootScope.$new();
 
-        $templateCache.put('ui-grid/uiGridCell', '<div/>');
-        $templateCache.put('ui-grid/editableCell', '<div editable_cell_directive></div>');
+    $templateCache.put('ui-grid/uiGridCell', '<div/>');
+    $templateCache.put('ui-grid/editableCell', '<div editable_cell_directive></div>');
 
-        grid = gridClassFactory.createGrid({});
-        grid.options.columnDefs = [
-            {field: 'col1', enableCellEdit: true}
-        ];
+    grid = gridClassFactory.createGrid({});
+    grid.options.columnDefs = [
+        {field: 'col1', enableCellEdit: true}
+    ];
 
-        _uiGridSelectionService_.initializeGrid(grid);
-        var data = [];
-        for (var i = 0; i < 10; i++) {
-            data.push({col1:'a_' + i});
-        }
-        grid.options.data = data;
+    _uiGridSelectionService_.initializeGrid(grid);
+    var data = [];
+    for (var i = 0; i < 10; i++) {
+        data.push({col1:'a_' + i});
+    }
+    grid.options.data = data;
 
-        grid.buildColumns();
-        grid.modifyRows(grid.options.data);
-    }));
-    
+    grid.buildColumns();
+    grid.modifyRows(grid.options.data);
+  }));
+  
 
-    describe('toggleSelection function', function () {
-        it('should toggle selected with multiselect', function () {
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true);
-            expect(grid.rows[0].isSelected).toBe(true);
+  describe('toggleSelection function', function () {
+    it('should toggle selected with multiselect', function () {
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true);
+      expect(grid.rows[0].isSelected).toBe(true);
 
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true);
-            expect(grid.rows[0].isSelected).toBe(false);
-        });
-
-        it('should toggle selected without multiselect', function () {
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], false);
-            expect(grid.rows[0].isSelected).toBe(true);
-
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], false);
-            expect(grid.rows[0].isSelected).toBe(false);
-            expect(grid.rows[1].isSelected).toBe(true);
-        });
-
-        it('should toggle selected with noUnselect', function () {
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], false, true);
-            expect(grid.rows[0].isSelected).toBe(true, 'row should be selected, noUnselect doesn\'t stop rows being selected');
-
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], false, true);
-            expect(grid.rows[0].isSelected).toBe(true, 'row should still be selected, noUnselect prevents unselect');
-            
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], false, true);
-            expect(grid.rows[0].isSelected).toBe(false, 'row should not be selected, noUnselect doesn\'t stop other rows being selected');
-            expect(grid.rows[1].isSelected).toBe(true, 'new row should be selected');
-        });
-
-        it('should remain selected', function () {
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true);
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true);
-            expect(grid.rows[0].isSelected).toBe(true);
-            expect(grid.rows[1].isSelected).toBe(true);
-
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], false);
-            expect(grid.rows[0].isSelected).toBe(false, 'row should not be selected, last row selection was not a multiselect selection');
-            expect(grid.rows[1].isSelected).toBe(true, 'row should be selected, multiple rows was selected before the selection');
-        });
-
-        it('should clear selected', function () {
-            uiGridSelectionService.toggleRowSelection(grid, grid.rows[0]);
-            expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(1);
-            uiGridSelectionService.clearSelectedRows(grid);
-            expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(0);
-        });
-
-        it('should utilize public apis', function () {
-            grid.api.selection.toggleRowSelection(grid.rows[0].entity);
-            expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(1);
-            grid.api.selection.clearSelectedRows();
-            expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(0);
-        });
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true);
+      expect(grid.rows[0].isSelected).toBe(false);
     });
 
-    describe('shiftSelect function', function() {
-        beforeEach(function() {
-            grid.setVisibleRows(grid.rows);          
-        });
-        
-        it('should select rows in between using shift key', function () {
-            grid.api.selection.toggleRowSelection(grid.rows[2].entity);
-            uiGridSelectionService.shiftSelect(grid, grid.rows[5], true);
-            expect(grid.rows[2].isSelected).toBe(true);
-            expect(grid.rows[3].isSelected).toBe(true);
-            expect(grid.rows[4].isSelected).toBe(true);
-            expect(grid.rows[5].isSelected).toBe(true);
-        });
+    it('should toggle selected without multiselect', function () {
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], false);
+      expect(grid.rows[0].isSelected).toBe(true);
 
-        it('should reverse selection order if from is bigger then to', function () {
-            grid.api.selection.toggleRowSelection(grid.rows[5].entity);
-            uiGridSelectionService.shiftSelect(grid, grid.rows[2], true);
-            expect(grid.rows[2].isSelected).toBe(true);
-            expect(grid.rows[3].isSelected).toBe(true);
-            expect(grid.rows[4].isSelected).toBe(true);
-            expect(grid.rows[5].isSelected).toBe(true);
-        });
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], false);
+      expect(grid.rows[0].isSelected).toBe(false);
+      expect(grid.rows[1].isSelected).toBe(true);
+    });
 
-        it('should return if multiSelect is false', function () {
-            uiGridSelectionService.shiftSelect(grid, grid.rows[2], false);
-            expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(0);
-        });
+    it('should toggle selected with noUnselect', function () {
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], false, true);
+      expect(grid.rows[0].isSelected).toBe(true, 'row should be selected, noUnselect doesn\'t stop rows being selected');
+
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], false, true);
+      expect(grid.rows[0].isSelected).toBe(true, 'row should still be selected, noUnselect prevents unselect');
+      
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], false, true);
+      expect(grid.rows[0].isSelected).toBe(false, 'row should not be selected, noUnselect doesn\'t stop other rows being selected');
+      expect(grid.rows[1].isSelected).toBe(true, 'new row should be selected');
+    });
+
+    it('should remain selected', function () {
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true);
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true);
+      expect(grid.rows[0].isSelected).toBe(true);
+      expect(grid.rows[1].isSelected).toBe(true);
+
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], false);
+      expect(grid.rows[0].isSelected).toBe(false, 'row should not be selected, last row selection was not a multiselect selection');
+      expect(grid.rows[1].isSelected).toBe(true, 'row should be selected, multiple rows was selected before the selection');
+    });
+
+    it('should clear selected', function () {
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[0]);
+      expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(1);
+      uiGridSelectionService.clearSelectedRows(grid);
+      expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(0);
+    });
+
+    it('should utilize public apis', function () {
+      grid.api.selection.toggleRowSelection(grid.rows[0].entity);
+      expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(1);
+      grid.api.selection.clearSelectedRows();
+      expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(0);
+    });
+  });
+
+  describe('shiftSelect function', function() {
+    beforeEach(function() {
+      grid.setVisibleRows(grid.rows);          
     });
     
-    describe('selectRow and unselectRow functions', function() {
-        it('select then unselect rows, including selecting rows already selected and unselecting rows not selected', function () {
-            grid.api.selection.selectRow(grid.rows[4].entity);
-            expect(grid.rows[4].isSelected).toBe(true);
-            
-            grid.api.selection.selectRow(grid.rows[6].entity);
-            expect(grid.rows[4].isSelected).toBe(true);
-            expect(grid.rows[6].isSelected).toBe(true);
-
-            grid.api.selection.selectRow(grid.rows[4].entity);
-            expect(grid.rows[4].isSelected).toBe(true);
-            expect(grid.rows[6].isSelected).toBe(true);
-            
-            grid.api.selection.unSelectRow(grid.rows[4].entity);
-            expect(grid.rows[4].isSelected).toBe(false);
-            expect(grid.rows[6].isSelected).toBe(true);
-
-            grid.api.selection.unSelectRow(grid.rows[4].entity);
-            expect(grid.rows[4].isSelected).toBe(false);
-            expect(grid.rows[6].isSelected).toBe(true);
-
-            grid.api.selection.unSelectRow(grid.rows[6].entity);
-            expect(grid.rows[4].isSelected).toBe(false);
-            expect(grid.rows[6].isSelected).toBe(false);
-        });      
+    it('should select rows in between using shift key', function () {
+      grid.api.selection.toggleRowSelection(grid.rows[2].entity);
+      uiGridSelectionService.shiftSelect(grid, grid.rows[5], true);
+      expect(grid.rows[2].isSelected).toBe(true);
+      expect(grid.rows[3].isSelected).toBe(true);
+      expect(grid.rows[4].isSelected).toBe(true);
+      expect(grid.rows[5].isSelected).toBe(true);
     });
 
-    describe('selectAllRows and clearSelectedRows functions', function() {
-        it('should select all rows, and select all rows when already all selected, then unselect again', function () {
-            grid.api.selection.selectRow(grid.rows[4].entity);
-            expect(grid.rows[4].isSelected).toBe(true);
-            
-            grid.api.selection.selectRow(grid.rows[6].entity);
-            expect(grid.rows[4].isSelected).toBe(true);
-            expect(grid.rows[6].isSelected).toBe(true);
-
-            grid.api.selection.selectAllRows();
-            for (var i = 0; i < 10; i++) {
-                expect(grid.rows[i].isSelected).toBe(true);
-            }
-
-            grid.api.selection.selectAllRows();
-            for (i = 0; i < 10; i++) {
-                expect(grid.rows[i].isSelected).toBe(true);
-            }
-            
-            grid.api.selection.clearSelectedRows();
-            for (i = 0; i < 10; i++) {
-                expect(grid.rows[i].isSelected).toBe(false);
-            }
-        });     
+    it('should reverse selection order if from is bigger then to', function () {
+      grid.api.selection.toggleRowSelection(grid.rows[5].entity);
+      uiGridSelectionService.shiftSelect(grid, grid.rows[2], true);
+      expect(grid.rows[2].isSelected).toBe(true);
+      expect(grid.rows[3].isSelected).toBe(true);
+      expect(grid.rows[4].isSelected).toBe(true);
+      expect(grid.rows[5].isSelected).toBe(true);
     });
 
-    describe('selectAllVisibleRows function', function() {
-        it('should select all visible rows', function () {
-            grid.api.selection.selectRow(grid.rows[4].entity);
-            expect(grid.rows[4].isSelected).toBe(true);
-            
-            grid.api.selection.selectRow(grid.rows[6].entity);
-            expect(grid.rows[4].isSelected).toBe(true);
-            expect(grid.rows[6].isSelected).toBe(true);
+    it('should return if multiSelect is false', function () {
+      uiGridSelectionService.shiftSelect(grid, grid.rows[2], false);
+      expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(0);
+    });
+  });
+  
+  describe('selectRow and unselectRow functions', function() {
+    it('select then unselect rows, including selecting rows already selected and unselecting rows not selected', function () {
+      grid.api.selection.selectRow(grid.rows[4].entity);
+      expect(grid.rows[4].isSelected).toBe(true);
+      
+      grid.api.selection.selectRow(grid.rows[6].entity);
+      expect(grid.rows[4].isSelected).toBe(true);
+      expect(grid.rows[6].isSelected).toBe(true);
 
-            grid.rows[3].visible = true;
-            grid.rows[4].visible = true;
-            grid.rows[6].visible = false;
-            grid.rows[7].visible = true;
-            grid.rows[9].visible = true;
-            
-            grid.api.selection.selectAllVisibleRows();
-            expect(grid.rows[3].isSelected).toBe(true);
-            expect(grid.rows[4].isSelected).toBe(true);
-            expect(grid.rows[6].isSelected).toBe(false);
-            expect(grid.rows[7].isSelected).toBe(true);
-            expect(grid.rows[9].isSelected).toBe(true);
-        });
+      grid.api.selection.selectRow(grid.rows[4].entity);
+      expect(grid.rows[4].isSelected).toBe(true);
+      expect(grid.rows[6].isSelected).toBe(true);
+      
+      grid.api.selection.unSelectRow(grid.rows[4].entity);
+      expect(grid.rows[4].isSelected).toBe(false);
+      expect(grid.rows[6].isSelected).toBe(true);
+
+      grid.api.selection.unSelectRow(grid.rows[4].entity);
+      expect(grid.rows[4].isSelected).toBe(false);
+      expect(grid.rows[6].isSelected).toBe(true);
+
+      grid.api.selection.unSelectRow(grid.rows[6].entity);
+      expect(grid.rows[4].isSelected).toBe(false);
+      expect(grid.rows[6].isSelected).toBe(false);
+    });      
+  });
+
+  describe('selectAllRows and clearSelectedRows functions', function() {
+    it('should select all rows, and select all rows when already all selected, then unselect again', function () {
+      grid.api.selection.selectRow(grid.rows[4].entity);
+      expect(grid.rows[4].isSelected).toBe(true);
+      
+      grid.api.selection.selectRow(grid.rows[6].entity);
+      expect(grid.rows[4].isSelected).toBe(true);
+      expect(grid.rows[6].isSelected).toBe(true);
+
+      grid.api.selection.selectAllRows();
+      for (var i = 0; i < 10; i++) {
+        expect(grid.rows[i].isSelected).toBe(true);
+      }
+
+      grid.api.selection.selectAllRows();
+      for (i = 0; i < 10; i++) {
+        expect(grid.rows[i].isSelected).toBe(true);
+      }
+      
+      grid.api.selection.clearSelectedRows();
+      for (i = 0; i < 10; i++) {
+        expect(grid.rows[i].isSelected).toBe(false);
+      }
+    });     
+  });
+
+  describe('selectAllVisibleRows function', function() {
+    it('should select all visible rows', function () {
+      grid.api.selection.selectRow(grid.rows[4].entity);
+      expect(grid.rows[4].isSelected).toBe(true);
+      
+      grid.api.selection.selectRow(grid.rows[6].entity);
+      expect(grid.rows[4].isSelected).toBe(true);
+      expect(grid.rows[6].isSelected).toBe(true);
+
+      grid.rows[3].visible = true;
+      grid.rows[4].visible = true;
+      grid.rows[6].visible = false;
+      grid.rows[7].visible = true;
+      grid.rows[9].visible = true;
+      
+      grid.api.selection.selectAllVisibleRows();
+      expect(grid.rows[3].isSelected).toBe(true);
+      expect(grid.rows[4].isSelected).toBe(true);
+      expect(grid.rows[6].isSelected).toBe(false);
+      expect(grid.rows[7].isSelected).toBe(true);
+      expect(grid.rows[9].isSelected).toBe(true);
+    });
+  });
+
+  describe('selectRowByVisibleIndex function', function() {
+    it('should select specified row', function () {
+      grid.rows[1].visible = false;
+      grid.setVisibleRows(grid.rows);
+      
+      grid.api.selection.selectRowByVisibleIndex(0);
+      expect(grid.rows[0].isSelected).toBe(true);
+      
+      grid.api.selection.selectRowByVisibleIndex(1);
+      expect(grid.rows[2].isSelected).toBe(true);
+    });
+  });
+  
+  describe('selectionChanged events', function(){
+    var selectionFunctions = {};
+    var singleCalls;
+    var batchCalls;
+    beforeEach( function() {
+      // can't use spy as the callback hits the function directly
+      singleCalls = [];
+      batchCalls = [];
+      
+      // row 5 isn't visible
+      // row 6 is already selected
+      // row 7 isn't visible and is already selected
+      grid.rows[5].visible = false;
+      grid.rows[7].visible = false;
+      grid.api.selection.toggleRowSelection( grid.rows[6].entity );
+      grid.api.selection.toggleRowSelection( grid.rows[7].entity );
+      selectionFunctions.single = function( row ){ singleCalls.push(row); };
+      selectionFunctions.batch = function( rows ) { batchCalls.push(rows);};
+      grid.api.selection.on.rowSelectionChanged( $scope, selectionFunctions.single );
+      grid.api.selection.on.rowSelectionChangedBatch( $scope, selectionFunctions.batch );
+    });
+    
+    it('select all rows, batch', function() {
+      grid.api.selection.selectAllRows();
+      expect( singleCalls.length ).toEqual( 0 );
+      expect( batchCalls.length ).toEqual( 1 );
+      expect( batchCalls[0].length ).toEqual( 8, "2 rows already selected" );
     });
 
-    describe('selectRowByVisibleIndex function', function() {
-        it('should select specified row', function () {
-            grid.rows[1].visible = false;
-            grid.setVisibleRows(grid.rows);
-            
-            grid.api.selection.selectRowByVisibleIndex(0);
-            expect(grid.rows[0].isSelected).toBe(true);
-            
-            grid.api.selection.selectRowByVisibleIndex(1);
-            expect(grid.rows[2].isSelected).toBe(true);
-        });
+    it('select all rows, not batch', function() {
+      grid.options.enableSelectionBatchEvent = false;
+      grid.api.selection.selectAllRows();
+      expect( singleCalls.length ).toEqual( 8, "2 rows already selected" );
+      expect( batchCalls.length ).toEqual( 0 );
     });
 
+    it('select all visible rows, batch', function() {
+      grid.api.selection.selectAllVisibleRows();
+      expect( singleCalls.length ).toEqual( 0 );
+      expect( batchCalls.length ).toEqual( 1 );
+      expect( batchCalls[0].length ).toEqual( 8, "8 visible rows, one already selected, one invisible row deselected" );
+    });
+
+    it('select all visible rows, not batch', function() {
+      grid.options.enableSelectionBatchEvent = false;
+      grid.api.selection.selectAllVisibleRows();
+      expect( singleCalls.length ).toEqual( 8, "8 visible rows, one already selected, one invisible row deselected" );
+      expect( batchCalls.length ).toEqual( 0 );
+    });
+    
+    // not testing toggle - simple
+    // not testing shift select - too messy and same logic as others
+
+    it('clear selected rows, batch', function() {
+      grid.api.selection.clearSelectedRows();
+      expect( singleCalls.length ).toEqual( 0 );
+      expect( batchCalls.length ).toEqual( 1 );
+      expect( batchCalls[0].length ).toEqual( 2, "2 selected rows" );
+    });
+
+    it('clear selected rows, not batch', function() {
+      grid.options.enableSelectionBatchEvent = false;
+      grid.api.selection.clearSelectedRows();
+      expect( singleCalls.length ).toEqual( 2, "2 selected rows" );
+      expect( batchCalls.length ).toEqual( 0 );
+    });
+  });
 });


### PR DESCRIPTION
Add batch selection event to the selection api.  Provide an option
to turn the batch event on and off - so users can just rely on
multiple calls to the individual row event if they wish.  By default
the batch events are used.
