### PR TITLE
Client side pagination feature

### DIFF
--- a/misc/tutorial/214_pagination.ngdoc
+++ b/misc/tutorial/214_pagination.ngdoc
@@ -1,0 +1,49 @@
+@ngdoc overview
+@name Tutorial: 214 Pagination
+@description
+
+When pagination is enabled, the data is displayed in pages that can be browsed using a page selector.
+
+@example
+<example module="app">
+  <file name="app.js">
+    var app = angular.module('app', ['ui.grid', 'ui.grid.pagination']);
+
+    app.controller('MainCtrl', ['$scope', '$http', function ($scope, $http) {
+      $scope.gridOptions = {};
+
+      $scope.gridOptions.columnDefs = [
+        { name:'name'},
+        { name:'gender' },
+        { name:'company' }
+      ];
+
+      $scope.gridOptions.onRegisterApi = function (gridApi) {
+        $scope.gridApi = gridApi;
+      }
+
+      $http.get('/data/100.json')
+        .success(function(data) {
+          $scope.gridOptions.data = data;
+        });
+    }]);
+  </file>
+  <file name="index.html">
+    <div ng-controller="MainCtrl">
+      <p>Page: {{ gridApi.pagination.getPage() }}</p>
+      <p>Total pages: {{ gridApi.pagination.getTotalPages() }}</p>
+      <button type="button" class="btn btn-success" ng-click="gridApi.pagination.previousPage()">
+        previous page
+      </button>
+      <button type="button" class="btn btn-success" ng-click="gridApi.pagination.nextPage()">
+        next page
+      </button>
+      <div ui-grid="gridOptions" ui-grid-pagination class="grid"></div>
+    </div>
+  </file>
+  <file name="main.css">
+    .grid {
+      width: 500px;
+    }
+  </file>
+</example>

