### PR TITLE
Fix #2272,#2232,#2336 (exporter): minor enhancements

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -62,7 +62,8 @@
     SELECTED: 'selected',
     CSV_CONTENT: 'CSV_CONTENT',
     LINK_LABEL: 'LINK_LABEL',
-    BUTTON_LABEL: 'BUTTON_LABEL'
+    BUTTON_LABEL: 'BUTTON_LABEL',
+    FILE_NAME: 'FILE_NAME'
   });
 
   /**
@@ -236,6 +237,15 @@
           gridOptions.exporterCsvColumnSeparator = gridOptions.exporterCsvColumnSeparator ? gridOptions.exporterCsvColumnSeparator : ',';
           /**
            * @ngdoc object
+           * @name exporterCsvFilename
+           * @propertyOf  ui.grid.exporter.api:GridOptions
+           * @description The default filename to use when saving the downloaded csv
+           * link.  This will only work in some browsers.
+           * <br/>Defaults to 'download.csv'
+           */
+          gridOptions.exporterCsvFilename = gridOptions.exporterCsvFilename ? gridOptions.exporterCsvFilename : 'download.csv';
+          /**
+           * @ngdoc object
            * @name exporterPdfDefaultStyle
            * @propertyOf  ui.grid.exporter.api:GridOptions
            * @description The default style in pdfMake format
@@ -401,21 +411,39 @@
           
           /**
            * @ngdoc object
+           * @name exporterHeaderFilterUseName
+           * @propertyOf  ui.grid.exporter.api:GridOptions
+           * @description Defaults to false, which leads to `displayName` being passed into the headerFilter.
+           * If set to true, then will pass `name` instead.
+           * 
+           * 
+           * @example
+           * <pre>
+           *   gridOptions.exporterHeaderFilterUseName = true;
+           * </pre>
+           */
+          gridOptions.exporterHeaderFilterUseName = gridOptions.exporterHeaderFilterUseName === true;          
+
+          /**
+           * @ngdoc object
            * @name exporterHeaderFilter
            * @propertyOf  ui.grid.exporter.api:GridOptions
            * @description A function to apply to the header displayNames before exporting.  Useful for internationalisation,
            * for example if you were using angular-translate you'd set this to `$translate.instant`.  Note that this
            * call must be synchronous, it cannot be a call that returns a promise.
+           * 
+           * Behaviour can be changed to pass in `name` instead of `displayName` through use of `exporterHeaderFilterUseName: true`.
+           * 
            * @example
            * <pre>
-           *   gridOptions.exporterHeaderFilter = function( displayName ){ return 'col: ' + displayName; };
+           *   gridOptions.exporterHeaderFilter = function( displayName ){ return 'col: ' + name; };
            * </pre>
            * OR
            * <pre>
            *   gridOptions.exporterHeaderFilter = $translate.instant;
            * </pre>
            */
