### PR TITLE
Fix #1792(options): use gridOptions rather than copy them

### DIFF
--- a/misc/tutorial/105_footer.ngdoc
+++ b/misc/tutorial/105_footer.ngdoc
@@ -41,6 +41,7 @@ show the aggregation but without a label.  Refer the third column in the example
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl">
+      <button id="footerButton" class="btn btn-success" ng-click="gridOptions.showFooter = !gridOptions.showFooter">Toggle Footer</button>
       <div id="grid1" ui-grid="gridOptions" class="grid"></div>
     </div>
   </file>

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -35,10 +35,7 @@ angular.module('ui.grid')
   delete options.id;
 
   // Get default options
-  self.options = new GridOptions();
-
-  // Extend the default options with what we were passed in
-  angular.extend(self.options, options);
+  self.options = GridOptions.initialize( options );
 
   self.headerHeight = self.options.headerRowHeight;
   self.footerHeight = self.options.showFooter === true ? self.options.footerRowHeight : 0;
@@ -322,7 +319,7 @@ angular.module('ui.grid')
    * @name deregisterDataChangeCallback
    * @methodOf ui.grid.class:Grid
    * @description Delete the callback identified by the id.
-   * @param {string} uid uid of the callback to be deregistered
+   * @param {string} uid the uid of the function that is to be deregistered
    */
   Grid.prototype.deregisterDataChangeCallback = function deregisterDataChangeCallback(uid) {
     delete this.dataChangeCallbacks[uid];
@@ -333,7 +330,7 @@ angular.module('ui.grid')
    * @name callDataChangeCallbacks
    * @methodOf ui.grid.class:Grid
    * @description Calls the callbacks based on the type of data change that
-   * has occurred. Always calls the ALL callbacks, calls the ROW, EDIT and COLUMN callbacks if the 
+   * has occurred. Always calls the ALL callbacks, calls the ROW, EDIT, and COLUMN callbacks if the 
    * event type is matching, or if the type is ALL.
    * @param {number} type the type of event that occurred - one of the 
    * uiGridConstants.dataChange values (ALL, ROW, EDIT, COLUMN)

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -34,237 +34,239 @@ angular.module('ui.grid')
    *    })
    *  })</pre>
    */