--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -1,0 +1,168 @@
+(function () {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @name ui.grid.pagination
+   *
+   * @description
+   *
+   * #ui.grid.pagination
+   * This module provides pagination support to ui-grid
+   */
+  var module = angular.module('ui.grid.pagination', ['ui.grid']);
+
+  /**
+   * @ngdoc service
+   * @name ui.grid.pagination.service:uiGridPaginationService
+   *
+   * @description Service for the pagination feature
+   */
+  module.service('uiGridPaginationService', function () {
+    var service = {
+
+      /**
+       * @ngdoc method
+       * @name initializeGrid
+       * @methodOf ui.grid.pagination.service:uiGridPaginationService
+       * @description Attaches the service to a certain grid
+       * @param {Grid} grid The grid we want to work with
+       */
+      initializeGrid: function (grid) {
+        service.defaultGridOptions(grid.options);
+        grid.pagination = {page: 1, totalPages: 1};
+
+        /**
+         * @ngdoc object
+         * @name ui.grid.pagination.api:PublicAPI
+         *
+         * @description Public API for the pagination feature
+         */
+        var publicApi = {
+          methods: {
+            pagination: {
+              /**
+               * @ngdoc method
+               * @name getPage
+               * @methodOf ui.grid.pagination.api:PublicAPI
+               * @description Returns the number of the current page
+               */
+              getPage: function () {
+                return grid.pagination.page;
+              },
+              /**
+               * @ngdoc method
+               * @name getTotalPages
+               * @methodOf ui.grid.pagination.api:PublicAPI
+               * @description Returns the total number of pages
+               */
+              getTotalPages: function () {
+                return grid.pagination.totalPages;
+              },
+              /**
+               * @ngdoc method
+               * @name nextPage
+               * @methodOf ui.grid.pagination.api:PublicAPI
+               * @description Moves to the next page, if possible
+               */
+              nextPage: function () {
+                grid.pagination.page++;
+                grid.refresh();
+              },
+              /**
+               * @ngdoc method
+               * @name previousPage
+               * @methodOf ui.grid.pagination.api:PublicAPI
+               * @description Moves to the previous page, if we're not on the first page
+               */
+              previousPage: function () {
+                grid.pagination.page = Math.max(1, grid.pagination.page - 1);
+                grid.refresh();
+              },
+              seek: function (page) {
+                if (!angular.isNumber(page) || page < 1) {
+                  throw 'Invalid page number: ' + page;
+                }
+
+                grid.pagination.page = page;
+                grid.refresh();
+              }
+            }
+          }
+        };
+        grid.api.registerMethodsFromObject(publicApi.methods);
+        grid.registerRowsProcessor(function (renderableRows) {
+          if (!grid.options.enablePagination) {
+            return renderableRows;
+          }
+          grid.pagination.totalPages = Math.max(
+            1,
+            Math.ceil(renderableRows.length / grid.options.rowsPerPage)
+          );
+
+          var firstRow = (grid.pagination.page - 1) * grid.options.rowsPerPage;
+          if (firstRow >= renderableRows.length) {
+            grid.pagination.page = grid.pagination.totalPages;
+            firstRow = (grid.pagination.page - 1) * grid.options.rowsPerPage;
+          }
+
+          return renderableRows.slice(
+            firstRow,
+            firstRow + grid.options.rowsPerPage
+          );
+        });
+      },
+
+      defaultGridOptions: function (gridOptions) {
+        /**
+         *  @ngdoc object
+         *  @name ui.grid.pagination.api:GridOptions
+         *
+         *  @description GridOptions for the pagination feature, these are available to be
+         *  set using the ui-grid {@link ui.grid.class:GridOptions gridOptions}
+         */
+
+        /**
+         *  @ngdoc object
+         *  @name enablePagination
+         *  @propertyOf  ui.grid.pagination.api:GridOptions
+         *  @description Enable pagination for this grid
+         *  <br/>Defaults to true
+         */
+        gridOptions.enablePagination = gridOptions.enablePagination !== false;
+
+        /**
+         *  @ngdoc object
+         *  @name rowsPerPage
+         *  @propertyOf  ui.grid.pagination.api:GridOptions
+         *  @description The number of rows that should be displayed per page
+         *  <br/>Defaults to 10
+         */
+        gridOptions.rowsPerPage = angular.isNumber(gridOptions.rowsPerPage) ? gridOptions.rowsPerPage : 10;
+      }
+    };
+
+    return service;
+  });
+
+  /**
+   * @ngdoc directive
+   * @name ui.grid.pagination.directive:uiGridPagination
+   * @element div
+   * @restrict A
+   *
+   * @description Adds pagination support to a grid.
+   */
+  module.directive('uiGridPagination', ['uiGridPaginationService', function (uiGridPaginationService) {
+    return {
+      priority: -400,
+      scope: false,
+      require: '^uiGrid',
+      link: {
+        pre: function (scope, element, attrs, uiGridCtrl) {
+          uiGridPaginationService.initializeGrid(uiGridCtrl.grid);
+        }
+      }
+    };
+  }]);
+})();

