### PR TITLE
Fix #2065 (dataChange): add refreshRows to dataChangeCallbacks

### DIFF
--- a/misc/tutorial/102_sorting.ngdoc
+++ b/misc/tutorial/102_sorting.ngdoc
@@ -18,6 +18,13 @@ on the existing column if you don't want to sort by it any more.
 
 When sorting using the headers, clicking on a header removes all other sorts unless you shift-click.
 
+The sort is automatically recalculated when you edit a field (the edit feature calls the dataChange api to notify of a data change).  If
+you change the data "behind the scenes" and want the sort to be recalculated, you can notify the grid that your
+data has changed by calling `gridApi.core.notifyDataChange( grid, uiGridUtils.dataChange.EDIT )`
+
+In the example we provide a button that toggles the gender of Alexander Foley on the top grid to demonstrate this,
+you can see this if you sort by gender then name (using shift click), so that Alexander is at the top of the grid.
+
 <example module="app">
   <file name="app.js">
     var app = angular.module('app', ['ngAnimate', 'ui.grid']);
@@ -29,13 +36,25 @@ When sorting using the headers, clicking on a header removes all other sorts unl
           { field: 'name' },
           { field: 'gender' },
           { field: 'company', enableSorting: false }
-        ]
+        ],
+        onRegisterApi: function( gridApi ) {
+          $scope.grid1Api = gridApi;
+        }
+      };
+      
+      $scope.toggleGender = function() {
+        if( $scope.gridOptions1.data[64].gender === 'male' ) {
+          $scope.gridOptions1.data[64].gender = 'female';
+        } else {
+          $scope.gridOptions1.data[64].gender = 'male';
+        };
+        $scope.grid1Api.core.notifyDataChange( $scope.grid1Api.grid, uiGridConstants.dataChange.EDIT );
       };
 
        $scope.gridOptions2 = {
         enableSorting: true,
         onRegisterApi: function( gridApi ) {
-          $scope.gridApi = gridApi;
+          $scope.grid2Api = gridApi;
         },
         columnDefs: [
           {
@@ -53,7 +72,7 @@ When sorting using the headers, clicking on a header removes all other sorts unl
             },
             
             sortingAlgorithm: function(a, b) {
-              var nulls = $scope.gridApi.core.sortHandleNulls(a, b);
+              var nulls = $scope.grid2Api.core.sortHandleNulls(a, b);
               if( nulls !== null ) {
                 return nulls;
               } else {
@@ -92,6 +111,7 @@ When sorting using the headers, clicking on a header removes all other sorts unl
       Click on a column header to sort by that column. (The third column has sorting disabled.)
       <br>
       <br>
+      <button id='toggleGender' ng-click='toggleGender()'>Toggle Gender</button>
       <div id="grid1" ui-grid="gridOptions1" class="grid"></div>
 
       <br>
@@ -183,6 +203,19 @@ When sorting using the headers, clicking on a header removes all other sorts unl
         gridTestUtils.expectVisibleColumnMenuItems( 'grid1', 0, 3 );
         gridTestUtils.expectVisibleColumnMenuItems( 'grid1', 1, 3 );
       });
+
+      it('toggle gender, expect Alexander Foley to move around', function() {
+        // sort gender asc, then name
+        gridTestUtils.clickHeaderCell( 'grid1', 1 );
+        gridTestUtils.clickHeaderCell( 'grid1', 1 );
+        gridTestUtils.shiftClickHeaderCell( 'grid1', 0 );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Alexander Foley' );
+        element(by.id('toggleGender')).click();
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Anthony Joyner' );
+        element(by.id('toggleGender')).click();
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Alexander Foley' );
+      });
+
     });
 
 

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -230,6 +230,7 @@ angular.module('ui.grid')
   self.api.registerMethod( 'core', 'notifyDataChange', this.notifyDataChange );
   
   self.registerDataChangeCallback( self.columnRefreshCallback, [uiGridConstants.dataChange.COLUMN]);
+  self.registerDataChangeCallback( self.processRowsCallback, [uiGridConstants.dataChange.EDIT]);
 };
 
     /**
@@ -376,11 +377,27 @@ angular.module('ui.grid')
    * @name columnRefreshCallback
    * @methodOf ui.grid.class:Grid
    * @description refreshes the grid when a column refresh
-   * is notified, which triggers handling of the visible flag 
+   * is notified, which triggers handling of the visible flag. 
+   * This is called on uiGridConstants.dataChange.COLUMN, and is 
+   * registered as a dataChangeCallback in grid.js
    * @param {string} name column name
    */
   Grid.prototype.columnRefreshCallback = function columnRefreshCallback( grid ){
     grid.refresh();
+  };
+    
+
+  /**
+   * @ngdoc function
+   * @name processRowsCallback
+   * @methodOf ui.grid.class:Grid
+   * @description calls the row processors, specifically
+   * intended to reset the sorting when an edit is called,
+   * registered as a dataChangeCallback on uiGridConstants.dataChange.EDIT
+   * @param {string} name column name
+   */
+  Grid.prototype.processRowsCallback = function processRowsCallback( grid ){
+    grid.refreshRows();
   };
     
 
@@ -1633,10 +1650,9 @@ angular.module('ui.grid')
       .then(function (renderableRows) {
         self.setVisibleRows(renderableRows);
 
-        // TODO: this method doesn't exist, so clearly refreshRows doesn't work.
-        self.redrawRows();
+        self.redrawInPlace();
 
-        self.refreshCanvas();
+        self.refreshCanvas( true );
       });
   };
 


### PR DESCRIPTION
When EDIT is notified, call refreshRows, which calls all rowProcessors,
including sorting.

Also fixed refreshRows to actually work (previously wasn't used and code
was out of date).
