### PR TITLE
Add 2 options: In CellNav, add option to highlight the entire row and in Selection add option to show/hide highlight on selection

### DIFF
--- a/misc/tutorial/202_cellnav.ngdoc
+++ b/misc/tutorial/202_cellnav.ngdoc
@@ -28,7 +28,8 @@ extract values of selected cells.
     app.controller('MainCtrl', ['$scope', '$http', '$log', function ($scope, $http, $log) {
       $scope.gridOptions = {
         modifierKeysToMultiSelectCells: true,
-        showGridFooter: true
+        showGridFooter: true,
+        highlightEntireRowOnCellFocus: false
       };
       $scope.gridOptions.columnDefs = [
         { name: 'id', width:'150' },
@@ -67,6 +68,10 @@ extract values of selected cells.
           $scope.printSelection = values.toString();
         };
         
+        $scope.toggleRowHighlight = function() {
+          $scope.gridOptions.highlightEntireRowOnCellFocus = !$scope.gridOptions.highlightEntireRowOnCellFocus;
+          $scope.scrollToFocus(0, 0);
+        };
         $scope.scrollTo = function( rowIndex, colIndex ) {
           $scope.gridApi.core.scrollTo( $scope.gridOptions.data[rowIndex], $scope.gridOptions.columnDefs[colIndex]);
         };
@@ -97,6 +102,8 @@ extract values of selected cells.
       <button type="button" class="btn btn-success" ng-click="scrollToFocus(50,7)">Focus Row 50, Balance</button>
       <button type="button" class="btn btn-success" ng-click="getCurrentFocus()">Get Current focused cell</button>  <span ng-bind="currentFocused"></span>
       <button type="button" class="btn btn-success" ng-click="getCurrentSelection()">Get Current focused cell values</button>
+      <br/>
+      <button type="button" class="btn btn-success" ng-click="toggleRowHighlight()">Toggle Row Highlight</button>  <strong>HighlightEntireRowOnCellFocus:</strong> <span ng-bind="gridOptions.highlightEntireRowOnCellFocus"> </span>
       <input type="text" ng-model="printSelection" placeholder="Click the 'Get current focused cell values' button to print cell values of selection here" class="printSelection">
       <br>
       <br>

--- a/misc/tutorial/210_selection.ngdoc
+++ b/misc/tutorial/210_selection.ngdoc
@@ -86,6 +86,9 @@ auto-selects the first row once the data is loaded.
           $scope.gridApi.selection.setMultiSelect(!$scope.gridApi.grid.options.multiSelect);
         };
 
+        $scope.toggleHighlightRowOnSelection = function() {
+          $scope.gridApi.selection.setHighlightRowOnSelection(!$scope.gridApi.grid.options.highlightRowOnSelection);
+        };
         $scope.toggleModifierKeysToMultiSelect = function() {
           $scope.gridApi.selection.setModifierKeysToMultiSelect(!$scope.gridApi.grid.options.modifierKeysToMultiSelect);
         };
@@ -183,6 +186,7 @@ auto-selects the first row once the data is loaded.
       <button type="button" class="btn btn-success" ng-click="clearAll()">Clear All</button>
       <button type="button" class="btn btn-success" ng-click="setSelectable()">Set Selectable</button>
       <button type="button" class="btn btn-success" ng-click="toggleFullRowSelection()">Toggle full row selection</button>
+      <button type="button" class="btn btn-success" ng-click="toggleHighlightRowOnSelection()">Toggle Selection Highlight</button>  <strong>HighlightRowOnSelection:</strong> <span ng-bind="gridApi.grid.options.highlightRowOnSelection"> </span>
       <br/>
 
       <div ui-grid="gridOptions" ui-grid-selection class="grid"></div>

--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -398,6 +398,14 @@
            */
           gridOptions.modifierKeysToMultiSelectCells = gridOptions.modifierKeysToMultiSelectCells === true;
 
+          /**
+           *  @ngdoc object
+           *  @name highlightEntireRowOnCellFocus
+           *  @propertyOf  ui.grid.cellNav.api:GridOptions
+           *  @description Enable higlighting of entire row when a cell has focus.
+           *  <br/>Defaults to false
+           */
+          gridOptions.highlightEntireRowOnCellFocus = gridOptions.highlightEntireRowOnCellFocus === true;
         },
 
         /**
@@ -915,18 +923,26 @@
              // }
             }
             else if (!(uiGridCtrl.grid.options.modifierKeysToMultiSelectCells && modifierDown)) {
+              if (((uiGridCtrl.grid.options.highlightEntireRowOnCellFocus) && (rowCol.row !== $scope.row)) || (!uiGridCtrl.grid.options.highlightEntireRowOnCellFocus)) {
               clearFocus();
+              }
             }
           });
 
           function setFocused() {
             var div = $elm.find('div');
+            var row = $elm.parent().parent();
             div.addClass('ui-grid-cell-focus');
+            if (uiGridCtrl.grid.options.highlightEntireRowOnCellFocus) {
+              row.addClass('ui-grid-row-highlighted');
+            }
           }
 
           function clearFocus() {
             var div = $elm.find('div');
+            var row = $elm.parent().parent();
             div.removeClass('ui-grid-cell-focus');
+            row.removeClass('ui-grid-row-highlighted');
           }
 
           $scope.$on('$destroy', function () {

--- a/src/features/cellnav/less/cellNav.less
+++ b/src/features/cellnav/less/cellNav.less
@@ -14,3 +14,6 @@
   width:0px;
   height:0px;
 }
+.ui-grid-row-highlighted  > [ui-grid-row] > .ui-grid-cell{
+  background-color: @focusedCell !important;
+}

--- a/src/features/cellnav/test/uiGridCellNavDirective.spec.js
+++ b/src/features/cellnav/test/uiGridCellNavDirective.spec.js
@@ -11,7 +11,8 @@ describe('ui.grid.cellNav directive', function () {
 
     $scope.gridOpts = {
       data: [{ name: 'Bob' }, {name: 'Mathias'}, {name: 'Fred'}],
-      modifierKeysToMultiSelectCells: true
+      modifierKeysToMultiSelectCells: true,
+      highlightEntireRowOnCellFocus: false
     };
 
     $scope.gridOpts.onRegisterApi = function (gridApi) {

--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -323,6 +323,16 @@
                  */
                 getSelectAllState: function () {
                   return grid.selection.selectAll;
+                },
+                /**
+                 * @ngdoc function
+                 * @name setHighlightRowOnSelection
+                 * @methodOf  ui.grid.selection.api:PublicApi
+                 * @description Sets the current gridOption.highlightRowOnSelection to true or false
+                 * @param {bool} highlightRowOnSelection true to allow allow selected rows to be highlighted
+                 */
+                setHighlightRowOnSelection: function (highlightRowOnSelection) {
+                  grid.options.highlightRowOnSelection = highlightRowOnSelection;
                 }
 
               }
