### PR TITLE
For SELECT filter ng-options, use track by instead of selectAs

### DIFF
--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -77,6 +77,13 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     }
 
     var term = rowSearcher.getTerm(filter);
+
+    // A searchOption value could be an object so it is better to user angular.equals instead of a regex.
+    if (angular.isObject(term) && term.value && !angular.isDefined(filter.condition)) {
+      return function(searchTerm, cellValue) {
+        return angular.equals(searchTerm, cellValue);
+      }
+    }
     
     if (/\*/.test(term)) {
       var regexpFlags = '';
@@ -178,7 +185,8 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     var conditionType = typeof(filter.condition);
 
     // Term to search for.
-    var term = filter.term;
+    // Exctract the term.value for selectOptions since ng-options track by returns the entire object.
+    var term = angular.isObject(filter.term) && filter.term.value ? filter.term.value : filter.term;
 
     // Get the column value for this row
     var value = grid.getCellValue(row, column);

--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -82,7 +82,7 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     if (angular.isObject(term) && term.value && !angular.isDefined(filter.condition)) {
       return function(searchTerm, cellValue) {
         return angular.equals(searchTerm, cellValue);
-      }
+      };
     }
     
     if (/\*/.test(term)) {

--- a/src/templates/ui-grid/ui-grid-filter.html
+++ b/src/templates/ui-grid/ui-grid-filter.html
@@ -8,7 +8,7 @@
   </div>
   
   <div ng-if="colFilter.type === 'select'">
-    <select class="ui-grid-filter-select" ng-model="colFilter.term" ng-attr-placeholder="{{colFilter.placeholder || ''}}" ng-options="option.value as option.label for option in colFilter.selectOptions">
+    <select class="ui-grid-filter-select" ng-model="colFilter.term" ng-attr-placeholder="{{colFilter.placeholder || ''}}" ng-options="option.label for option in colFilter.selectOptions track by option.label">
       <option value=""></option>
     </select>
 


### PR DESCRIPTION
This fixes the dropdown view when initializing the dropdown value’s "term" or when setting the "term" value programmatically such as during table restore state.

For an example of how this is a problem in ui-grid, please see this [plnkr](http://plnkr.co/edit/h95AeH?p=preview).  For the plnkr, I've modified the Company field to be an object instead of a string and use the object to display multiple object properties in that column.  A SELECT filter is in place and it works but say I wanted an initial filter so I set the term to be "{name: 'Oulu Incorporated', country: 'US'}".  Although the table is properly filtered, the filter dropdown is blank.  This is because Angular's ng-options determines that the term is not an identical reference to the option value.  This problem is also encountered when doing a restoreState since again, ng-options will not detect the restored value to be the same as an existing option.  Technically, we could fix this by adding a track by expression but AngularJS does not fully support "track by" and "selectAs" as per https://github.com/angular/angular.js/issues/6564.  Angular core team does not appear to be planning to fix this.

A workaround is described in that ticket, [plnkr](http://plnkr.co/edit/tevxjW?p=preview), which involves using "track by" instead of "selectAs" and then adjusting for the changes in the code.  That workaround was used for this second [plnkr](http://plnkr.co/edit/WNrW9r?p=preview) and contains the fix in this pull request.  Note that the initial value shows up in the dropdown, the table is properly filtered on that initial value, and that other dropdown options work as well.

Due to this change, the term that is set in ng-model now will be the full selectOption object with value and label properties instead of just the .value.  This affects the comparison when the filters are run.  Therefore, code was added to A) extract the .value property before doing the filter comparison and B) set up a default condition function for SELECT filters instead of using the default startswithRE regex.  B helps when the selectOption .value is an object and not a string.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3408)
<!-- Reviewable:end -->
