### PR TITLE
Use local rather than global path bower install

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
         }
       },
       'bower-install': {
-        command: 'bower install'
+        command: 'node ./node_modules/bower/bin/bower install'
       }
     },
 


### PR DESCRIPTION
This brings bower handling in line with protractor, and is needed for
those who don't actually have enough admin rights to have a
globally installed bower command. It also means that we can be
sure we get the version of bower we asked for in package.json.
