### PR TITLE
user-configurable expandableRowHeaderColDef

### DIFF
--- a/misc/tutorial/306_expandable_grid.ngdoc
+++ b/misc/tutorial/306_expandable_grid.ngdoc
@@ -175,6 +175,5 @@ $scope.gridOptions = {
 
     name: 'Custom Name',
     width: 50
-      },
-
+      }
 }

--- a/misc/tutorial/306_expandable_grid.ngdoc
+++ b/misc/tutorial/306_expandable_grid.ngdoc
@@ -165,3 +165,16 @@ SubGrid nesting can be done upto multiple levels.
     <div ui-grid="row.entity.subGridOptions" style="height:140px;"></div>
   </file>
 </example>
+
+In addition, you can customize the Headers for expandable rows via $scope.gridOptions.expandableRowHeaderColDef. For example, the following will hide the expand button if the subgrid contains no data, assign 'Custon Name' as the column header instead of 'expandableButtons', and increase the width of the column from 40 to 50
+
+@example
+$scope.gridOptions = {
+  expandableRowHeaderColDef: {
+    cellTemplate: "<div style= \"height:32px \" class=\"ui-grid-row-header-cell ui-grid-expandable-buttons-cell\"><div class=\"ui-grid-cell-contents\"><i ng-class=\"{ 'ui-grid-icon-plus-squared' : !row.isExpanded && row.entity.subGridOptions.data.length !== 0, 'ui-grid-icon-minus-squared' : row.isExpanded, 'ng-grid-cell': row.entity.subGridOptions.data.length == 0 }\" ng-click=\"grid.api.expandable.toggleRowExpansion(row.entity)\"></i></div></div>",
+
+    name: 'Custom Name',
+    width: 50
+      },
+
+}

--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -20,10 +20,10 @@
    *
    *  @description Services for the expandable grid
    */
-  module.service('uiGridExpandableService', ['gridUtil', '$compile', function (gridUtil, $compile) {
+  module.service('uiGridExpandableService', ['gridUtil', '$compile', '$templateCache', function (gridUtil, $compile, $templateCache) {
     var service = {
       initializeGrid: function (grid) {
-        
+
         /**
          *  @ngdoc object
          *  @name enableExpandable
@@ -38,6 +38,25 @@
          *  </pre>  
          */
         grid.options.enableExpandable = grid.options.enableExpandable !== false;
+
+        /**
+         *  @ngdoc object
+         *  @name expandableRowHeaderColDef
+         *  @propertyOf  ui.grid.expandable.api:GridOptions
+         *  @description Defines Row Headers for expandable rows, as well as the cellTemplate uesed for expandable cells.
+         *  Allows you to customize both.
+         *  @example
+         *  <pre>
+         *    $scope.gridOptions = {
+         *      expandableRowHeaderColDef: {
+         *        cellTemplate: "<div style= \"height:32px \" class=\"ui-grid-row-header-cell ui-grid-expandable-buttons-cell\"><div class=\"ui-grid-cell-contents\"><i ng-class=\"{ 'ui-grid-icon-plus-squared' : !row.isExpanded && row.entity.subGridOptions.data.length !== 0, 'ui-grid-icon-minus-squared' : row.isExpanded, 'ng-grid-cell': row.entity.subGridOptions.data.length == 0 }\" ng-click=\"grid.api.expandable.toggleRowExpansion(row.entity)\"></i></div></div>";
+         *    }
+         *  </pre>
+         */
+        grid.options.expandableRowHeaderColDef = grid.options.expandableRowHeaderColDef || {};
+        grid.options.expandableRowHeaderColDef.name = grid.options.expandableRowHeaderColDef.name || 'expandableButtons';
+        grid.options.expandableRowHeaderColDef.width = grid.options.expandableRowHeaderColDef.width || 40;
+        grid.options.expandableRowHeaderColDef.cellTemplate = grid.options.expandableRowHeaderColDef.cellTemplate || $templateCache.get('ui-grid/expandableRowHeader');
         
         /**
          *  @ngdoc object
@@ -211,17 +230,10 @@
         compile: function () {
           return {
             pre: function ($scope, $elm, $attrs, uiGridCtrl) {
-              if ( uiGridCtrl.grid.options.enableExpandableRowHeader !== false ) {
-                var defaultExpandableRowHeaderColDef = {
-                    name: 'expandableButtons',
-                    width: 40,
-                    cellTemplate: $templateCache.get('ui-grid/expandableRowHeader')
-                  },
-                  userInjectedExpandableRowHeaderColDef = $scope.gridOptions.expandableRowHeaderColDef || {},
-                  finalExpandableRowHeaderColDef = angular.extend({}, defaultExpandableRowHeaderColDef, userInjectedExpandableRowHeaderColDef);
-                uiGridCtrl.grid.addRowHeaderColumn(finalExpandableRowHeaderColDef);
-              }
               uiGridExpandableService.initializeGrid(uiGridCtrl.grid);
+              if ( uiGridCtrl.grid.options.enableExpandableRowHeader !== false ) {
+                uiGridCtrl.grid.addRowHeaderColumn(grid.options.expandableRowHeaderColDef);
+              }
             },
             post: function ($scope, $elm, $attrs, uiGridCtrl) {
             }

--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -212,9 +212,14 @@
           return {
             pre: function ($scope, $elm, $attrs, uiGridCtrl) {
               if ( uiGridCtrl.grid.options.enableExpandableRowHeader !== false ) {
-                var expandableRowHeaderColDef = {name: 'expandableButtons', displayName: '', enableColumnResizing: false, width: 40};
-                expandableRowHeaderColDef.cellTemplate = $templateCache.get('ui-grid/expandableRowHeader');
-                uiGridCtrl.grid.addRowHeaderColumn(expandableRowHeaderColDef);
+                var defaultExpandableRowHeaderColDef = {
+                    name: 'expandableButtons',
+                    width: 40,
+                    cellTemplate: $templateCache.get('ui-grid/expandableRowHeader')
+                  },
+                  userInjectedExpandableRowHeaderColDef = $scope.gridOptions.expandableRowHeaderColDef || {},
+                  finalExpandableRowHeaderColDef = angular.extend({}, defaultExpandableRowHeaderColDef, userInjectedExpandableRowHeaderColDef);
+                uiGridCtrl.grid.addRowHeaderColumn(finalExpandableRowHeaderColDef);
               }
               uiGridExpandableService.initializeGrid(uiGridCtrl.grid);
             },

--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -232,7 +232,7 @@
             pre: function ($scope, $elm, $attrs, uiGridCtrl) {
               uiGridExpandableService.initializeGrid(uiGridCtrl.grid);
               if ( uiGridCtrl.grid.options.enableExpandableRowHeader !== false ) {
-                uiGridCtrl.grid.addRowHeaderColumn(grid.options.expandableRowHeaderColDef);
+                uiGridCtrl.grid.addRowHeaderColumn(uiGridCtrl.grid.options.expandableRowHeaderColDef);
               }
             },
             post: function ($scope, $elm, $attrs, uiGridCtrl) {


### PR DESCRIPTION
Related to issue #1990.

This allows the user to configure the expandableRowHeaderColDef by adding a $scope.gridOptions.expandableRowHeaderColDef to js files.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/2396)
<!-- Reviewable:end -->
