### PR TITLE
Fix #2080(gridApi): change getVisibleRows to use visibleCache

### DIFF
--- a/src/js/core/factories/GridApi.js
+++ b/src/js/core/factories/GridApi.js
@@ -82,7 +82,7 @@
            * @param {Grid} grid the grid you want to get visible rows from
            * @returns {array} an array of gridRow 
            */
-          this.registerMethod( 'core', 'getVisibleRows', GridRow.prototype.getVisibleRows );
+          this.registerMethod( 'core', 'getVisibleRows', this.grid.getVisibleRows );
           
           /**
            * @ngdoc event

--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -130,22 +130,6 @@ angular.module('ui.grid')
     }        
   };
 
-  /**
-   * @ngdoc function
-   * @name getVisibleRows
-   * @methodOf ui.grid.class:GridRow
-   * @description Returns all the visible rows
-   * @param {Grid} grid the grid to return rows from
-   * @returns {array} rows that are currently visible, returns the
-   * GridRows rather than gridRow.entity
-   * TODO: should this come from visible row cache instead?
-   */
-  GridRow.prototype.getVisibleRows = function ( grid ) {
-    return grid.rows.filter(function (row) {
-      return row.visible;
-    });
-  };  
-
   return GridRow;
 }]);
 

--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -40,7 +40,7 @@ module.exports = {
      */
     expectRowCount: function( gridId, expectedNumRows ) {
 
-      var rows = element( by.id( gridId ) ).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid') );
+      var rows = element( by.id( gridId ) ).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index') );
       expect(rows.count()).toEqual(expectedNumRows);
     },
     
@@ -169,7 +169,7 @@ module.exports = {
      * 
      */
     dataCell: function( gridId, fetchRow, fetchCol ) {
-      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid').row( fetchRow )  );
+      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index').row( fetchRow )  );
       return row.element( by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.colDef.name').row( fetchCol ));
     },
 
@@ -240,7 +240,7 @@ module.exports = {
      * 
      */
     expectCellValueMatch: function( gridId, expectedRow, expectedCol, expectedValue ) {
-      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid').row( expectedRow )  );
+      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index').row( expectedRow )  );
       expect(row.element( by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.colDef.name').row(expectedCol)).getText()).toMatch(expectedValue);
     },
     
@@ -263,7 +263,7 @@ module.exports = {
      * 
      */
     expectRowValuesMatch: function( gridId, expectedRow, expectedValueArray ) {
-      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid').row( expectedRow )  );
+      var row = element( by.id( gridId ) ).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index').row( expectedRow )  );
 
       for ( var i = 0; i < expectedValueArray.length; i++){
         expect(row.element( by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.colDef.name').row(i)).getText()).toMatch(expectedValueArray[i], 'Expected to match: ' + expectedValueArray[i] + ' in column: ' + i);

--- a/test/unit/core/factories/GridRow.spec.js
+++ b/test/unit/core/factories/GridRow.spec.js
@@ -57,20 +57,22 @@ describe('GridRow factory', function () {
 
       grid.buildColumns();
       grid.modifyRows(grid.options.data);
+      grid.setVisibleRows(grid.rows);
     });
     
     it('should set then unset forceInvisible on visible row, raising visible rows changed event', function () {
       grid.api.core.on.rowsVisibleChanged( $scope, function() { rowsVisibleChanged = true; });
 
-      expect(grid.api.core.getVisibleRows(grid).length).toEqual(10);
+      expect(grid.api.core.getVisibleRows(grid).length).toEqual(10, 'all rows visible');
       
       grid.api.core.setRowInvisible(grid.rows[0]);
       expect(grid.rows[0].forceInvisible).toBe(true);
       expect(grid.rows[0].visible).toBe(false);
       
       expect(rowsVisibleChanged).toEqual(true);
+      $scope.$apply();
       
-      expect(grid.api.core.getVisibleRows(grid).length).toEqual(9);
+      expect(grid.api.core.getVisibleRows(grid).length).toEqual(9, 'one row now invisible');
       
       rowsVisibleChanged = false;
 
@@ -79,8 +81,9 @@ describe('GridRow factory', function () {
       expect(grid.rows[0].visible).toBe(true);
 
       expect(rowsVisibleChanged).toEqual(true);
+      $scope.$apply();
 
-      expect(grid.api.core.getVisibleRows(grid).length).toEqual(10);
+      expect(grid.api.core.getVisibleRows(grid).length).toEqual(10, 'should be visible again');
     });
 
     it('should set then clear forceInvisible on invisible row, doesn\'t raise visible rows changed event', function () {


### PR DESCRIPTION
Also fixes the e2e tests to find the repeater based on $index.