--- a/src/features/pagination/test/pagination.spec.js
+++ b/src/features/pagination/test/pagination.spec.js
@@ -1,0 +1,173 @@
+describe('ui.grid.pagination uiGridPaginationService', function () {
+  'use strict';
+
+  var gridApi;
+  var gridElement;
+  var $rootScope;
+
+  beforeEach(module('ui.grid'));
+  beforeEach(module('ui.grid.pagination'));
+
+  beforeEach(inject(function (_$rootScope_, $compile) {
+    $rootScope = _$rootScope_;
+
+    $rootScope.gridOptions = {
+      columnDefs: [
+        {name: 'col1'},
+        {name: 'col2'},
+        {name: 'col3'},
+        {name: 'col4'}
+      ],
+      data: [
+        {col1: '1_1', col2: 'G', col3: '1_3', col4: '1_4'},
+        {col1: '2_1', col2: 'B', col3: '2_3', col4: '2_4'},
+        {col1: '3_1', col2: 'K', col3: '3_3', col4: '3_4'},
+        {col1: '4_1', col2: 'J', col3: '4_3', col4: '4_4'},
+        {col1: '5_1', col2: 'A', col3: '5_3', col4: '5_4'},
+        {col1: '6_1', col2: 'C', col3: '6_3', col4: '6_4'},
+        {col1: '7_1', col2: 'D', col3: '7_3', col4: '7_4'},
+        {col1: '8_1', col2: 'P', col3: '8_3', col4: '8_4'},
+        {col1: '9_1', col2: 'Q', col3: '9_3', col4: '9_4'},
+        {col1: '10_1', col2: 'X', col3: '10_3', col4: '10_4'},
+        {col1: '11_1', col2: 'H', col3: '11_3', col4: '11_4'},
+        {col1: '12_1', col2: 'Y', col3: '12_3', col4: '12_4'},
+        {col1: '13_1', col2: 'I', col3: '13_3', col4: '13_4'},
+        {col1: '14_1', col2: 'L', col3: '14_3', col4: '14_4'},
+        {col1: '15_1', col2: 'T', col3: '15_3', col4: '15_4'},
+        {col1: '16_1', col2: 'W', col3: '16_3', col4: '16_4'},
+        {col1: '17_1', col2: 'E', col3: '17_3', col4: '17_4'},
+        {col1: '18_1', col2: 'N', col3: '18_3', col4: '18_4'},
+        {col1: '19_1', col2: 'F', col3: '19_3', col4: '19_4'},
+        {col1: '20_1', col2: 'Z', col3: '20_3', col4: '20_4'},
+        {col1: '21_1', col2: 'V', col3: '21_3', col4: '21_4'},
+        {col1: '22_1', col2: 'O', col3: '22_3', col4: '22_4'},
+        {col1: '23_1', col2: 'M', col3: '23_3', col4: '23_4'},
+        {col1: '24_1', col2: 'U', col3: '24_3', col4: '24_4'},
+        {col1: '25_1', col2: 'S', col3: '25_3', col4: '25_4'},
+        {col1: '26_1', col2: 'R', col3: '26_3', col4: '26_4'}
+      ],
+      onRegisterApi: function (api) {
+        gridApi = api;
+      },
+      enablePagination: true,
+      rowsPerPage: 10
+    };
+
+    var element = angular.element('<div ui-grid="gridOptions" ui-grid-pagination></div>');
+    document.body.appendChild(element[0]);
+    gridElement = $compile(element)($rootScope);
+    $rootScope.$digest();
+  }));
+
+  describe('initialisation', function () {
+    it('registers the API and methods', function () {
+      expect(gridApi.pagination.getPage).toEqual(jasmine.any(Function));
+      expect(gridApi.pagination.getTotalPages).toEqual(jasmine.any(Function));
+      expect(gridApi.pagination.nextPage).toEqual(jasmine.any(Function));
+      expect(gridApi.pagination.previousPage).toEqual(jasmine.any(Function));
+      expect(gridApi.pagination.seek).toEqual(jasmine.any(Function));
+    });
+  });
+
+  describe('pagination', function () {
+    it('starts at page 1 with 10 records', function () {
+      var gridRows = gridElement.find('div.ui-grid-row');
+
+      expect(gridApi.pagination.getPage()).toBe(1);
+      expect(gridRows.length).toBe(10);
+
+      var firstCell = gridRows.eq(0).find('div.ui-grid-cell:first-child');
+      expect(firstCell.text()).toBe('1_1');
+
+      var lastCell = gridRows.eq(9).find('div.ui-grid-cell:last-child');
+      expect(lastCell.text()).toBe('10_4');
+    });
+
+    it('calculates the total number of pages correctly', function () {
+      expect(gridApi.pagination.getTotalPages()).toBe(3);
+    });
+
+    it('displays page 2 if I call nextPage()', function () {
+      gridApi.pagination.nextPage();
+      $rootScope.$digest();
+
+      var gridRows = gridElement.find('div.ui-grid-row');
+
+      expect(gridApi.pagination.getPage()).toBe(2);
+      expect(gridRows.length).toBe(10);
+
+      var firstCell = gridRows.eq(0).find('div.ui-grid-cell:first-child');
+      expect(firstCell.text()).toBe('11_1');
+
+      var lastCell = gridRows.eq(9).find('div.ui-grid-cell:last-child');
+      expect(lastCell.text()).toBe('20_4');
+    });
+
+    it('displays only 6 rows on page 3', function () {
+      gridApi.pagination.seek(3);
+      $rootScope.$digest();
+
+      var gridRows = gridElement.find('div.ui-grid-row');
+
+      expect(gridApi.pagination.getPage()).toBe(3);
+      expect(gridRows.length).toBe(6);
+
+      var firstCell = gridRows.eq(0).find('div.ui-grid-cell:first-child');
+      expect(firstCell.text()).toBe('21_1');
+
+      var lastCell = gridRows.eq(5).find('div.ui-grid-cell:last-child');
+      expect(lastCell.text()).toBe('26_4');
+    });
+
+    it('displays page 1 if I move to page 2 and back again', function () {
+      gridApi.pagination.nextPage();
+      gridApi.pagination.previousPage();
+      $rootScope.$digest();
+
+      expect(gridApi.pagination.getPage()).toBe(1);
+    });
+
+    it('does not allow to move before page 1', function () {
+      gridApi.pagination.previousPage();
+      $rootScope.$digest();
+
+      expect(gridApi.pagination.getPage()).toBe(1);
+    });
+
+    it('does not allow to move past page 3', function () {
+      gridApi.pagination.nextPage();
+      gridApi.pagination.nextPage();
+      gridApi.pagination.nextPage();
+      $rootScope.$digest();
+
+      expect(gridApi.pagination.getPage()).toBe(3);
+    });
+
+    it('paginates correctly on a sorted grid', function() {
+      gridApi.grid.sortColumn(gridApi.grid.columns[1]).then(function () {
+        gridApi.grid.refresh();
+      });
+      $rootScope.$digest();
+
+      var gridRows = gridElement.find('div.ui-grid-row');
+      expect(gridApi.pagination.getPage()).toBe(1);
+      expect(gridRows.eq(0).find('div.ui-grid-cell').eq(1).text()).toBe('A');
+      expect(gridRows.eq(1).find('div.ui-grid-cell').eq(1).text()).toBe('B');
+      expect(gridRows.eq(2).find('div.ui-grid-cell').eq(1).text()).toBe('C');
+      expect(gridRows.eq(3).find('div.ui-grid-cell').eq(1).text()).toBe('D');
+      expect(gridRows.eq(4).find('div.ui-grid-cell').eq(1).text()).toBe('E');
+      expect(gridRows.eq(5).find('div.ui-grid-cell').eq(1).text()).toBe('F');
+      expect(gridRows.eq(6).find('div.ui-grid-cell').eq(1).text()).toBe('G');
+      expect(gridRows.eq(7).find('div.ui-grid-cell').eq(1).text()).toBe('H');
+      expect(gridRows.eq(8).find('div.ui-grid-cell').eq(1).text()).toBe('I');
+      expect(gridRows.eq(9).find('div.ui-grid-cell').eq(1).text()).toBe('J');
+
+      gridApi.pagination.nextPage();
+      $rootScope.$digest();
+
+      gridRows = gridElement.find('div.ui-grid-row');
+      expect(gridApi.pagination.getPage()).toBe(2);
+      expect(gridRows.eq(0).find('div.ui-grid-cell').eq(1).text()).toBe('K');
+    });
+  });
+});


### PR DESCRIPTION
This plugin enables client side pagination as requested in #1367.

Having pagination enabled, the grid renders only a configured number of records (defaults to 10). Via API methods, you can move to the next page, the previous page or specify a page you want to jump to. Currently, the user would have to build his own pagination controls outside the grid. But I would be willing to build a pagination bar into the grid if you decide to merge my feature.

This feature is obviously only useful, if the grid knows about the complete data set. You should not combine it with infinite scroll.
