### PR TITLE
Issue #2149 - override expandableRowHeaderColDef.displayName

### DIFF
--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -212,7 +212,7 @@
           return {
             pre: function ($scope, $elm, $attrs, uiGridCtrl) {
               if ( uiGridCtrl.grid.options.enableExpandableRowHeader !== false ) {
-                var expandableRowHeaderColDef = {name: 'expandableButtons', width: 40};
+                var expandableRowHeaderColDef = {name: 'expandableButtons', displayName: '', width: 40};
                 expandableRowHeaderColDef.cellTemplate = $templateCache.get('ui-grid/expandableRowHeader');
                 uiGridCtrl.grid.addRowHeaderColumn(expandableRowHeaderColDef);
               }


### PR DESCRIPTION
The column generated when enabling expandable rows uses the header "Expandable Buttons". Until a method to configure this header text is provided, an empty string is preferable to the current text.
