### PR TITLE
Fix for issue #1924 - Corrected footer display when there is no aggregationType for a column

### DIFF
--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -652,7 +652,7 @@ angular.module('ui.grid')
         return self.getAggregationText('aggregation.max', Math.max.apply(null, cellValues));
       }
       else {
-        return null;
+        return '\u00A0';
       }
     };
     


### PR DESCRIPTION
The current template will place an empty string when there is no aggregate defined. This causes the vertical bar to smoosh as it takes up no height. Adding an nbsp solves the issue cleanly. 