-  function GridOptions() {
-
-    this.onRegisterApi = angular.noop();
-
-    /**
-     * @ngdoc object
-     * @name data
-     * @propertyOf ui.grid.class:GridOptions
-     * @description (mandatory) Array of data to be rendered into the grid, providing the data source or data binding for 
-     * the grid.  The most common case is an array of objects, where each object has a number of attributes.
-     * Each attribute automatically becomes a column in your grid.  This array could, for example, be sourced from
-     * an angularJS $resource query request.  The array can also contain complex objects.
-     * 
-     */
-    this.data = [];
-
-    /**
-     * @ngdoc array
-     * @name columnDefs
-     * @propertyOf  ui.grid.class:GridOptions
-     * @description Array of columnDef objects.  Only required property is name.
-     * The individual options available in columnDefs are documented in the
-     * {@link ui.grid.class:GridOptions.columnDef columnDef} section
-     * </br>_field property can be used in place of name for backwards compatibility with 2.x_
-     *  @example
-     *
-     * <pre>var columnDefs = [{name:'field1'}, {name:'field2'}];</pre>
-     *
-     */
-    this.columnDefs = [];
-
-    /**
-     * @ngdoc object
-     * @name ui.grid.class:GridOptions.columnDef
-     * @description Definition / configuration of an individual column, which would typically be
-     * one of many column definitions within the gridOptions.columnDefs array
-     * @example
-     * <pre>{name:'field1', field: 'field1', filter: { term: 'xxx' }}</pre>
-     *
-     */
-
-        
-    /**
-     * @ngdoc array
-     * @name excludeProperties
-     * @propertyOf  ui.grid.class:GridOptions
-     * @description Array of property names in data to ignore when auto-generating column names.  Provides the
-     * inverse of columnDefs - columnDefs is a list of columns to include, excludeProperties is a list of columns
-     * to exclude. 
-     * 
-     * If columnDefs is defined, this will be ignored.
-     * 
-     * Defaults to ['$$hashKey']
-     */
-    
-    this.excludeProperties = ['$$hashKey'];
-
-    /**
-     * @ngdoc boolean
-     * @name enableRowHashing
-     * @propertyOf ui.grid.class:GridOptions
-     * @description True by default. When enabled, this setting allows uiGrid to add
-     * `$$hashKey`-type properties (similar to Angular) to elements in the `data` array. This allows
-     * the grid to maintain state while vastly speeding up the process of altering `data` by adding/moving/removing rows.
-     * 
-     * Note that this DOES add properties to your data that you may not want, but they are stripped out when using `angular.toJson()`. IF
-     * you do not want this at all you can disable this setting but you will take a performance hit if you are using large numbers of rows
-     * and are altering the data set often.
-     */
-    this.enableRowHashing = true;
-
-    /**
-     * @ngdoc function
-     * @name rowIdentity
-     * @methodOf ui.grid.class:GridOptions
-     * @description This function is used to get and, if necessary, set the value uniquely identifying this row.
-     * 
-     * By default it returns the `$$hashKey` property if it exists. If it doesn't it uses gridUtil.nextUid() to generate one
-     */
-    this.rowIdentity = function rowIdentity(row) {
+  return {
+    initialize: function( baseOptions ){
+      baseOptions.onRegisterApi = baseOptions.onRegisterApi || angular.noop();
+  
+      /**
+       * @ngdoc object
+       * @name data
+       * @propertyOf ui.grid.class:GridOptions
+       * @description (mandatory) Array of data to be rendered into the grid, providing the data source or data binding for 
+       * the grid.  The most common case is an array of objects, where each object has a number of attributes.
+       * Each attribute automatically becomes a column in your grid.  This array could, for example, be sourced from
+       * an angularJS $resource query request.  The array can also contain complex objects.
+       * 
+       */
+      baseOptions.data = baseOptions.data || [];
+  
+      /**
+       * @ngdoc array
+       * @name columnDefs
+       * @propertyOf  ui.grid.class:GridOptions
+       * @description Array of columnDef objects.  Only required property is name.
+       * The individual options available in columnDefs are documented in the
+       * {@link ui.grid.class:GridOptions.columnDef columnDef} section
+       * </br>_field property can be used in place of name for backwards compatibility with 2.x_
+       *  @example
+       *
+       * <pre>var columnDefs = [{name:'field1'}, {name:'field2'}];</pre>
+       *
+       */
+      baseOptions.columnDefs = baseOptions.columnDefs || [];
+  
+      /**
+       * @ngdoc object
+       * @name ui.grid.class:GridOptions.columnDef
+       * @description Definition / configuration of an individual column, which would typically be
+       * one of many column definitions within the gridOptions.columnDefs array
+       * @example
+       * <pre>{name:'field1', field: 'field1', filter: { term: 'xxx' }}</pre>
+       *
+       */
+  
+          
+      /**
+       * @ngdoc array
+       * @name excludeProperties
+       * @propertyOf  ui.grid.class:GridOptions
+       * @description Array of property names in data to ignore when auto-generating column names.  Provides the
+       * inverse of columnDefs - columnDefs is a list of columns to include, excludeProperties is a list of columns
+       * to exclude. 
+       * 
+       * If columnDefs is defined, this will be ignored.
+       * 
+       * Defaults to ['$$hashKey']
+       */
+      
+      baseOptions.excludeProperties = baseOptions.excludeProperties || ['$$hashKey'];
+  
+      /**
+       * @ngdoc boolean
+       * @name enableRowHashing
+       * @propertyOf ui.grid.class:GridOptions
+       * @description True by default. When enabled, this setting allows uiGrid to add
+       * `$$hashKey`-type properties (similar to Angular) to elements in the `data` array. This allows
+       * the grid to maintain state while vastly speeding up the process of altering `data` by adding/moving/removing rows.
+       * 
+       * Note that this DOES add properties to your data that you may not want, but they are stripped out when using `angular.toJson()`. IF
+       * you do not want this at all you can disable this setting but you will take a performance hit if you are using large numbers of rows
+       * and are altering the data set often.
+       */
+      baseOptions.enableRowHashing = baseOptions.enableRowHashing !== false;
+  
+      /**
+       * @ngdoc function
+       * @name rowIdentity
+       * @methodOf ui.grid.class:GridOptions
+       * @description This function is used to get and, if necessary, set the value uniquely identifying this row.
+       * 
+       * By default it returns the `$$hashKey` property if it exists. If it doesn't it uses gridUtil.nextUid() to generate one
+       */
+      baseOptions.rowIdentity = baseOptions.rowIdentity || function rowIdentity(row) {
         return gridUtil.hashKey(row);
-    };
-
-    /**
-     * @ngdoc function
-     * @name getRowIdentity
-     * @methodOf ui.grid.class:GridOptions
-     * @description This function returns the identity value uniquely identifying this row.
-     * 
-     * By default it returns the `$$hashKey` property but can be overridden to use any property or set of properties you want.
-     */
-    this.getRowIdentity = function getRowIdentity(row) {
+      };
+  
+      /**
+       * @ngdoc function
+       * @name getRowIdentity
+       * @methodOf ui.grid.class:GridOptions
+       * @description This function returns the identity value uniquely identifying this row.
+       * 
+       * By default it returns the `$$hashKey` property but can be overridden to use any property or set of properties you want.
+       */
+      baseOptions.getRowIdentity = baseOptions.getRowIdentity || function getRowIdentity(row) {
         return row.$$hashKey;
-    };
+      };
+  
+      baseOptions.headerRowHeight = typeof(baseOptions.headerRowHeight) !== "undefined" ? baseOptions.headerRowHeight : 30;
+      baseOptions.rowHeight = baseOptions.rowHeight || 30;
+      baseOptions.maxVisibleRowCount = baseOptions.maxVisibleRowCount || 200;
+  
+      /**
+       * @ngdoc integer
+       * @name minRowsToShow
+       * @propertyOf ui.grid.class:GridOptions
+       * @description Minimum number of rows to show when the grid doesn't have a defined height. Defaults to "10".
+       */
+      baseOptions.minRowsToShow = typeof(baseOptions.minRowsToShow) !== "undefined" ? baseOptions.minRowsToShow : 10;
+  
+      baseOptions.showFooter = baseOptions.showFooter === true;
+      baseOptions.footerRowHeight = typeof(baseOptions.footerRowHeight) !== "undefined" ? baseOptions.footerRowHeight : 30;
+  
+      baseOptions.columnWidth = typeof(baseOptions.columnWidth) !== "undefined" ? baseOptions.columnWidth : 50;
+      baseOptions.maxVisibleColumnCount = typeof(baseOptions.maxVisibleColumnCount) !== "undefined" ? baseOptions.maxVisibleColumnCount : 200;
+  
+      // Turn virtualization on when number of data elements goes over this number
+      baseOptions.virtualizationThreshold = typeof(baseOptions.virtualizationThreshold) !== "undefined" ? baseOptions.virtualizationThreshold : 20;
+  
+      baseOptions.columnVirtualizationThreshold = typeof(baseOptions.columnVirtualizationThreshold) !== "undefined" ? baseOptions.columnVirtualizationThreshold : 10;
+  
+      // Extra rows to to render outside of the viewport
+      baseOptions.excessRows = typeof(baseOptions.excessRows) !== "undefined" ? baseOptions.excessRows : 4;
+      baseOptions.scrollThreshold = typeof(baseOptions.scrollThreshold) !== "undefined" ? baseOptions.scrollThreshold : 4;
+  
+      // Extra columns to to render outside of the viewport
+      baseOptions.excessColumns = typeof(baseOptions.excessColumns) !== "undefined" ? baseOptions.excessColumns : 4;
+      baseOptions.horizontalScrollThreshold = typeof(baseOptions.horizontalScrollThreshold) !== "undefined" ? baseOptions.horizontalScrollThreshold : 2;
+  
+      // Default time to throttle scroll events to.
+      baseOptions.scrollThrottle = typeof(baseOptions.scrollThrottle) !== "undefined" ? baseOptions.scrollThrottle : 70;
+  
+      /**
+       * @ngdoc boolean
+       * @name enableSorting
+       * @propertyOf ui.grid.class:GridOptions
+       * @description True by default. When enabled, this setting adds sort
+       * widgets to the column headers, allowing sorting of the data for the entire grid.
+       * Sorting can then be disabled on individual columns using the columnDefs.
+       */
+      baseOptions.enableSorting = baseOptions.enableSorting !== false;
+  
+      /**
+       * @ngdoc boolean
+       * @name enableFiltering
+       * @propertyOf ui.grid.class:GridOptions
+       * @description False by default. When enabled, this setting adds filter 
+       * boxes to each column header, allowing filtering within the column for the entire grid.
+       * Filtering can then be disabled on individual columns using the columnDefs. 
+       */
+      baseOptions.enableFiltering = baseOptions.enableFiltering === true;
+  
+      /**
+       * @ngdoc boolean
+       * @name enableColumnMenus
+       * @propertyOf ui.grid.class:GridOptions
+       * @description True by default. When enabled, this setting displays a column
+       * menu within each column.
+       */
+      baseOptions.enableColumnMenus = baseOptions.enableColumnMenus !== false;
+  
+      /**
+       * @ngdoc boolean
+       * @name enableScrollbars
+       * @propertyOf ui.grid.class:GridOptions
+       * @description True by default. When enabled, this settings enable vertical
+       * and horizontal scrollbar for grid.
+       */
+      baseOptions.enableScrollbars = baseOptions.enableScrollbars !== false;
+  
+      // Columns can't be smaller than 10 pixels
+      baseOptions.minimumColumnSize = typeof(baseOptions.minimumColumnSize) !== "undefined" ? baseOptions.minimumColumnSize : 10;
+  
+      /**
+       * @ngdoc function
+       * @name rowEquality
+       * @methodOf ui.grid.class:GridOptions
+       * @description By default, rows are compared using object equality.  This option can be overridden
+       * to compare on any data item property or function
+       * @param {object} entityA First Data Item to compare
+       * @param {object} entityB Second Data Item to compare
+       */
+      baseOptions.rowEquality = baseOptions.rowEquality || function(entityA, entityB) {
+        return entityA === entityB;
+      };
+  
+      /**
+       * @ngdoc string
+       * @name headerTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description Null by default. When provided, this setting uses a custom header
+       * template, rather than the default template. Can be set to either the name of a template file:
+       * <pre>  $scope.gridOptions.headerTemplate = 'header_template.html';</pre>
+       * inline html 
+       * <pre>  $scope.gridOptions.headerTemplate = '<div class="ui-grid-top-panel" style="text-align: center">I am a Custom Grid Header</div>'</pre>
+       * or the id of a precompiled template (TBD how to use this).  
+       * </br>Refer to the custom header tutorial for more information.
+       * If you want no header at all, you can set to an empty div:
+       * <pre>  $scope.gridOptions.headerTemplate = '<div></div>';</pre>
+       * 
+       * If you want to only have a static header, then you can set to static content.  If
+       * you want to tailor the existing column headers, then you should look at the
+       * current 'ui-grid-header.html' template in github as your starting point.
+       * 
+       */
+      baseOptions.headerTemplate = baseOptions.headerTemplate || null;
+  
+      /**
+       * @ngdoc string
+       * @name footerTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description (optional) Null by default. When provided, this setting uses a custom footer
+       * template. Can be set to either the name of a template file 'footer_template.html', inline html
+       * <pre>'<div class="ui-grid-bottom-panel" style="text-align: center">I am a Custom Grid Footer</div>'</pre>, or the id
+       * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
+       */
+      baseOptions.footerTemplate = baseOptions.footerTemplate || null;
+  
+      /**
+       * @ngdoc string
+       * @name rowTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description 'ui-grid/ui-grid-row' by default. When provided, this setting uses a 
+       * custom row template.  Can be set to either the name of a template file:
+       * <pre> $scope.gridOptions.rowTemplate = 'row_template.html';</pre>
+       * inline html 
+       * <pre>  $scope.gridOptions.rowTemplate = '<div style="background-color: aquamarine" ng-click="getExternalScopes().fnOne(row)" ng-repeat="col in colContainer.renderedColumns track by col.colDef.name" class="ui-grid-cell" ui-grid-cell></div>';</pre>
+       * or the id of a precompiled template (TBD how to use this) can be provided.  
+       * </br>Refer to the custom row template tutorial for more information.
+       */
+      baseOptions.rowTemplate = baseOptions.rowTemplate || 'ui-grid/ui-grid-row';
+      
+      return baseOptions;
+    }     
+  };
 
-    this.headerRowHeight = 30;
-    this.rowHeight = 30;
-    this.maxVisibleRowCount = 200;
-
-    /**
-     * @ngdoc integer
-     * @name minRowsToShow
-     * @propertyOf ui.grid.class:GridOptions
-     * @description Minimum number of rows to show when the grid doesn't have a defined height. Defaults to "10".
-     */
-    this.minRowsToShow = 10;
-
-    this.showFooter = false;
-    this.footerRowHeight = 30;
-
-    this.columnWidth = 50;
-    this.maxVisibleColumnCount = 200;
-
-    // Turn virtualization on when number of data elements goes over this number
-    this.virtualizationThreshold = 20;
-
-    this.columnVirtualizationThreshold = 10;
-
-    // Extra rows to to render outside of the viewport
-    this.excessRows = 4;
-    this.scrollThreshold = 4;
-
-    // Extra columns to to render outside of the viewport
-    this.excessColumns = 4;
-    this.horizontalScrollThreshold = 2;
-
-    // Default time to throttle scroll events to.
-    this.scrollThrottle = 70;
-
-    /**
-     * @ngdoc boolean
-     * @name enableSorting
-     * @propertyOf ui.grid.class:GridOptions
-     * @description True by default. When enabled, this setting adds sort
-     * widgets to the column headers, allowing sorting of the data for the entire grid.
-     * Sorting can then be disabled on individual columns using the columnDefs.
-     */
-    this.enableSorting = true;
-
-    /**
-     * @ngdoc boolean
-     * @name enableFiltering
-     * @propertyOf ui.grid.class:GridOptions
-     * @description False by default. When enabled, this setting adds filter 
-     * boxes to each column header, allowing filtering within the column for the entire grid.
-     * Filtering can then be disabled on individual columns using the columnDefs. 
-     */
-    this.enableFiltering = false;
-
-    /**
-     * @ngdoc boolean
-     * @name enableColumnMenus
-     * @propertyOf ui.grid.class:GridOptions
-     * @description True by default. When enabled, this setting displays a column
-     * menu within each column.
-     */
-    this.enableColumnMenus = true;
-
-    /**
-     * @ngdoc boolean
-     * @name enableScrollbars
-     * @propertyOf ui.grid.class:GridOptions
-     * @description True by default. When enabled, this settings enable vertical
-     * and horizontal scrollbar for grid.
-     */
-    this.enableScrollbars = true;
-
-    // Columns can't be smaller than 10 pixels
-    this.minimumColumnSize = 10;
-
-    /**
-     * @ngdoc function
-     * @name rowEquality
-     * @methodOf ui.grid.class:GridOptions
-     * @description By default, rows are compared using object equality.  This option can be overridden
-     * to compare on any data item property or function
-     * @param {object} entityA First Data Item to compare
-     * @param {object} entityB Second Data Item to compare
-     */
-    this.rowEquality = function(entityA, entityB) {
-      return entityA === entityB;
-    };
-
-    /**
-     * @ngdoc string
-     * @name headerTemplate
-     * @propertyOf ui.grid.class:GridOptions
-     * @description Null by default. When provided, this setting uses a custom header
-     * template, rather than the default template. Can be set to either the name of a template file:
-     * <pre>  $scope.gridOptions.headerTemplate = 'header_template.html';</pre>
-     * inline html 
-     * <pre>  $scope.gridOptions.headerTemplate = '<div class="ui-grid-top-panel" style="text-align: center">I am a Custom Grid Header</div>'</pre>
-     * or the id of a precompiled template (TBD how to use this).  
-     * </br>Refer to the custom header tutorial for more information.
-     * If you want no header at all, you can set to an empty div:
-     * <pre>  $scope.gridOptions.headerTemplate = '<div></div>';</pre>
-     * 
-     * If you want to only have a static header, then you can set to static content.  If
-     * you want to tailor the existing column headers, then you should look at the
-     * current 'ui-grid-header.html' template in github as your starting point.
-     * 
-     */
-    this.headerTemplate = null;
-
-    /**
-     * @ngdoc string
-     * @name footerTemplate
-     * @propertyOf ui.grid.class:GridOptions
-     * @description (optional) Null by default. When provided, this setting uses a custom footer
-     * template. Can be set to either the name of a template file 'footer_template.html', inline html
-     * <pre>'<div class="ui-grid-bottom-panel" style="text-align: center">I am a Custom Grid Footer</div>'</pre>, or the id
-     * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
-     */
-    this.footerTemplate = null;
-
-    /**
-     * @ngdoc string
-     * @name rowTemplate
-     * @propertyOf ui.grid.class:GridOptions
-     * @description 'ui-grid/ui-grid-row' by default. When provided, this setting uses a 
-     * custom row template.  Can be set to either the name of a template file:
-     * <pre> $scope.gridOptions.rowTemplate = 'row_template.html';</pre>
-     * inline html 
-     * <pre>  $scope.gridOptions.rowTemplate = '<div style="background-color: aquamarine" ng-click="getExternalScopes().fnOne(row)" ng-repeat="col in colContainer.renderedColumns track by col.colDef.name" class="ui-grid-cell" ui-grid-cell></div>';</pre>
-     * or the id of a precompiled template (TBD how to use this) can be provided.  
-     * </br>Refer to the custom row template tutorial for more information.
-     */
-    this.rowTemplate = 'ui-grid/ui-grid-row';
-  }
-
-  return GridOptions;
 
 }]);
 

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -1,0 +1,194 @@
+describe('GridOptions factory', function () {
+  var GridOptions;
+
+  beforeEach(module('ui.grid'));
+
+  beforeEach(inject(function (_GridOptions_) {
+    GridOptions = _GridOptions_;
+  }));
+
+
+ describe('initialize', function() {
+    it('defaults all options', function() {
+      var options = {};
+      expect( GridOptions.initialize(options) ).toEqual({
+        onRegisterApi: undefined,
+        data: [],
+        columnDefs: [],
+        excludeProperties: [ '$$hashKey' ],
+        enableRowHashing: true,
+        rowIdentity: jasmine.any(Function),
+        getRowIdentity: jasmine.any(Function),
+        headerRowHeight: 30,
+        rowHeight: 30,
+        maxVisibleRowCount: 200,
+        minRowsToShow: 10,
+        showFooter: false,
+        footerRowHeight: 30,
+        columnWidth: 50,
+        maxVisibleColumnCount: 200,
+        virtualizationThreshold: 20,
+        columnVirtualizationThreshold: 10,
+        excessRows: 4,
+        scrollThreshold: 4,
+        excessColumns: 4,
+        horizontalScrollThreshold: 2,
+        scrollThrottle: 70,
+        enableSorting: true,
+        enableFiltering: false,
+        enableColumnMenus: true,
+        enableScrollbars: true,
+        minimumColumnSize: 10,
+        rowEquality: jasmine.any(Function),
+        headerTemplate: null,
+        footerTemplate: null,
+        rowTemplate: 'ui-grid/ui-grid-row'
+      });
+    });
+
+    it('true and values', function() {
+      var testFunction = function() {};
+      var options = {
+        onRegisterApi: testFunction,
+        data: [ { name: 'x' } ],
+        columnDefs: [ { name: 'y' }],
+        excludeProperties: [ 'y' ],
+        enableRowHashing: true,
+        rowIdentity: testFunction,
+        getRowIdentity: testFunction,
+        headerRowHeight: 40,
+        rowHeight: 40,
+        maxVisibleRowCount: 20,
+        minRowsToShow: 15,
+        showFooter: true,
+        footerRowHeight: 50,
+        columnWidth: 60,
+        maxVisibleColumnCount: 25,
+        virtualizationThreshold: 27,
+        columnVirtualizationThreshold: 12,
+        excessRows: 5,
+        scrollThreshold: 6,
+        excessColumns: 7,
+        horizontalScrollThreshold: 3,
+        scrollThrottle: 75,
+        enableSorting: true,
+        enableFiltering: true,
+        enableColumnMenus: true,
+        enableScrollbars: true,
+        minimumColumnSize: 20,
+        rowEquality: testFunction,
+        headerTemplate: 'testHeader',
+        footerTemplate: 'testFooter',
+        rowTemplate: 'testRow',
+        extraOption: 'testExtraOption'
+      };
+      expect( GridOptions.initialize(options) ).toEqual({
+        onRegisterApi: testFunction,
+        data: [ { name: 'x' } ],
+        columnDefs: [ { name: 'y' }],
+        excludeProperties: [ 'y' ],
+        enableRowHashing: true,
+        rowIdentity: testFunction,
+        getRowIdentity: testFunction,
+        headerRowHeight: 40,
+        rowHeight: 40,
+        maxVisibleRowCount: 20,
+        minRowsToShow: 15,
+        showFooter: true,
+        footerRowHeight: 50,
+        columnWidth: 60,
+        maxVisibleColumnCount: 25,
+        virtualizationThreshold: 27,
+        columnVirtualizationThreshold: 12,
+        excessRows: 5,
+        scrollThreshold: 6,
+        excessColumns: 7,
+        horizontalScrollThreshold: 3,
+        scrollThrottle: 75,
+        enableSorting: true,
+        enableFiltering: true,
+        enableColumnMenus: true,
+        enableScrollbars: true,
+        minimumColumnSize: 20,
+        rowEquality: testFunction,
+        headerTemplate: 'testHeader',
+        footerTemplate: 'testFooter',
+        rowTemplate: 'testRow',
+        extraOption: 'testExtraOption'
+      });
+    });
+
+    it('false and values', function() {
+      var testFunction = function() {};
+      var options = {
+        onRegisterApi: testFunction,
+        data: [ { name: 'x' } ],
+        columnDefs: [ { name: 'y' }],
+        excludeProperties: [ 'y' ],
+        enableRowHashing: false,
+        rowIdentity: testFunction,
+        getRowIdentity: testFunction,
+        headerRowHeight: 40,
+        rowHeight: 40,
+        maxVisibleRowCount: 20,
+        minRowsToShow: 15,
+        showFooter: false,
+        footerRowHeight: 50,
+        columnWidth: 60,
+        maxVisibleColumnCount: 25,
+        virtualizationThreshold: 27,
+        columnVirtualizationThreshold: 12,
+        excessRows: 5,
+        scrollThreshold: 6,
+        excessColumns: 7,
+        horizontalScrollThreshold: 3,
+        scrollThrottle: 75,
+        enableSorting: false,
+        enableFiltering: false,
+        enableColumnMenus: false,
+        enableScrollbars: false,
+        minimumColumnSize: 10,
+        rowEquality: testFunction,
+        headerTemplate: 'testHeader',
+        footerTemplate: 'testFooter',
+        rowTemplate: 'testRow',
+        extraOption: 'testExtraOption'
+      };
+      expect( GridOptions.initialize(options) ).toEqual({
+        onRegisterApi: testFunction,
+        data: [ { name: 'x' } ],
+        columnDefs: [ { name: 'y' }],
+        excludeProperties: [ 'y' ],
+        enableRowHashing: false,
+        rowIdentity: testFunction,
+        getRowIdentity: testFunction,
+        headerRowHeight: 40,
+        rowHeight: 40,
+        maxVisibleRowCount: 20,
+        minRowsToShow: 15,
+        showFooter: false,
+        footerRowHeight: 50,
+        columnWidth: 60,
+        maxVisibleColumnCount: 25,
+        virtualizationThreshold: 27,
+        columnVirtualizationThreshold: 12,
+        excessRows: 5,
+        scrollThreshold: 6,
+        excessColumns: 7,
+        horizontalScrollThreshold: 3,
+        scrollThrottle: 75,
+        enableSorting: false,
+        enableFiltering: false,
+        enableColumnMenus: false,
+        enableScrollbars: false,
+        minimumColumnSize: 10,
+        rowEquality: testFunction,
+        headerTemplate: 'testHeader',
+        footerTemplate: 'testFooter',
+        rowTemplate: 'testRow',
+        extraOption: 'testExtraOption'
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
The current arrangement is to shallow copy gridOptions, which
means changes to scalar values are not automatically noticed.

Change to reference gridOptions directly, defaulting any necessary
values over the top.  This then allows options to be referenced
and updated dynamically.
