### PR TITLE
fix #2278 (gridMenu scroll)

### DIFF
--- a/src/less/menu.less
+++ b/src/less/menu.less
@@ -1,7 +1,7 @@
 .ui-grid-menu-button {
   z-index: 2;
   position: absolute;
-  right: 0;  
+  right: 0;
   background: @headerBackgroundColor;
   border: @gridBorderWidth solid @borderColor;
   cursor: pointer;
@@ -15,6 +15,11 @@
 
 .ui-grid-menu-button .ui-grid-menu {
   right: 0;
+  .ui-grid-menu-mid {
+    overflow-y: scroll;
+    max-height: 300px;
+    border: @gridBorderWidth solid @borderColor;
+  }
 }
 
 .ui-grid-menu {


### PR DESCRIPTION
added overflow-y scroll to grid-menu. This loses the outer
shadow, so might not be ideal solution. Added border to
make it look better.
