### PR TITLE
Fix #1955 (expandable): Left panel features coexistance

### DIFF
--- a/misc/tutorial/306_expandable_grid.ngdoc
+++ b/misc/tutorial/306_expandable_grid.ngdoc
@@ -30,7 +30,7 @@ SubGrid nesting can be done upto multiple levels.
 @example
 <example module="app">
   <file name="app.js">
-    var app = angular.module('app', ['ui.grid', 'ui.grid.expandable']);
+    var app = angular.module('app', ['ui.grid', 'ui.grid.expandable', 'ui.grid.selection', 'ui.grid.pinning']);
 
     app.controller('MainCtrl', ['$scope', '$http', '$log', function ($scope, $http, $log) {
       $scope.gridOptions = {
@@ -39,7 +39,7 @@ SubGrid nesting can be done upto multiple levels.
       }
 
       $scope.gridOptions.columnDefs = [
-        { name: 'id'},
+        { name: 'id' },
         { name: 'name'},
         { name: 'age'},
         { name: 'address.city'}
@@ -68,6 +68,32 @@ SubGrid nesting can be done upto multiple levels.
           $scope.gridApi.expandable.collapseAllRows();
         }
     }]);
+
+    app.controller('SecondCtrl', ['$scope', '$http', '$log', function ($scope, $http, $log) {
+          $scope.gridOptions = {
+            enableRowSelection: true,
+            expandableRowTemplate: 'expandableRowTemplate.html',
+            expandableRowHeight: 150
+          }
+
+          $scope.gridOptions.columnDefs = [
+            { name: 'id', pinnedLeft:true },
+            { name: 'name'},
+            { name: 'age'},
+            { name: 'address.city'}
+          ];
+
+          $http.get('/data/500_complex.json')
+            .success(function(data) {
+              for(i = 0; i < data.length; i++){
+                data[i].subGridOptions = {
+                  columnDefs: [ {name:"Id", field:"id"},{name:"Name", field:"name"} ],
+                  data: data[i].friends
+                }
+              }
+              $scope.gridOptions.data = data;
+            });
+        }]);
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl">
@@ -76,6 +102,10 @@ SubGrid nesting can be done upto multiple levels.
         <input type="button" class="btn btn-small" ng-click="collapseAllRows()" value="Collapse All"/>
       </div>
       <div ui-grid="gridOptions" ui-grid-pinning ui-grid-expandable class="grid"></div>
+    </div>
+    Expandable rows works with checkboxes from selection and left pins
+    <div ng-controller="SecondCtrl">
+       <div ui-grid="gridOptions" ui-grid-pinning ui-grid-expandable ui-grid-selection class="grid"></div>
     </div>
   </file>
   <file name="main.css">

--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -279,7 +279,13 @@
 
                   function updateRowContainerWidth() {
                       var grid = $scope.grid;
-                      var colWidth = grid.getColumn('expandableButtons').width;
+                      var colWidth = 0;
+                      angular.forEach(grid.columns, function (column) {
+                          if (column.renderContainer === 'left') {
+                            colWidth += column.width;
+                          }
+                      });
+                      colWidth = Math.floor(colWidth);
                       return '.grid' + grid.id + ' .ui-grid-pinned-container-' + $scope.colContainer.name + ', .grid' + grid.id +
                           ' .ui-grid-pinned-container-' + $scope.colContainer.name + ' .ui-grid-render-container-' + $scope.colContainer.name +
                           ' .ui-grid-viewport .ui-grid-canvas .ui-grid-row { width: ' + colWidth + 'px; }';

--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -516,7 +516,7 @@
                 var selectionRowHeaderDef = {
                   name: uiGridSelectionConstants.selectionRowHeaderColName,
                   displayName: '',
-                  width: 30,
+                  width: 40,
                   cellTemplate: 'ui-grid/selectionRowHeader',
                   headerCellTemplate: 'ui-grid/selectionHeaderCell',
                   enableColumnResizing: false,


### PR DESCRIPTION
Changed so that the width of the left container is calculated depending on all columns in it. Without Math.floor() the left container takes too much space when left pinning a column (thus pushing the body beneath it), I guess this has something to do with rounding issues elsewhere. I also included a second example in expandable tutorial where the coexistance of these features that utilizes the left renderContainer can be verified.
