### PR TITLE
Support function templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="v3.0.4"></a>
+### v3.0.4 (2015-08-13)
+
+
+#### Bug Fixes
+
+* **grouping:** Grouping now raises a sort changed event ([d30b1ad3](http://github.com/angular-ui/ng-grid/commit/d30b1ad343ace939bf165bad2b061638a1404692), closes [#4155](http://github.com/angular-ui/ng-grid/issues/4155))
+
 <a name="v3.0.3"></a>
 ### v3.0.3 (2015-08-10)
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-grid",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "homepage": "http://ui-grid.info",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-grid",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A data grid for Angular",
   "directories": {
     "test": "test"


### PR DESCRIPTION
ui-grid fails when template is defined as a function, for example:
````
$templateCache.put('ui-grid/uiGridCell', function () {
   return "<div class=\"ui-grid-cell-contents\" title=\"TOOLTIP\">{{COL_FIELD CUSTOM_FILTERS}}</div>"
});
````