### PR TITLE
feat(exporter): add exporterPdfPrefix and exporterPdfPostfix options

### DIFF
--- a/misc/tutorial/206_exporting_data.ngdoc
+++ b/misc/tutorial/206_exporting_data.ngdoc
@@ -72,6 +72,19 @@ In this example we use the native grid menu buttons, and we show both the pdf an
         exporterPdfOrientation: 'portrait',
         exporterPdfPageSize: 'LETTER',
         exporterPdfMaxGridWidth: 500,
+        exporterPdfPrefix : [
+          {
+            text: 'My prefix - custom title of pdf export',
+            style: "headerStyle"
+          },
+          {
+            text: 'Prefix can contain several differently formatted sections',
+            margin: [10,10,10,10]
+          }
+        ],
+        exporterPdfPostfix: {
+          text: "My postfix - add anything at the end of exported document"
+        }
         exporterCsvLinkElement: angular.element(document.querySelectorAll(".custom-csv-link-location")),
         onRegisterApi: function(gridApi){
           $scope.gridApi = gridApi;

--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -355,6 +355,77 @@
           gridOptions.exporterPdfMaxGridWidth = gridOptions.exporterPdfMaxGridWidth ? gridOptions.exporterPdfMaxGridWidth : 720;
           /**
            * @ngdoc object
+           * @name exporterPdfPrefix
+           * @propertyOf  ui.grid.exporter.api:GridOptions
+           * @description content which will be displayed above 
+           * the exported table, but not in the header.
+           * Can be array or just one object 
+           * in a same format as pdfMake document definition's content,
+           * for example
+           * <pre>
+           *   gridOptions.exporterPdfPrefix = 'My Prefix';
+           * </pre>
+           * or 
+           * <pre>
+           *   gridOptions.exporterPdfPrefix = {
+           *     text: 'This is my prefix',
+           *     style: 'myCustomStyle'
+           *   }
+           * </pre>
+           * or 
+           * <pre>
+           *   gridOptions.exporterPdfPrefix = [
+           *     {
+           *       text: 'This is my prefix'
+           *     },
+           *     {
+           *       text: 'There is some more text in prefix',
+           *       margin: [-25,0,0,0],
+           *       style: 'myCustomStyle1'
+           *     }
+           *   ]
+           * </pre>
+           * <br/>Defaults to null
+           */
+          gridOptions.exporterPdfPrefix = gridOptions.exporterPdfPrefix ? gridOptions.exporterPdfPrefix : null;
+          /**
+           * @ngdoc object
+           * @name exporterPdfPostfix
+           * @propertyOf  ui.grid.exporter.api:GridOptions
+           * @description content which will be displayed below
+           * the exported table, but not in the footer.
+           * Can be array or just one object
+           * in a same format as pdfMake document definition's content,
+           * for example
+           * <pre>
+           *   gridOptions.exporterPdfPostfix = 'My postfix';
+           * </pre>
+           * or 
+           * <pre>
+           *   gridOptions.exporterPdfPostfix = {
+           *     text: 'This is my postfix',
+           *     style: 'myCustomStyle'
+           *   }
+           * </pre>
+           * or 
+           * <pre>
+           *   gridOptions.exporterPdfPostfix = [
+           *     {
+           *       text: 'This is my postfix'
+           *     },
+           *     {
+           *       text: 'There is some more text in postfix',
+           *       margin: [-25,0,0,0],
+           *       style: 'myCustomStyle1'
+           *     }
+           *   ]
+           * </pre>
+           * <br/>Defaults to null
+           */
+          gridOptions.exporterPdfPostfix = gridOptions.exporterPdfPostfix ? gridOptions.exporterPdfPostfix : null;
+
+          /**
+           * @ngdoc object
            * @name exporterPdfTableLayout
            * @propertyOf  ui.grid.exporter.api:GridOptions
            * @description A tableLayout in pdfMake format,
@@ -1046,18 +1117,35 @@
           var stringData = exportData.map(this.formatRowAsPdf(this));
 
           var allData = [headerColumns].concat(stringData);
+          var docDefinitionContent = [
+             {
+               style: 'tableStyle',
+                 table: {
+                   headerRows: 1,
+                   widths: headerWidths,
+                   body: allData
+               }
+             }
+           ];
+
+          if ( grid.options.exporterPdfPrefix ) {
+            var docPrefix;
+            if ( angular.isArray(grid.options.exporterPdfPrefix) ) {
+              docPrefix = grid.options.exporterPdfPrefix;
+            } else {
+              docPrefix = [grid.options.exporterPdfPrefix];
+            }
+            docDefinitionContent = docPrefix.concat(docDefinitionContent);
+          }
+
+          if ( grid.options.exporterPdfPostfix ) {
+            docDefinitionContent = docDefinitionContent.concat(grid.options.exporterPdfPostfix);
+          }
 
           var docDefinition = {
             pageOrientation: grid.options.exporterPdfOrientation,
             pageSize: grid.options.exporterPdfPageSize,
-            content: [{
-              style: 'tableStyle',
-              table: {
-                headerRows: 1,
-                widths: headerWidths,
-                body: allData
-              }
-            }],
+            content: docDefinitionContent,
             styles: {
               tableStyle: grid.options.exporterPdfTableStyle,
               tableHeader: grid.options.exporterPdfTableHeaderStyle

--- a/src/features/exporter/test/exporter.spec.js
+++ b/src/features/exporter/test/exporter.spec.js
@@ -81,6 +81,8 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterPdfPageSize : 'A4',
         exporterPdfMaxGridWidth : 720,
         exporterPdfCustomFormatter: jasmine.any(Function),
+        exporterPdfPrefix: null,
+        exporterPdfPostfix: null,
         exporterHeaderFilterUseName: false,
         exporterMenuAllData: true,
         exporterMenuCsv: true,
@@ -109,6 +111,8 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterPdfPageSize : 'LETTER',
         exporterPdfMaxGridWidth : 670,
         exporterPdfCustomFormatter: callback,
+        exporterPdfPrefix: 'My Prefix',
+        exporterPdfPostfix: 'My Postfix',
         exporterHeaderFilterUseName: true,
         exporterMenuAllData: false,
         exporterMenuCsv: false,
@@ -134,6 +138,8 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         exporterPdfPageSize : 'LETTER',
         exporterPdfMaxGridWidth : 670,
         exporterPdfCustomFormatter: callback,
+        exporterPdfPrefix: 'My Prefix',
+        exporterPdfPostfix: 'My Postfix',
         exporterHeaderFilterUseName: true,
         exporterMenuAllData: false,
         exporterMenuCsv: false,
@@ -410,7 +416,19 @@ describe('ui.grid.exporter uiGridExporterService', function () {
       grid.options.exporterPdfOrientation = 'portrait';
       grid.options.exporterPdfPageSize = 'LETTER';
       grid.options.exporterPdfMaxGridWidth = 500;
-      
+      grid.options.exporterPdfPrefix = {
+        text: 'My prefix'
+      };
+      grid.options.exporterPdfPostfix = [
+        {
+          text: 'My postfix',
+          margin: [-25, 0, 0, 0]
+        },
+        {
+          text: 'More text in postfix',
+          style: 'headerStyle'
+        }
+      ];
       var columnHeaders = [
         {name: 'col1', displayName: 'Col1', width: 100, exporterPdfAlign: 'right'},
         {name: 'col2', displayName: 'Col2', width: '*', exporterPdfAlign: 'left'},
@@ -430,7 +448,10 @@ describe('ui.grid.exporter uiGridExporterService', function () {
       expect(result).toEqual({
         pageOrientation : 'portrait',
         pageSize: 'LETTER', 
-        content : [
+        content: [
+          {
+            text: 'My prefix'
+          },
           { 
             style : 'tableStyle', 
             table : { 
@@ -448,8 +469,16 @@ describe('ui.grid.exporter uiGridExporterService', function () {
                 [ {text: date.toISOString(), alignment: 'right'}, {text: '45', alignment: 'center'}, {text: 'A string', alignment: 'left'}, 'TRUE' ] 
               ] 
             } 
+          },
+          {
+            text: 'My postfix',
+            margin: [-25, 0, 0, 0]
+          },
+          {
+            text: 'More text in postfix',
+            style: 'headerStyle'
           }
-         ],
+        ],
         header : "My Header",
         footer : "My Footer",  
         styles : { 
@@ -464,9 +493,8 @@ describe('ui.grid.exporter uiGridExporterService', function () {
         defaultStyle : { 
           fontSize : 10 
         }
-      }); 
-      
-    });    
+      });
+    });
   });
   
   describe( 'calculatePdfHeaderWidths', function() {


### PR DESCRIPTION
Adds two grid options, exporterPdfPrefix and exporterPdfPostfix,
allowing to display custom content in pdf export
before and after the exported grid

Resolves #4073