### PR TITLE
Fixing column widths snapping back to their pre-resized widths

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -391,6 +391,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 cols.push(column);
             });
             $scope.columns = cols;
+            $scope.hasUserChangedGridColumnWidths = false;
             if (self.config.groups.length > 0) {
                 self.rowFactory.getGrouping(self.config.groups);
             }
@@ -440,10 +441,8 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 t = isPercent ? colDef.width : parseInt(colDef.width, 10);
             }
 
-             // has bug for resize event causing NaN for all column width after another http.get
-             // if (isNaN(t) && !$scope.hasUserChangedGridColumnWidths) {
              // check if it is a number
-            if (isNaN(t)) {
+            if (isNaN(t) && !$scope.hasUserChangedGridColumnWidths) {
                 t = colDef.width;
                 // figure out if the width is defined or if we need to calculate it
                 if (t === 'auto') { // set it for now until we have data and subscribe when it changes so we can set the width.


### PR DESCRIPTION
The fix for #1202 caused issues with column widths snapping back to their original values after calls to rebuildGrid.

Basically, what was happening was the columns were being lazy loaded. When resizing the columns, `hasUserChangedGridColumnWidths` gets set to true. When the grid received the new columnDefs, it destroyed the old columns collection, whose widths had already been calculated, and filled the columns collection with a new set of ngColumns. The new column widths were unable to be calculated because `hasUserChangedGridColumnWidths` was still set to true. 

Reverting the original fix for #1202, and instead setting `hasUserChangedGridColumnWidths` to false when building a new columns collection.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3279)
<!-- Reviewable:end -->
