### PR TITLE
Enabling Cell selection on mobile browsers

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -646,7 +646,7 @@
             }
 
             function registerRowSelectionEvents() {
-              $elm.on('click', function (evt) {
+              $elm.on('click touchend', function (evt) {
                 if (evt.shiftKey) {
                   uiGridSelectionService.shiftSelect($scope.grid, $scope.row, $scope.grid.options.multiSelect);
                 }


### PR DESCRIPTION
Adding the touchend event to the row selection event, so that selection works on mobile browsers. This is a fix for Issue https://github.com/angular-ui/ng-grid/issues/1759. Similar in nature to these fixes https://github.com/angular-ui/ng-grid/commit/4bb2d6996aad6463155bcd01b1521441cab45270 for Issue https://github.com/angular-ui/ng-grid/issues/1551
