### PR TITLE
The module dependency is currently named ui.grid instead of ngGrid.

### DIFF
--- a/partials/gettingStartedPage.html
+++ b/partials/gettingStartedPage.html
@@ -8,7 +8,7 @@
 				<ol>
 					<li>Add references to <a href="http://code.jquery.com/">jQuery</a> and <a href="http://ajax.googleapis.com/ajax/libs/angularjs/1.0.4/angular.min.js">AngularJS</a>.</li>
 					<li>Add references to <a href="https://github.com/angular-ui/ng-grid">ngGrid</a>'s javascript and css files.</li>
-					<li>Where you declare your app module, add ngGrid:<br /> <code>angular.module('myApp',['ngGrid']);</code><br />If you use <a target="blank" href="https://github.com/angular/angular-seed">angular seed</a>, it is in your app.js file.</li>
+					<li>Where you declare your app module, add ui.grid:<br /> <code>angular.module('myApp',['ui.grid']);</code><br />If you use <a target="blank" href="https://github.com/angular/angular-seed">angular seed</a>, it is in your app.js file.</li>
 					<li>In your html file within the controller where you plan to use ng-grid, add:<br /><code>&lt;div class="gridStyle" ng-grid="gridOptions"&gt;&lt;/div&gt;</code><br/>gridOptions is the variable we are going to bind to where we will initialize our grid options.</li>
 					<li>We are going to define a basic style for our grid in style.css:
 					<pre style="margin-top:10px" class="prettyprint">.gridStyle {
@@ -57,7 +57,7 @@
 }</pre>
 		<h3>Javascript:</h3>
 		<pre class="prettyprint linenums">// main.js
-var app = angular.module('myApp', ['ngGrid']);
+var app = angular.module('myApp', ['ui.grid']);
 app.controller('MyCtrl', function($scope) {
     $scope.myData = [{name: "Moroni", age: 50},
                      {name: "Tiancum", age: 43},


### PR DESCRIPTION
I'm currently using the 3.0.0-rc.12 build of ng-grid. The github page "getting starting" guide says to use the module "ngGrid", when actually the module is currently named "ui.grid". The current directions result in the module not being found.
