### PR TITLE
Fix homepage tutorial link taking you to localhost

### DIFF
--- a/misc/site/index.html
+++ b/misc/site/index.html
@@ -70,7 +70,7 @@
             Download <small>( <%= version %> )</small>
           </a>
 
-          <a class="btn btn-success btn-large" href="http://<%= site %>/docs/#/tutorial" title="Tutorial">
+          <a class="btn btn-success btn-large" href="/docs/#/tutorial" title="Tutorial">
             <i class="fa fa-book fa-fw"></i>
             Tutorial
           </a>


### PR DESCRIPTION
Updated the link to match the tutorial href on the nav bar