### PR TITLE
Wrong url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ We're always looking for new contributors, for pro-level contribution guidelines
 ```
 
 ```html
-    <link rel="stylesheet" type="text/css" href="bower_components/angular-ui-grid/ui.grid.min.css">
-    <script src="bower_components/angular-ui-grid/ui.grid.min.js">
+    <link rel="stylesheet" type="text/css" href="bower_components/angular-ui-grid/ui-grid.min.css">
+    <script src="bower_components/angular-ui-grid/ui-grid.min.js">
 ```
 
 ## NPM


### PR DESCRIPTION
Grunt build uses pkg.name which is `ui-grid`. Documentation uses . as a separator. 

- Change url in README.md