### PR TITLE
Move scrollbar bottom to account for viewport adjustments

### DIFF
--- a/src/js/core/directives/ui-grid-native-scrollbar.js
+++ b/src/js/core/directives/ui-grid-native-scrollbar.js
@@ -107,6 +107,10 @@
           if (grid.options.showFooter) {
             bottom -= 1;
           }
+          
+          var adjustment = colContainer.getViewportAdjustment();
+          bottom -= adjustment.height;
+          
           var ondemand = grid.options.enableHorizontalScrollbar === uiGridConstants.scrollbars.WHEN_NEEDED ? "overflow-x:auto" : "";
           var ret = '.grid' + grid.id + ' .ui-grid-render-container-' + containerCtrl.containerId + ' .ui-grid-native-scrollbar.horizontal { bottom: ' + bottom + 'px;' +ondemand + ' }';
           ret += '.grid' + grid.id + ' .ui-grid-render-container-' + containerCtrl.containerId + ' .ui-grid-native-scrollbar.horizontal .contents { width: ' + w + 'px; }';


### PR DESCRIPTION
When there is a panel below the render containers, the horizontal scroll bar does not account for it.

Not sure how often this will happen, but a more dedicated panel below all the render containers would be nice.
