### PR TITLE
Fix asterisk widths on columns tweak

### DIFF
--- a/src/js/core/directives/ui-grid-header.js
+++ b/src/js/core/directives/ui-grid-header.js
@@ -91,7 +91,7 @@
                   canvasWidth = 0,
                   asteriskNum = 0,
                   leftoverWidth = availableWidth,
-				  autoWidth = 0,
+                  autoWidth = 0,
                   hasVariableWidth = false;
               
               var getColWidth = function(column){
@@ -143,10 +143,10 @@
                 }
                 column.drawnWidth = Math.floor(colWidth);
                 canvasWidth += column.drawnWidth;
-				if (column.widthType === "auto") {
-                    autoWidth += column.drawnWidth;
+                if (column.widthType === "auto") {
+                  autoWidth += column.drawnWidth;
                 } else {
-                    leftoverWidth -= column.drawnWidth;
+                  leftoverWidth -= column.drawnWidth;
                 }
               });
               leftoverWidth = leftoverWidth - autoWidth;


### PR DESCRIPTION
This is a tweak for #1927. Subtracting the auto width(s) from the leftoverWidth reduces the width of oneAsterisk if there is more than one column. i.e. leftoverWidth = 400, the first gets 200 (400/2) and the second gets 100 (200/2). Instead, I add up the autoWidths, then subtract that from leftoverWidth before doling out the extra.
