### PR TITLE
extended gridedit api to allow invoking cell editor by row/column

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -114,8 +114,9 @@
             methods: {
               edit: {
                 /**
-                 * @ngDoc method
+                 * @ngDoc function
                  * @name editCell
+                 * @methodOf ui.grid.edit.api:PublicApi
                  * @description invokes a cells editor and optionally allows the edit to persist
                  * <pre>
                  *      gridApi.edit.editCell(row, col, true);
@@ -131,8 +132,9 @@
                   this.rows[row].cols[col].$scope.$broadcast('editCell');
                 },
                 /**
-                 * @ngDoc method
+                 * @ngDoc function
                  * @name editEditCell
+                 * @methodOf ui.grid.edit.api:PublicApi
                  * @description cancels a cells editor if persisted by editCell(...)
                  * <pre>
                  *      gridApi.edit.endEditCell(row, col);
@@ -519,7 +521,7 @@
             if (!$scope.row.cols) {
               $scope.row.cols = [];
             }
-            $scope.row.cols[$scope.colRenderIndex] = { "$scope": $scope, "$elm": $elm };
+            $scope.row.cols.push({ "$scope": $scope, "$elm": $elm });
 
             // Bind to keydown events in the render container
             if (uiGridCtrl && uiGridCtrl.grid.api.cellNav) {

--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -126,10 +126,11 @@
                  * @param {boolean} persist the cell in edit mode. Prevent cancel events such as scroll from removing the editor
                  */
                 editCell: function (row, col, persist) {
+                  var cellScope = this.element.find("div[id*=" + row.toString() + "-" + this.columns[col].uid + "]").scope();
                   if (persist) {
-                    this.rows[row].cols[col].$scope.persistEdit = true;
+                    cellScope.persistEdit = true;
                   }
-                  this.rows[row].cols[col].$scope.$broadcast('editCell');
+                  cellScope.$broadcast('editCell');
                 },
                 /**
                  * @ngDoc function
@@ -143,8 +144,9 @@
                  * @param {integer} col of the cell to edit
                  */
                 endEditCell: function (row, col) {
-                  this.rows[row].cols[col].$scope.persistEdit = false;
-                  this.rows[row].cols[col].$scope.$broadcast('endEditCell', false);
+                  var cellScope = this.element.find("div[id*=" + row.toString() + "-" + this.columns[col].uid + "]").scope();
+                  cellScope.persistEdit = false;
+                  cellScope.$broadcast('endEditCell', false);
                 }
 
               }
@@ -518,10 +520,6 @@
             }
 
             var cellNavNavigateDereg = function() {};
-            if (!$scope.row.cols) {
-              $scope.row.cols = [];
-            }
-            $scope.row.cols.push({ "$scope": $scope, "$elm": $elm });
 
             // Bind to keydown events in the render container
             if (uiGridCtrl && uiGridCtrl.grid.api.cellNav) {

--- a/src/features/edit/test/uiGridCell.spec.js
+++ b/src/features/edit/test/uiGridCell.spec.js
@@ -1,3 +1,10 @@
+/* global angular */
+/* global input */
+/* global it */
+/* global describe */
+/* global beforeEach */
+/* global expect */
+/* global jQuery */
 describe('ui.grid.edit GridCellDirective', function () {
   var gridUtil;
   var scope;
@@ -109,7 +116,7 @@ describe('ui.grid.edit GridCellDirective', function () {
       //back to beginning
       expect(element.html()).toBe(displayHtml);
     });
-
+    
     it('should stop editing on tab', function () {
       //stop edit
       var event = jQuery.Event("keydown");
@@ -149,6 +156,101 @@ describe('ui.grid.edit GridCellDirective', function () {
 
     }));
 
+
+  });
+  it('should contain a method called editCell and endEditCell', function(){
+    expect(scope.grid.api.edit.editCell).toBeDefined();
+    expect(scope.grid.api.edit.endEditCell).toBeDefined();
+  });
+  it('should not persist edit is the parameter persist is not set', function(){
+    
+      element = angular.element('<div ui-grid-cell/>');
+      recompile();
+
+      var displayHtml = element.html();
+      expect(element.text()).toBe('val');
+      //invoke edit
+      scope.grid.api.edit.editCell(0, 0, false);
+      $timeout(function () {
+        expect(element.find('input')).toBeDefined();
+        expect(element.find('input').val()).toBe('val');
+        var event = jQuery.Event("keydown");
+        event.keyCode = uiGridConstants.keymap.ENTER;
+        element.find('input').trigger(event);
+        expect(element.html()).toBe(displayHtml);
+      });
+      $timeout.flush();
+  
+  });
+  describe('ui.grid.edit uiGridCell and uiGridEditor with editCell full workflow', function () {
+    var displayHtml;
+    beforeEach(function () {
+      element = angular.element('<div ui-grid-cell/>');
+      recompile();
+
+      displayHtml = element.html();
+      expect(element.text()).toBe('val');
+      //invoke edit
+      scope.grid.api.edit.editCell(0, 0, true);
+      $timeout(function () {
+        expect(element.find('input')).toBeDefined();
+        expect(element.find('input').val()).toBe('val');
+      });
+      $timeout.flush();
+    });
+
+    it('should not stop editing on enter', function () {
+      //stop edit
+      var event = jQuery.Event("keydown");
+      event.keyCode = uiGridConstants.keymap.ENTER;
+      element.find('input').trigger(event);
+      input = element.find('input');
+      //back to beginning
+      expect(input.length).toBe(1);
+      scope.grid.api.edit.endEditCell(0, 0);
+      input = element.find('input');
+      expect(input.length).toBe(0);
+    });
+
+    it('should not stop editing on esc', function () {
+      //stop edit
+      var event = jQuery.Event("keydown");
+      event.keyCode = uiGridConstants.keymap.ESC;
+      element.find('input').trigger(event);
+
+      //back to beginning
+      input = element.find('input');
+      expect(input.length).toBe(1);
+      scope.grid.api.edit.endEditCell(0, 0);
+      input = element.find('input');
+      expect(input.length).toBe(0);
+    });
+
+    it('should not stop editing on tab', function () {
+      //stop edit
+      var event = jQuery.Event("keydown");
+      event.keyCode = uiGridConstants.keymap.TAB;
+      element.find('input').trigger(event);
+
+      //back to beginning
+      input = element.find('input');
+      expect(input.length).toBe(1);
+      scope.grid.api.edit.endEditCell(0, 0);
+      input = element.find('input');
+      expect(input.length).toBe(0);
+    });
+
+    it('should not stop when grid scrolls', function () {
+      //stop edit
+      scope.grid.api.core.raise.scrollBegin();
+      scope.$digest();
+      //back to beginning
+      input = element.find('input');
+      expect(input.length).toBe(1);
+      scope.grid.api.edit.endEditCell(0, 0);
+      input = element.find('input');
+      expect(input.length).toBe(0);
+    });
 
   });
 


### PR DESCRIPTION
new to pull requests, hope im doing it right.
I have not put much here  because im hoping the documentation on the methods is mostly enough.
My main concern is around security. Im mostly used to working in Dojo which does not hide much and was hoping that adding an array of column scopes column directive to the row object was in fitting with the way things are done here.
```
            if (!$scope.row.cols) {
              $scope.row.cols = [];
            }
            $scope.row.cols[$scope.colRenderIndex] = { "$scope": $scope, "$elm": $elm };
```