### PR TITLE
Preserving the collapse state of aggregate rows across calls to filteredRowsChanged

### DIFF
--- a/src/classes/rowFactory.js
+++ b/src/classes/rowFactory.js
@@ -187,8 +187,9 @@
 
         function getPreviousAggregateRef(group) {
             for (var i = 0; prevCache && i < prevCache.length; i++) {
-                if (prevCache[i].label == group)
+                if (prevCache[i].label === group) {
                     return prevCache[i];
+                }
             }
 
             return null;


### PR DESCRIPTION
When filteredRowsChanged is called, the aggregate row collection gets cleared and rebuilt. When this happens, the collapse states of the new aggregate rows are set to the default specified in the gridOptions.

This can be seen in the following plunker by expanding aggregate rows until the grid has a vertical scrollbar, then resize the browser (which changes the width of a grouped column, and results in the 'configGroups' watch getting fired):
http://plnkr.co/edit/OxvvRmjW7H3OdQDMxKkg?p=preview

This pull request preserves the collapse state when the aggregate row collection is cleared and rebuilt, if one existed, otherwise it defaults to the property in gridOptions, as before.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3286)
<!-- Reviewable:end -->
