### PR TITLE
Put header text in a span so it can be styled

### DIFF
--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -1,7 +1,7 @@
 <div ng-class="{ 'sortable': sortable }">
   <div class="ui-grid-vertical-bar">&nbsp;</div>
   <div class="ui-grid-cell-contents" col-index="renderIndex">
-    {{ col.displayName CUSTOM_FILTERS }}
+    <span>{{ col.displayName CUSTOM_FILTERS }}</span>
 
     <span ui-grid-visible="col.sort.direction" ng-class="{ 'ui-grid-icon-up-dir': col.sort.direction == asc, 'ui-grid-icon-down-dir': col.sort.direction == desc, 'ui-grid-icon-blank': !col.sort.direction }">
       &nbsp;


### PR DESCRIPTION
Putting text-decoration: underline on the header extends the underline past the up/down icon. Add span so it can be styled with span:first-child
