### PR TITLE
Fix rowBuilders gridOption attribute

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -917,7 +917,7 @@ angular.module('ui.grid')
     var self = this;
 
     self.rowBuilders.forEach(function (builder) {
-      builder.call(self, gridRow, self.gridOptions);
+      builder.call(self, gridRow, self.options);
     });
 
     return gridRow;

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -174,6 +174,21 @@ describe('Grid factory', function () {
       }).toThrow();
     });
   });
+  
+  describe('row builder', function () {
+    function testObj () { }
+    
+    it('should return a defined gridOptions', function () {
+      var testRowBuilder = function (row, gridOptions) {
+        expect(gridOptions).toBeDefined();
+      };
+      var row = new GridRow({str:'abc'}, 0, grid);
+      testObj.testRowBuilder = jasmine.createSpy('testRowBuilder').andCallFake(testRowBuilder);
+      grid.registerRowBuilder(testObj.testRowBuilder);  
+      grid.processRowBuilders(row);
+      expect(testObj.testRowBuilder).toHaveBeenCalled();
+    });
+  });
 
   describe('renderContainers', function () {
     it('should have a body render container', function () {


### PR DESCRIPTION
Was using the registerRowBuilder function from grid.js. However, the gridOptions that was returned to my function was "undefined". This commit fixes this issue so that the gridOptions is indeed returned.