@@ -444,6 +454,14 @@
            */
 
           gridOptions.isRowSelectable = angular.isDefined(gridOptions.isRowSelectable) ? gridOptions.isRowSelectable : angular.noop;
+          /**
+           *  @ngdoc object
+           *  @name highlightRowOnSelection
+           *  @propertyOf  ui.grid.selection.api:GridOptions
+           *  @description Option to highlight the entire row when row is selected.
+           *  <br/>Defaults to true.
+           */
+          gridOptions.highlightRowOnSelection = gridOptions.highlightRowOnSelection !== false;
         },
 
         /**
@@ -778,9 +796,9 @@
             var existingNgClass = rowRepeatDiv.attr("ng-class");
             var newNgClass = '';
             if ( existingNgClass ) {
-              newNgClass = existingNgClass.slice(0, -1) + ",'ui-grid-row-selected': row.isSelected}";
+              newNgClass = existingNgClass.slice(0, -1) + ",'ui-grid-row-selected': ((row.isSelected) && (grid.options.highlightRowOnSelection))}";
             } else {
-              newNgClass = "{'ui-grid-row-selected': row.isSelected}";
+              newNgClass = "{'ui-grid-row-selected': ((row.isSelected) && (grid.options.highlightRowOnSelection))}";
             }
             rowRepeatDiv.attr("ng-class", newNgClass);
 


### PR DESCRIPTION
We have had to customize a lot in the grid to achieve the enhancements
requested. We use the grid in a way that makes the row the item which is
actionable, not an individual cell. It would help us a lot if the
following option were added:

1. In the cellNav feature, add an option that will highlight the entire
row rather than the just the cell on the row that has focus. This will
act as a highlight bar that will indicate the row that we will act upon.

2. In The selection feature, add an option that does not apply the row
highlight on selection. This will help us by not causing confusion when
used in conjunction with the highlight bar. The check box in the header
will signal the row is selected.

Both changes are included in this pull request.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3746)
<!-- Reviewable:end -->
