### PR TITLE
Fixing selection problem with mobile scroll

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -646,7 +646,9 @@
             }
 
             function registerRowSelectionEvents() {
-              $elm.on('click touchend', function (evt) {
+              var touchStartTime = 0;
+              var touchTimeout = 300;
+              var selectCells = function(evt){
                 if (evt.shiftKey) {
                   uiGridSelectionService.shiftSelect($scope.grid, $scope.row, $scope.grid.options.multiSelect);
                 }
@@ -657,6 +659,24 @@
                   uiGridSelectionService.toggleRowSelection($scope.grid, $scope.row, ($scope.grid.options.multiSelect && !$scope.grid.options.modifierKeysToMultiSelect), $scope.grid.options.noUnselect);
                 }
                 $scope.$apply();
+              };
+
+              $elm.on('touchstart', function(event) {
+                touchStartTime = (new Date()).getTime();
+              });
+
+              $elm.on('touchend', function (evt) {
+                var touchEndTime = (new Date()).getTime();
+                var touchTime = touchEndTime - touchStartTime;
+
+                if (touchTime < touchTimeout ) {
+                  // short touch
+                  selectCells(evt);
+                }
+              });
+
+              $elm.on('click', function (evt) {
+                selectCells(evt);
               });
             }
           }


### PR DESCRIPTION
These changes allow someone to scroll the grid on a mobile browser without inadvertently selecting a row, by adding a timeout. Short touches will select a row. Long touches, like a scroll, will not. The click event behavior is unchanged, so desktop browsers will behave the same. Related to Issues  https://github.com/angular-ui/ng-grid/issues/1759 and https://github.com/angular-ui/ng-grid/issues/1551 and previous commit https://github.com/angular-ui/ng-grid/commit/4bb2d6996aad6463155bcd01b1521441cab45270
