### PR TITLE
Adds twitter bootstrap less files under a namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   ],
   "author": "UI Grid Team",
   "license": "MIT",
+  "dependencies": {
+    "bootstrap": "~3.3.5"
+  },
   "devDependencies": {
     "bower": "^1.3.8",
     "canonical-path": "0.0.2",

--- a/src/less/bootstrap/bootstrap.less
+++ b/src/less/bootstrap/bootstrap.less
@@ -1,0 +1,78 @@
+/*!
+ * Bootstrap v3.3.5 (http://getbootstrap.com)
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+/****** NOTE: IMPORTANT INFORMATION ABOUT USING THIS FILE *********\
+ * If you are importing this file then use `@import (reference) '..../bootstrap'`
+ * ENSURE that you use the (refrerence)
+ * WHY? Because otherwise you will import the entire contents of less bootstrap
+ *
+ * How does this work?
+ * All of the bootstrap less elements are namespaced under `#ui-grid-twbs`
+ * This prevents the CSS generated using this file from conflicting with a project's
+ * import of bootstrap.
+ *
+ * XXX: Why are so many of these imports commented out?
+ * There are several issues with the `extend` function in less.
+ * Using extend, even within an import that only has a reference will import that
+ * css element. This causes bloat in the distributed css files.
+ * Related Issues:
+ * https://github.com/less/less.js/issues/1968
+ * https://github.com/less/less.js/issues/1851
+ *
+ * If you comment in one of these files you may get much more than css then you want.
+ * Only do this sparingly.
+ */
+#ui-grid-twbs {
+  // Core variables and mixins
+  @import (reference) "../../../node_modules/bootstrap/less/variables.less";
+  @import (reference) "../../../node_modules/bootstrap/less/mixins.less";
+
+  // Reset and dependencies
+  @import (reference) "../../../node_modules/bootstrap/less/normalize.less";
+  @import (reference) "../../../node_modules/bootstrap/less/print.less";
+  @import (reference) "../../../node_modules/bootstrap/less/glyphicons.less";
+
+  // Core CSS
+  @import (reference) "../../../node_modules/bootstrap/less/scaffolding.less";
+  @import (reference) "../../../node_modules/bootstrap/less/code.less";
+  @import (reference) "../../../node_modules/bootstrap/less/tables.less";
+  @import (reference) "../../../node_modules/bootstrap/less/forms.less";
+  @import (reference) "../../../node_modules/bootstrap/less/buttons.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/type.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/grid.less";
+
+  // Components
+  @import (reference) "../../../node_modules/bootstrap/less/component-animations.less";
+  @import (reference) "../../../node_modules/bootstrap/less/dropdowns.less";
+  @import (reference) "../../../node_modules/bootstrap/less/button-groups.less";
+  @import (reference) "../../../node_modules/bootstrap/less/input-groups.less";
+  @import (reference) "../../../node_modules/bootstrap/less/breadcrumbs.less";
+  @import (reference) "../../../node_modules/bootstrap/less/pagination.less";
+  @import (reference) "../../../node_modules/bootstrap/less/labels.less";
+  @import (reference) "../../../node_modules/bootstrap/less/badges.less";
+  @import (reference) "../../../node_modules/bootstrap/less/jumbotron.less";
+  @import (reference) "../../../node_modules/bootstrap/less/alerts.less";
+  @import (reference) "../../../node_modules/bootstrap/less/progress-bars.less";
+  @import (reference) "../../../node_modules/bootstrap/less/media.less";
+  @import (reference) "../../../node_modules/bootstrap/less/list-group.less";
+  @import (reference) "../../../node_modules/bootstrap/less/responsive-embed.less";
+  @import (reference) "../../../node_modules/bootstrap/less/wells.less";
+  @import (reference) "../../../node_modules/bootstrap/less/close.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/navs.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/navbar.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/pager.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/thumbnails.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/panels.less";
+
+  // Components w/ JavaScript
+  @import (reference) "../../../node_modules/bootstrap/less/tooltip.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/modals.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/popovers.less";
+
+  // Utility classes
+  @import (reference) "../../../node_modules/bootstrap/less/utilities.less";
+  //@import (reference) "../../../node_modules/bootstrap/less/responsive-utilities.less";
+}

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -1,4 +1,4 @@
-
+@import (once, reference) 'bootstrap/bootstrap';
 @import 'grid';
 @import 'header';
 @import 'body';


### PR DESCRIPTION
# Adds Twitter Bootstrap Less components
This allows the twitter bootstrap less elements to be used inside of
ui-grid without causing naming conflicts.
Bootstrap less components only get imported if they are used in the less files.

## Usage
Twitter Bootstrap elements can be used inside of the less files by using the namespace `#ui-grid-twbs`
Example:
````less
button {
  #ui-grid-twbs > .btn;
  #ui-grid-twbs > .button-size(1px; 1px; 10px; 1; 2px);
  #ui-grid-twbs > .button-variant(@headerGradientStart, @headerBackgroundColor, @paginationButtonBorder);
}
```

## Why?
This allows ui-grid to take advantage of the many browser workaround and fixes that bootstrap has already implemented. This means we can take advantage of its power without needing to worry about it increasing the size of the css file. At the same time it won't cause conflicts with other developers install of bootstrap as all of ui-grids bootstrap usages are namespaced.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3909)
<!-- Reviewable:end -->