-
+          
           /**
            * @ngdoc function
            * @name exporterFieldCallback
@@ -583,7 +611,7 @@
                  grid.options.exporterSuppressColumns.indexOf( gridCol.name ) === -1 ){
               headers.push({
                 name: gridCol.field,
-                displayName: grid.options.exporterHeaderFilter ? grid.options.exporterHeaderFilter(gridCol.displayName) : gridCol.displayName,
+                displayName: grid.options.exporterHeaderFilter ? ( grid.options.exporterHeaderFilterUseName ? grid.options.exporterHeaderFilter(gridCol.name) : grid.options.exporterHeaderFilter(gridCol.displayName) ) : gridCol.displayName,
                 width: gridCol.drawnWidth ? gridCol.drawnWidth : gridCol.width,
                 align: gridCol.colDef.type === 'number' ? 'right' : 'left'
               });
@@ -758,6 +786,10 @@
               template.children("a").attr("href", 
                   template.children("a").attr("href").replace(
                       uiGridExporterConstants.CSV_CONTENT, encodeURIComponent(csvContent)));
+
+              template.children("a").attr("download", 
+                  template.children("a").attr("download").replace(
+                      uiGridExporterConstants.FILE_NAME, grid.options.exporterCsvFilename));
             
             var newElm = $compile(template)(grid.exporter.$scope);
             targetElm.append(newElm);
@@ -839,11 +871,11 @@
           }
           
           if ( grid.options.exporterPdfHeader ){
-            docDefinition.content.unshift( grid.options.exporterPdfHeader );
+            docDefinition.header = grid.options.exporterPdfHeader;
           }
           
           if ( grid.options.exporterPdfFooter ){
-            docDefinition.content.push( grid.options.exporterPdfFooter );
+            docDefinition.footer = grid.options.exporterPdfFooter;
           }
           
           if ( grid.options.exporterPdfCustomFormatter ){

--- a/src/features/exporter/templates/csvLink.html
+++ b/src/features/exporter/templates/csvLink.html
@@ -1,5 +1,5 @@
 <span class="ui-grid-exporter-csv-link-span">
-    <a href="data:text/csv;charset=UTF-8,CSV_CONTENT">
+    <a href="data:text/csv;charset=UTF-8,CSV_CONTENT" download="FILE_NAME">
       LINK_LABEL
     </a>
 </span>

--- a/src/features/exporter/test/exporter.spec.js
+++ b/src/features/exporter/test/exporter.spec.js
@@ -71,6 +71,7 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterLinkLabel: 'Download CSV',
         exporterMenuLabel: 'Export',
         exporterCsvColumnSeparator: ',',
+        exporterCsvFilename: 'download.csv',
         exporterPdfDefaultStyle : { fontSize : 11 },
         exporterPdfTableStyle : { margin : [ 0, 5, 0, 15 ] },
         exporterPdfTableHeaderStyle : { bold : true, fontSize : 12, color : 'black' },
@@ -80,6 +81,7 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterPdfPageSize : 'A4',
         exporterPdfMaxGridWidth : 720,
         exporterPdfCustomFormatter: jasmine.any(Function),
+        exporterHeaderFilterUseName: false,
         exporterMenuCsv: true,
         exporterMenuPdf: true,
         exporterFieldCallback: jasmine.any(Function),
@@ -96,6 +98,7 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterLinkLabel: 'special download label',
         exporterMenuLabel: 'custom export button',
         exporterCsvColumnSeparator: ';',
+        exporterCsvFilename: 'myfile.csv',
         exporterPdfDefaultStyle : { fontSize : 12 },
         exporterPdfTableStyle : { margin : [ 15, 5, 15, 15 ] },
         exporterPdfTableHeaderStyle : { bold : false, fontSize : 12, color : 'green' },
@@ -105,6 +108,7 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterPdfPageSize : 'LETTER',
         exporterPdfMaxGridWidth : 670,
         exporterPdfCustomFormatter: callback,
+        exporterHeaderFilterUseName: true,
         exporterMenuCsv: false,
         exporterMenuPdf: false,
         exporterFieldCallback: callback,
@@ -118,6 +122,7 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterLinkLabel: 'special download label',
         exporterMenuLabel: 'custom export button',
         exporterCsvColumnSeparator: ';',
+        exporterCsvFilename: 'myfile.csv',
         exporterPdfDefaultStyle : { fontSize : 12 },
         exporterPdfTableStyle : { margin : [ 15, 5, 15, 15 ] },
         exporterPdfTableHeaderStyle : { bold : false, fontSize : 12, color : 'green' },
@@ -127,6 +132,7 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterPdfPageSize : 'LETTER',
         exporterPdfMaxGridWidth : 670,
         exporterPdfCustomFormatter: callback,
+        exporterHeaderFilterUseName: true,
         exporterMenuCsv: false,
         exporterMenuPdf: false,
         exporterFieldCallback: callback,
@@ -180,6 +186,18 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         {name: 'col2', displayName: 'mapped_Col2', width: '*', align: 'right'},
         {name: 'col3', displayName: 'mapped_Col3', width: 100, align: 'left'},
         {name: 'col4', displayName: 'mapped_Col4', width: 200, align: 'left'}
+      ]);
+    });
+
+    it('gets all headers using headerFilter, passing name not displayName', function() {
+      grid.options.exporterHeaderFilterUseName = true;
+      grid.options.exporterHeaderFilter = function( name ){ return "mapped_" + name; };
+
+      expect(uiGridExporterService.getColumnHeaders(grid, uiGridExporterConstants.ALL)).toEqual([
+        {name: 'col1', displayName: 'mapped_col1', width: 50, align: 'left'},
+        {name: 'col2', displayName: 'mapped_col2', width: '*', align: 'right'},
+        {name: 'col3', displayName: 'mapped_col3', width: 100, align: 'left'},
+        {name: 'col4', displayName: 'mapped_col4', width: 200, align: 'left'}
       ]);
     });
   });
@@ -432,7 +450,6 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         pageOrientation : 'portrait',
         pageSize: 'LETTER', 
         content : [
-          'My Header', 
           { 
             style : 'tableStyle', 
             table : { 
@@ -450,9 +467,10 @@ describe('ui.grid.exporter uiGridExporterService', function () {
                 [ {text: date.toISOString(), alignment: 'right'}, {text: '45', alignment: 'center'}, {text: 'A string', alignment: 'left'}, 'TRUE' ] 
               ] 
             } 
-          },
-          'My Footer'
-         ], 
+          }
+         ],
+        header : "My Header",
+        footer : "My Footer",  
         styles : { 
           tableStyle : { 
             margin : [ 30, 30, 30, 30 ] 

--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -1,4 +1,4 @@
-/* globals protractor, element, by */
+/* globals protractor, element, by, browser */
 /**
  * @ngdoc overview
  * @name ui.grid.e2eTestLibrary


### PR DESCRIPTION
Fix #2272: allow use of name instead of displayName in exporterHeaderFilter, through new option exporterHeaderFilterUseName
Fix #2232: footer and header need to be in separate sections, not part of content.  Not clear if this is a change at pdfMake end, or never worked
Fix $2336: allow specifying filename for csv, only works in some recent browsers 

Also minor fix to warning from jshint in e2e tests
