### PR TITLE
zero height header when `hideHeader` is `true`

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -37,7 +37,7 @@ angular.module('ui.grid')
   // Get default options
   self.options = GridOptions.initialize( options );
 
-  self.headerHeight = self.options.headerRowHeight;
+  self.headerHeight = self.options.hideHeader === false ? self.options.headerRowHeight : 0;
   self.footerHeight = self.options.showFooter === true ? self.options.footerRowHeight : 0;
 
   self.rtl = false;


### PR DESCRIPTION
Grid viewport height is incorrectly calculated when `hideHeader` option is `ture`. This can result in what appears as an empty row in the grid under certain circumstances.
