### PR TITLE
Remove prevent defaults blocking actions on mobile

### DIFF
--- a/src/js/core/directives/ui-grid-render-container.js
+++ b/src/js/core/directives/ui-grid-render-container.js
@@ -246,8 +246,6 @@
                 event = event.originalEvent;
               }
 
-              event.preventDefault();
-
               $document.unbind('touchmove', touchmove);
               $document.unbind('touchend', touchend);
               $document.unbind('touchcancel', touchend);
@@ -311,8 +309,6 @@
                 if (event.originalEvent) {
                   event = event.originalEvent;
                 }
-
-                event.preventDefault();
 
                 uiGridCtrl.scrollbars.forEach(function (sbar) {
                   sbar.addClass('ui-grid-scrollbar-visible');


### PR DESCRIPTION
The preventdefault is blocking the click events on touch devices, so nothing in the grid (buttons; edit boxes etc...) is usable.

Referencing mathieu-ma on #1551, I thought I'd create a PR with the fix to review it.
From what I can see (been running this in production for a week or so) I can't see any negative side effects.
