### PR TITLE
Add visibleRowsChanged event for #2038

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1111,6 +1111,7 @@ angular.module('ui.grid')
         }
       }
     }
+    self.api.core.raise.rowsRendered(this.api);
   };
 
   /**

--- a/src/js/core/factories/GridApi.js
+++ b/src/js/core/factories/GridApi.js
@@ -98,6 +98,14 @@
            * 
            */
           this.registerEvent( 'core', 'rowsVisibleChanged' );
+
+          /**
+           * @ngdoc event
+           * @name rowsRendered
+           * @eventOf  ui.grid.core.api:PublicApi
+           * @description  is raised after the cache of visible rows is changed.
+           */
+          this.registerEvent( 'core', 'rowsRendered' );
         };
 
         /**


### PR DESCRIPTION
Creating a `visibleRowsChanged` event for solving issue #2038.
There was already a `rowsVisibleChanged` event, but it seems to be for something different and is not fired at the the same times. We may want to combine the two events, but I am not sure what the existing one is for.
