### PR TITLE
Refactored GridColumn.getAggregationValue.

### DIFF
--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -619,13 +619,18 @@ angular.module('ui.grid')
       var self = this;
       var result = 0;
       var visibleRows = self.grid.getVisibleRows();
-      var cellValues = [];
-      angular.forEach(visibleRows, function (row) {
-        var cellValue = self.grid.getCellValue(row, self);
-        if (angular.isNumber(cellValue)) {
-          cellValues.push(cellValue);
-        }
-      });
+
+      var cellValues = function(){
+        var values = [];
+        angular.forEach(visibleRows, function (row) {
+          var cellValue = self.grid.getCellValue(row, self);
+          if (angular.isNumber(cellValue)) {
+            values.push(cellValue);
+          }
+        });
+        return values;
+      };
+
       if (angular.isFunction(self.aggregationType)) {
         return self.aggregationType(visibleRows, self);
       }
@@ -633,23 +638,23 @@ angular.module('ui.grid')
         return self.getAggregationText('aggregation.count', self.grid.getVisibleRowCount());
       }
       else if (self.aggregationType === uiGridConstants.aggregationTypes.sum) {
-        angular.forEach(cellValues, function (value) {
+        angular.forEach(cellValues(), function (value) {
           result += value;
         });
         return self.getAggregationText('aggregation.sum', result);
       }
       else if (self.aggregationType === uiGridConstants.aggregationTypes.avg) {
-        angular.forEach(cellValues, function (value) {
+        angular.forEach(cellValues(), function (value) {
           result += value;
         });
-        result = result / cellValues.length;
+        result = result / cellValues().length;
         return self.getAggregationText('aggregation.avg', result);
       }
       else if (self.aggregationType === uiGridConstants.aggregationTypes.min) {
-        return self.getAggregationText('aggregation.min', Math.min.apply(null, cellValues));
+        return self.getAggregationText('aggregation.min', Math.min.apply(null, cellValues()));
       }
       else if (self.aggregationType === uiGridConstants.aggregationTypes.max) {
-        return self.getAggregationText('aggregation.max', Math.max.apply(null, cellValues));
+        return self.getAggregationText('aggregation.max', Math.max.apply(null, cellValues()));
       }
       else {
         return '\u00A0';


### PR DESCRIPTION
The function were always iterating all rows and saving the results on a local variable to be used in only 4/6 of the time, causing a lot of overhead.

Its now wrapped in a local function and is called only when needed.

Here are the Batarang and ngStats screeshots from before and after the modification.

Before:

![monitorangularforeachpadrao - ngstats](https://cloud.githubusercontent.com/assets/5025985/5142524/c2efa216-716a-11e4-8b72-3903e9aba681.PNG)
![monitorangularforeachpadrao](https://cloud.githubusercontent.com/assets/5025985/5142525/c2f44d8e-716a-11e4-8cb7-5ea22d38ee7c.PNG)

After:

![monitorangularforeachcomfuncaolocal -ngstats](https://cloud.githubusercontent.com/assets/5025985/5142531/ddbf8124-716a-11e4-8ff7-16d1ec82e359.PNG)
![monitorangularforeachcomfuncaolocaltodosagregadores](https://cloud.githubusercontent.com/assets/5025985/5142545/009199c6-716b-11e4-80a7-78d2d359234a.PNG)
