### PR TITLE
Removing the gap between the bottom of the viewport, and the bottom of the grid

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -856,7 +856,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
     };
 
     $scope.viewportDimHeight = function() {
-        return Math.max(0, self.rootDim.outerHeight - $scope.topPanelHeight() - $scope.footerRowHeight - 2);
+        return Math.max(0, self.rootDim.outerHeight - $scope.topPanelHeight() - $scope.footerRowHeight);
     };
     $scope.groupBy = function (col) {
         if (self.data.length < 1 || !col.groupable  || !col.field) {


### PR DESCRIPTION
There is a 2px gap between the bottom of the viewport, and the bottom of
the grid. The high contrast colors in the following plunker shows this:

http://plnkr.co/edit/J44cYftFauaZ5LPY4aOM?p=preview

This changeset removes this gap.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3353)
<!-- Reviewable:end -->
