### PR TITLE
Adding a grid option for enabling/disabling column virtualization

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -52,6 +52,9 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
         //Enable or disable HEAVY column virtualization. This turns off selection checkboxes and column pinning and is designed for spreadsheet-like data.
         enableColumnHeavyVirt: false,
 
+        //Enable or disable column virtualization.
+        enableColumnVirtualization: true,
+
         //Enables the server-side paging feature
         enablePaging: false,
 
@@ -771,6 +774,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             totalLeft = 0,
             x = $scope.columns.length,
             newCols = [],
+            disableColumnVirt = !self.config.enableColumnVirtualization,
             dcv = !self.config.enableColumnHeavyVirt;
         var r = 0;
         var addCol = function (c) {
@@ -795,7 +799,9 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                     domUtilityService.setColLeft(col, newLeft, self);
                     totalLeft += col.width;
                 } else {
-                    if (w >= scrollLeft) {
+                    if (disableColumnVirt) {
+                        addCol(col);
+                    } else if (w >= scrollLeft) {
                         if (colwidths <= scrollLeft + self.rootDim.outerWidth) {
                             addCol(col);
                         }


### PR DESCRIPTION
Adding the ability to disable column virtualization. Column virtualization causes lag for columns that are expensive to rebuild (and where pinning is undesired). It also causes grids with a lot of/wide columns to have horizontal scrollbars that are jumpy and do not actually reflect the true width of the grid.

Closed out the pull request for #2969 because I don't think it was going to be merged anytime soon, and I didn't create a separate branch out of 2.x for it (whoops).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3278)
<!-- Reviewable:end -->
