### PR TITLE
reverting the fix for #1221

### DIFF
--- a/src/services/DomUtilityService.js
+++ b/src/services/DomUtilityService.js
@@ -126,12 +126,8 @@
         for (var i = 0; i < cols.length; i++) {
             var col = cols[i];
             if (col.visible !== false) {
-                var rightPad = 0;
-                if ((i === cols.length - 1) && (sumWidth + col.width < grid.elementDims.rootMaxW)) {
-                    rightPad = grid.elementDims.rootMaxW - sumWidth - col.width;
-                }
-                css += "." + gridId + " .col" + i + " { width: " + (col.width + rightPad) + "px; left: " + sumWidth + "px; height: " + rowHeight + "px }" +
-                    "." + gridId + " .colt" + i + " { width: " + (col.width + rightPad) + "px; }";
+                css += "." + gridId + " .col" + i + " { width: " + col.width + "px; left: " + sumWidth + "px; height: " + rowHeight + "px }" +
+                    "." + gridId + " .colt" + i + " { width: " + col.width + "px; }";
                 sumWidth += col.width;
             }
         }


### PR DESCRIPTION
The fix for this issue seems to have introduced various other issues. I've noticed that the column headers sometimes get out of alignment with their corresponding columns, especially when a grid contains pinned columns. This should also fix #3044.

Is the issue expressed in #1221 expected to be base behavior of a data grid? I wouldn't expect the width of the last column in a grid to be dependent on the width of the other columns by default.

If the expectation is that the row striping extends all the way across the grid, that can be done purely with css:
```css
.gridStyle .ngCanvas {
  min-width: 100%;
}

.gridStyle .ngRow {
  min-width: 100%;
}
```

The last column can also be set to fill the remaining width of the row with css as well:
```css
.gridStyle .ngRow .ngCell:last-child {
  width: auto !important;
  right: 0px;
}

.gridStyle .ngRow .ngCell:last-child .ngCellText {
  width: inherit;
}
```

The following plunker demonstrates this:
http://plnkr.co/edit/lqMtOz7DzPC9t9zmBRbX?p=preview

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3280)
<!-- Reviewable:end -->
