### PR TITLE
Update Grid.js

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -974,7 +974,7 @@ angular.module('ui.grid')
 
   /**
    * @ngdoc function
-   * @name hasLeftContainer
+   * @name hasRightContainer
    * @methodOf ui.grid.class:Grid
    * @description returns true if rightContainer exists
    */


### PR DESCRIPTION
fix(docs): rename hasLeftContainer to hasRightContainer
Fixes for **Ctrl + C, Ctrl + V** programming style