### PR TITLE
Sorting to asc from desc doesn't work when suppressRemoveSort is set to false

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1957,9 +1957,9 @@ angular.module('ui.grid')
         column.sort.direction = uiGridConstants.DESC;
       }
       else if (column.sort.direction && column.sort.direction === uiGridConstants.DESC) {
-        if ( column.colDef && column.suppressRemoveSort ){
-          column.sort.direction = uiGridConstants.ASC;
-        } else {
+        column.sort.direction = uiGridConstants.ASC;
+
+        if (!(column.colDef && column.suppressRemoveSort)) {
           column.sort = {};
         }
       }


### PR DESCRIPTION
When clicking on a column to sort it (not via the menu dropdown), it sorts in asc order correctly. I then can click it again and it will sort in desc order correctly. If I then attempt to sort it asc again by clicking the column a 3rd time, nothing happens.  If I then set suppressRemoveSort = true for my column in the columnDef, then the sort works as expected.

I traced this back to the code in question. Removing the check for suppressRemoveSort fixes the issue for my particular case.  I do not fully understand what the purpose of this check is so I fully admit that this may regress some obscure state in the grid that I don't understand.  

In any case, I my change is correct and if the suppressRemoveSort check needs to be re-instated it should probably outside of this particular if/else block and should stand on its own.  

Definitely open to discussing, but the sorting does seem to function as expected with this change.

Thanks!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3993)
<!-- Reviewable:end -->
