### PR TITLE
recalculates header height when it changes visible state

### DIFF
--- a/src/js/core/directives/ui-grid-render-container.js
+++ b/src/js/core/directives/ui-grid-render-container.js
@@ -367,7 +367,7 @@
               }
               // Otherwise if the render container has an INNER header height, use that on the header cells (so that all the header cells are the same height and those that have less elements don't have undersized borders)
               else if (renderContainer.innerHeaderHeight !== undefined && renderContainer.innerHeaderHeight !== null && renderContainer.innerHeaderHeight > 0) {
-                ret += '\n .grid' + uiGridCtrl.grid.id + ' .ui-grid-render-container-' + $scope.containerId + ' .ui-grid-header-cell { height: ' + renderContainer.innerHeaderHeight + 'px; }';
+                ret += '\n .grid' + uiGridCtrl.grid.id + ' .ui-grid-render-container-' + $scope.containerId + ' .ui-grid-header-cell { height }';
               }
 
               return ret;

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1193,7 +1193,7 @@ angular.module('ui.grid')
     }
 
     self.refreshCanceller = $timeout(function () {
-      self.refreshCanvas(true);
+      self.refreshCanvas();
     });
 
     self.refreshCanceller.then(function () {
@@ -1605,9 +1605,7 @@ angular.module('ui.grid')
   Grid.prototype.refreshCanvas = function(buildStyles) {
     var self = this;
     
-    if (buildStyles) {
-      self.buildStyles();
-    }
+
 
     var p = $q.defer();
 
@@ -1618,10 +1616,15 @@ angular.module('ui.grid')
         var container = self.renderContainers[containerId];
 
         if (container.header) {
+          container.explicitHeaderHeight = null;
           containerHeadersToRecalc.push(container);
         }
       }
     }
+
+    if (buildStyles) {
+      self.buildStyles();
+    }    
 
     if (containerHeadersToRecalc.length > 0) {
       // Putting in a timeout as it's not calculating after the grid element is rendered and filled out
@@ -1670,6 +1673,7 @@ angular.module('ui.grid')
           // If this header's height is less than another header's height, then explicitly set it so they're the same and one isn't all offset and weird looking
           if (container.headerHeight < maxHeight) {
             container.explicitHeaderHeight = maxHeight;
+            rebuildStyles = true;
           }
         }
 


### PR DESCRIPTION
If columns with only little headers are shown and columns with huge headers are hidden and we want to show hidden columns then height of header row will be not recalculated, so this commit fixes it
[plunker example](http://plnkr.co/edit/GpAjskivh1OFl1mLuVxH?p=preview)
