### PR TITLE
Fix callDataChangeCallbacks - pass grid to callback

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -342,7 +342,7 @@ angular.module('ui.grid')
            type === uiGridConstants.dataChange.ALL ) {
         callback.callback( this );
       }
-    });
+    }, this);
   };
   
   /**


### PR DESCRIPTION
callback.callback(this) was passing window instead of the grid.
