### PR TITLE
Pager $watchers will not fire if sum of totalItems and page size stays the same

### DIFF
--- a/src/features/paging/js/ui-grid-paging.js
+++ b/src/features/paging/js/ui-grid-paging.js
@@ -273,15 +273,23 @@
             return (options.totalItems === 0) ? 1 : Math.ceil(options.totalItems / options.pagingPageSize);
           };
 
-          var deregT = $scope.$watch('grid.options.totalItems + grid.options.pagingPageSize', function () {
-              $scope.currentMaxPages = getMaxPages();
-              setShowing();
-            }
-          );
+          var deregT = $scope.$watch(
+                function (scope) {
+                  return String(scope.grid.options.totalItems) + String(scope.grid.options.pagingPageSize);
+                },
+                function () {
+                  $scope.currentMaxPages = getMaxPages();
+                  setShowing();
+                }
+              );
 
-          var deregP = $scope.$watch('grid.options.pagingCurrentPage + grid.options.pagingPageSize', function (newValues, oldValues) {
-              if (newValues === oldValues) { 
-                return; 
+          var deregP = $scope.$watch(
+            function (scope) {
+              return String(scope.grid.options.pagingCurrentPage) + String(scope.grid.options.pagingPageSize);
+            },
+            function (newValues, oldValues) {
+              if (newValues === oldValues) {
+                return;
               }
 
               if (!angular.isNumber(options.pagingCurrentPage) || options.pagingCurrentPage < 1) {


### PR DESCRIPTION
As mentioned by @c0bra at https://github.com/brianchance/ng-grid/commit/45e1b5c58a621b36f4fdd9cfed85544d5bb2fa36#commitcomment-8565148 

if decrement and increment of the totalItems and page size don't change the overall sum within one digest cycle then watchers will not fire. Changing the $watch expression to a function which compares string values fixes this.
