### PR TITLE
Bug fix #1408 and #1195

### DIFF
--- a/src/directives/ng-input.js
+++ b/src/directives/ng-input.js
@@ -1,4 +1,4 @@
-ngGridDirectives.directive('ngInput', [function() {
+ngGridDirectives.directive('ngInput', ['$timeout', function($timeout) {
     return {
         require: 'ngModel',
         link: function (scope, elm, attrs, ngModel) {
@@ -60,8 +60,10 @@ ngGridDirectives.directive('ngInput', [function() {
                 elm.select();
             }));
 
-            angular.element(elm).bind('blur', function () {
-                scope.$emit('ngGridEventEndCellEdit');
+            $timeout(function () {
+                angular.element(elm).bind('blur', function () {
+                    scope.$emit('ngGridEventEndCellEdit');
+                });
             });
         }
     };


### PR DESCRIPTION
Wrap blur in a timeout which resolves an issue in Firefox where blur is triggered on focus for input type=number

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/2902)
<!-- Reviewable:end -->
