### PR TITLE
regression fix for: #2357 scrolling with large amount of columns,columns disappear after sort 

### DIFF
--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -335,13 +335,15 @@ angular.module('ui.grid')
     
     var newRange = [];
     if (rowCache.length > self.grid.options.virtualizationThreshold) {
-      // Have we hit the threshold going down?
-      if (self.prevScrollTop < scrollTop && rowIndex < self.prevRowScrollIndex + self.grid.options.scrollThreshold && rowIndex < maxRowIndex) {
-        return;
-      }
-      //Have we hit the threshold going up?
-      if (self.prevScrollTop > scrollTop && rowIndex > self.prevRowScrollIndex - self.grid.options.scrollThreshold && rowIndex < maxRowIndex) {
-        return;
+      if (!(typeof(scrollTop) === 'undefined' || scrollTop === null)) {
+        // Have we hit the threshold going down?
+        if (self.prevScrollTop < scrollTop && rowIndex < self.prevRowScrollIndex + self.grid.options.scrollThreshold && rowIndex < maxRowIndex) {
+          return;
+        }
+        //Have we hit the threshold going up?
+        if (self.prevScrollTop > scrollTop && rowIndex > self.prevRowScrollIndex - self.grid.options.scrollThreshold && rowIndex < maxRowIndex) {
+          return;
+        }
       }
 
       var rangeStart = Math.max(0, rowIndex - self.grid.options.excessRows);


### PR DESCRIPTION
scrollTop can now be undefined/null then that value should not be used
for calculating if this is a scroll that doesn't have to update
anything.
