### PR TITLE
feat(core): Add Clear all filters to grid menu

### DIFF
--- a/src/features/cellnav/test/uiGridCellNavService.spec.js
+++ b/src/features/cellnav/test/uiGridCellNavService.spec.js
@@ -162,20 +162,20 @@ describe('ui.grid.edit uiGridCellNavService', function () {
 
   describe('scrollTo', function () {
     /*
-     * We have 11 rows (10 visible) and 11 columns (10 visible).  The column widths are 
+     * We have 11 rows (10 visible) and 11 columns (10 visible).  The column widths are
      * 100 for the first 5, and 200 for the second 5.  Column 2 and row 2 are invisible.
      */
     var evt;
     var args;
     var $scope;
-    
+
     beforeEach(function(){
       var i, j, row;
       grid.options.columnDefs = [];
       for ( i = 0; i < 11; i++ ){
         grid.options.columnDefs.push({name: 'col' + i});
       }
-  
+
       grid.options.data = [];
       for ( i = 0; i < 11; i++ ){
         row = {};
@@ -184,16 +184,16 @@ describe('ui.grid.edit uiGridCellNavService', function () {
         }
         grid.options.data.push( row );
       }
-      
+
       uiGridCellNavService.initializeGrid(grid);
-      grid.modifyRows(grid.options.data);      
-      
+      grid.modifyRows(grid.options.data);
+
       grid.registerColumnBuilder(uiGridCellNavService.cellNavColumnBuilder);
       grid.buildColumns();
-      
+
       grid.columns[2].visible = false;
       grid.rows[2].visible = false;
-      
+
       grid.setVisibleColumns(grid.columns);
       grid.setVisibleRows(grid.rows);
 
@@ -202,14 +202,14 @@ describe('ui.grid.edit uiGridCellNavService', function () {
       for ( i = 0; i < 11; i++ ){
         grid.columns[i].drawnWidth = i < 6 ? 100 : 200;
       }
-      
+
       $scope = $rootScope.$new();
 
       args = null;
       grid.api.core.on.scrollEnd($scope, function( receivedArgs ){
         args = receivedArgs;
       });
-      
+
     });
 
 
@@ -232,7 +232,7 @@ describe('ui.grid.edit uiGridCellNavService', function () {
         grid.scrollTo( grid.options.data[0], null);
       });
       $timeout.flush();
-      
+
       expect(Math.round(args.y.percentage * 10)/10).toBe(0.1);
     });
 
@@ -241,7 +241,7 @@ describe('ui.grid.edit uiGridCellNavService', function () {
         grid.scrollTo( grid.options.data[10], null);
       });
       $timeout.flush();
-      
+
       expect(args.y.percentage).toBeGreaterThan(0.5);
       expect(args.x).toBe(null);
     });
@@ -251,7 +251,7 @@ describe('ui.grid.edit uiGridCellNavService', function () {
         grid.scrollTo( grid.options.data[5], null);
       });
       $timeout.flush();
-      
+
       expect(Math.round(args.y.percentage * 10)/10).toEqual( 0.5);
       expect(args.x).toBe(null);
     });
@@ -281,7 +281,7 @@ describe('ui.grid.edit uiGridCellNavService', function () {
         grid.scrollTo(  null, grid.columns[8].colDef);
       });
       $timeout.flush();
-      
+
       expect(isNaN(args.x.percentage)).toEqual( true );
     });
 
@@ -290,7 +290,7 @@ describe('ui.grid.edit uiGridCellNavService', function () {
         grid.scrollTo( null, null );
       });
       $timeout.flush();
-      
+
       expect(args).toEqual( null );
     });
   });

--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -190,6 +190,18 @@ angular.module('ui.grid')
         }
       }
 
+      var clearFilters = [{
+        title: i18nService.getSafeText('gridMenu.clearAllFilters'),
+        action: function ($event) {
+          $scope.grid.clearAllFilters(undefined, true, undefined);
+        },
+        shown: function() {
+          return $scope.grid.options.enableFiltering;
+        },
+        order: 100
+      }];
+      menuItems = menuItems.concat( clearFilters );
+
       menuItems = menuItems.concat( $scope.registeredMenuItems );
 
       if ( $scope.grid.options.gridMenuShowHideColumns !== false ){

--- a/src/js/i18n/cs.js
+++ b/src/js/i18n/cs.js
@@ -53,7 +53,8 @@
                   exporterSelectedAsCsv: 'Exportovat vybranné data do csv',
                   exporterAllAsPdf: 'Exportovat všechny data do pdf',
                   exporterVisibleAsPdf: 'Exportovat viditelné data do pdf',
-                  exporterSelectedAsPdf: 'Exportovat vybranné data do pdf'
+                  exporterSelectedAsPdf: 'Exportovat vybranné data do pdf',
+                clearAllFilters: 'Vyčistěte všechny filtry'
               },
               importer: {
                   noHeaders: 'Názvy sloupců se nepodařilo získat, obsahuje soubor záhlaví?',

--- a/src/js/i18n/da.js
+++ b/src/js/i18n/da.js
@@ -40,7 +40,8 @@
           exporterSelectedAsCsv: 'Export selected data as csv',
           exporterAllAsPdf: 'Export all data as pdf',
           exporterVisibleAsPdf: 'Export visible data as pdf',
-          exporterSelectedAsPdf: 'Export selected data as pdf'
+          exporterSelectedAsPdf: 'Export selected data as pdf',
+          clearAllFilters: 'Clear all filters'
         },
         importer: {
           noHeaders: 'Column names were unable to be derived, does the file have a header?',

--- a/src/js/i18n/de.js
+++ b/src/js/i18n/de.js
@@ -53,7 +53,8 @@
           exporterSelectedAsCsv: 'markierte Daten als CSV exportieren',
           exporterAllAsPdf: 'Alle Daten als PDF exportieren',
           exporterVisibleAsPdf: 'sichtbare Daten als PDF exportieren',
-          exporterSelectedAsPdf: 'markierte Daten als CSV exportieren'
+          exporterSelectedAsPdf: 'markierte Daten als CSV exportieren',
+          clearAllFilters: 'Alle filter reinigen'
         },
         importer: {
           noHeaders: 'Es konnten keine Spaltennamen ermittelt werden. Sind in der Datei Spaltendefinitionen enthalten?',

--- a/src/js/i18n/en.js
+++ b/src/js/i18n/en.js
@@ -69,7 +69,8 @@
           exporterSelectedAsCsv: 'Export selected data as csv',
           exporterAllAsPdf: 'Export all data as pdf',
           exporterVisibleAsPdf: 'Export visible data as pdf',
-          exporterSelectedAsPdf: 'Export selected data as pdf'
+          exporterSelectedAsPdf: 'Export selected data as pdf',
+          clearAllFilters: 'Clear all filters'
         },
         importer: {
           noHeaders: 'Column names were unable to be derived, does the file have a header?',

--- a/src/js/i18n/es.js
+++ b/src/js/i18n/es.js
@@ -50,7 +50,8 @@
           exporterSelectedAsCsv: 'Exportar selección como csv',
           exporterAllAsPdf: 'Exportar todo como pdf',
           exporterVisibleAsPdf: 'Exportar vista como pdf',
-          exporterSelectedAsPdf: 'Exportar selección como pdf'
+          exporterSelectedAsPdf: 'Exportar selección como pdf',
+          clearAllFilters: 'Limpiar todos los filtros'
         },
         importer: {
           noHeaders: 'No fue posible derivar los nombres de las columnas, ¿tiene encabezados el archivo?',

--- a/src/js/i18n/fa.js
+++ b/src/js/i18n/fa.js
@@ -56,7 +56,8 @@
           exporterSelectedAsCsv: 'خروجی داده\u200cهای انتخاب\u200cشده در فایل csv',
           exporterAllAsPdf: 'خروجی تمام داده\u200cها در فایل pdf',
           exporterVisibleAsPdf: 'خروجی داده\u200cهای قابل مشاهده در فایل pdf',
-          exporterSelectedAsPdf: 'خروجی داده\u200cهای انتخاب\u200cشده در فایل pdf'
+          exporterSelectedAsPdf: 'خروجی داده\u200cهای انتخاب\u200cشده در فایل pdf',
+          clearAllFilters: 'پاک کردن تمام فیلتر'
         },
         importer: {
           noHeaders: 'نام ستون قابل استخراج نیست. آیا فایل عنوان دارد؟',

--- a/src/js/i18n/fi.js
+++ b/src/js/i18n/fi.js
@@ -53,7 +53,8 @@
           exporterSelectedAsCsv: 'Vie valittu tieto csv-muodossa',
           exporterAllAsPdf: 'Vie tiedot pdf-muodossa',
           exporterVisibleAsPdf: 'Vie näkyvä tieto pdf-muodossa',
-          exporterSelectedAsPdf: 'Vie valittu tieto pdf-muodossa'
+          exporterSelectedAsPdf: 'Vie valittu tieto pdf-muodossa',
+          clearAllFilters: 'Puhdista kaikki suodattimet'
         },
         importer: {
           noHeaders: 'Sarakkeen nimiä ei voitu päätellä, onko tiedostossa otsikkoriviä?',

--- a/src/js/i18n/fr.js
+++ b/src/js/i18n/fr.js
@@ -50,7 +50,8 @@
           exporterSelectedAsCsv: 'Exporter les données sélectionnées en CSV',
           exporterAllAsPdf: 'Exporter toutes les données en PDF',
           exporterVisibleAsPdf: 'Exporter les données visibles en PDF',
-          exporterSelectedAsPdf: 'Exporter les données sélectionnées en PDF'
+          exporterSelectedAsPdf: 'Exporter les données sélectionnées en PDF',
+          clearAllFilters: 'Nettoyez tous les filtres'
         },
         importer: {
           noHeaders: 'Impossible de déterminer le nom des colonnes, le fichier possède-t-il une en-tête ?',

--- a/src/js/i18n/he.js
+++ b/src/js/i18n/he.js
@@ -48,7 +48,8 @@
           exporterSelectedAsCsv: 'Export selected data as csv',
           exporterAllAsPdf: 'Export all data as pdf',
           exporterVisibleAsPdf: 'Export visible data as pdf',
-          exporterSelectedAsPdf: 'Export selected data as pdf'
+          exporterSelectedAsPdf: 'Export selected data as pdf',
+          clearAllFilters: 'Clean all filters'
         },
         importer: {
           noHeaders: 'Column names were unable to be derived, does the file have a header?',

--- a/src/js/i18n/hy.js
+++ b/src/js/i18n/hy.js
@@ -53,7 +53,8 @@
           exporterSelectedAsCsv: 'Արտահանել ընտրված տվյալները CSV',
           exporterAllAsPdf: 'Արտահանել PDF',
           exporterVisibleAsPdf: 'Արտահանել երևացող տվյալները PDF',
-          exporterSelectedAsPdf: 'Արտահանել ընտրված տվյալները PDF'
+          exporterSelectedAsPdf: 'Արտահանել ընտրված տվյալները PDF',
+          clearAllFilters: 'Մաքրել բոլոր ֆիլտրերը'
         },
         importer: {
           noHeaders: 'Հնարավոր չեղավ որոշել սյան վերնագրերը։ Արդյո՞ք ֆայլը ունի վերնագրեր։',

--- a/src/js/i18n/it.js
+++ b/src/js/i18n/it.js
@@ -53,7 +53,8 @@
           exporterSelectedAsCsv: 'Esporta i dati selezionati in CSV',
           exporterAllAsPdf: 'Esporta tutti i dati in PDF',
           exporterVisibleAsPdf: 'Esporta i dati visibili in PDF',
-          exporterSelectedAsPdf: 'Esporta i dati selezionati in PDF'
+          exporterSelectedAsPdf: 'Esporta i dati selezionati in PDF',
+          clearAllFilters: 'Pulire tutti i filtri'
         },
         importer: {
           noHeaders: 'Impossibile reperire i nomi delle colonne, sicuro che siano indicati all\'interno del file?',

--- a/src/js/i18n/ja.js
+++ b/src/js/i18n/ja.js
@@ -50,7 +50,8 @@
           exporterSelectedAsCsv: '選択したデータをCSV形式でエクスポート',
           exporterAllAsPdf: 'すべてのデータをPDF形式でエクスポート',
           exporterVisibleAsPdf: '表示中のデータをPDF形式でエクスポート',
-          exporterSelectedAsPdf: '選択したデータをPDF形式でエクスポート'
+          exporterSelectedAsPdf: '選択したデータをPDF形式でエクスポート',
+          clearAllFilters: 'すべてのフィルタを清掃してください'
         },
         importer: {
           noHeaders: '列名を取得できません。ファイルにヘッダが含まれていることを確認してください。',

--- a/src/js/i18n/ko.js
+++ b/src/js/i18n/ko.js
@@ -50,7 +50,8 @@
           exporterSelectedAsCsv: 'csv로 선택된 데이터 내보내기',
           exporterAllAsPdf: 'pdf로 모든 데이터 내보내기',
           exporterVisibleAsPdf: 'pdf로 보이는 데이터 내보내기',
-          exporterSelectedAsPdf: 'pdf로 선택 데이터 내보내기'
+          exporterSelectedAsPdf: 'pdf로 선택 데이터 내보내기',
+          clearAllFilters: '모든 필터를 청소'
         },
         importer: {
           noHeaders: '컬럼명이 지정되어 있지 않습니다. 파일에 헤더가 명시되어 있는지 확인해 주세요.',

--- a/src/js/i18n/nl.js
+++ b/src/js/i18n/nl.js
@@ -50,7 +50,8 @@
           exporterSelectedAsCsv: 'Exporteer geselecteerde data als csv',
           exporterAllAsPdf: 'Exporteer alle data als pdf',
           exporterVisibleAsPdf: 'Exporteer zichtbare data als pdf',
-          exporterSelectedAsPdf: 'Exporteer geselecteerde data als pdf'
+          exporterSelectedAsPdf: 'Exporteer geselecteerde data als pdf',
+          clearAllFilters: 'Reinig alle filters'
         },
         importer: {
           noHeaders: 'Kolomnamen kunnen niet worden afgeleid. Heeft het bestand een header?',

--- a/src/js/i18n/pt-br.js
+++ b/src/js/i18n/pt-br.js
@@ -53,7 +53,8 @@
           exporterSelectedAsCsv: 'Exportar dados selecionados como csv',
           exporterAllAsPdf: 'Exportar todos os dados como pdf',
           exporterVisibleAsPdf: 'Exportar dados visíveis como pdf',
-          exporterSelectedAsPdf: 'Exportar dados selecionados como pdf'
+          exporterSelectedAsPdf: 'Exportar dados selecionados como pdf',
+          clearAllFilters: 'Limpar todos os filtros'
         },
         importer: {
           noHeaders: 'Nomes de colunas não puderam ser derivados. O arquivo tem um cabeçalho?',

--- a/src/js/i18n/pt.js
+++ b/src/js/i18n/pt.js
@@ -50,7 +50,8 @@
           exporterSelectedAsCsv: 'Exportar dados selecionados como csv',
           exporterAllAsPdf: 'Exportar todos os dados como pdf',
           exporterVisibleAsPdf: 'Exportar dados visíveis como pdf',
-          exporterSelectedAsPdf: 'Exportar dados selecionados como pdf'
+          exporterSelectedAsPdf: 'Exportar dados selecionados como pdf',
+          clearAllFilters: 'Limpar todos os filtros'
         },
         importer: {
           noHeaders: 'Nomes de colunas não puderam ser derivados. O ficheiro tem um cabeçalho?',
@@ -73,7 +74,7 @@
           aggregate_min: 'Agr: Min',
           aggregate_avg: 'Agr: Med',
           aggregate_remove: 'Agr: Remover'
-        }        
+        }
       });
       return $delegate;
     }]);

--- a/src/js/i18n/ru.js
+++ b/src/js/i18n/ru.js
@@ -49,7 +49,8 @@
           exporterSelectedAsCsv: 'Экспортировать выбранные данные в CSV',
           exporterAllAsPdf: 'Экспортировать всё в PDF',
           exporterVisibleAsPdf: 'Экспортировать видимые данные в PDF',
-          exporterSelectedAsPdf: 'Экспортировать выбранные данные в PDF'
+          exporterSelectedAsPdf: 'Экспортировать выбранные данные в PDF',
+          clearAllFilters: 'Очистите все фильтры'
         },
         importer: {
           noHeaders: 'Column names were unable to be derived, does the file have a header?',

--- a/src/js/i18n/sk.js
+++ b/src/js/i18n/sk.js
@@ -45,7 +45,8 @@
           exporterSelectedAsCsv: 'Export selected data as csv',
           exporterAllAsPdf: 'Export all data as pdf',
           exporterVisibleAsPdf: 'Export visible data as pdf',
-          exporterSelectedAsPdf: 'Export selected data as pdf'
+          exporterSelectedAsPdf: 'Export selected data as pdf',
+          clearAllFilters: 'Clear all filters'
         },
         importer: {
           noHeaders: 'Column names were unable to be derived, does the file have a header?',

--- a/src/js/i18n/sv.js
+++ b/src/js/i18n/sv.js
@@ -53,7 +53,8 @@
           exporterSelectedAsCsv: 'Exportera markerad data som CSV',
           exporterAllAsPdf: 'Exportera all data som PDF',
           exporterVisibleAsPdf: 'Exportera synlig data som PDF',
-          exporterSelectedAsPdf: 'Exportera markerad data som PDF'
+          exporterSelectedAsPdf: 'Exportera markerad data som PDF',
+          clearAllFilters: 'Rengör alla filter'
         },
         importer: {
           noHeaders: 'Kolumnnamn kunde inte härledas. Har filen ett sidhuvud?',

--- a/src/js/i18n/ta.js
+++ b/src/js/i18n/ta.js
@@ -53,7 +53,8 @@
           exporterSelectedAsCsv: 'தேர்ந்தெடுத்த தரவுகளை கோப்பாக்கு: csv',
           exporterAllAsPdf: 'எல்லா தரவுகளையும் கோப்பாக்கு: pdf',
           exporterVisibleAsPdf: 'இருக்கும் தரவுகளை கோப்பாக்கு: pdf',
-          exporterSelectedAsPdf: 'தேர்ந்தெடுத்த தரவுகளை கோப்பாக்கு: pdf'
+          exporterSelectedAsPdf: 'தேர்ந்தெடுத்த தரவுகளை கோப்பாக்கு: pdf',
+          clearAllFilters: 'Clear all filters'
         },
         importer: {
           noHeaders: 'பத்தியின் தலைப்புகளை பெற இயலவில்லை, கோப்பிற்கு தலைப்பு உள்ளதா?',

--- a/src/js/i18n/zh-cn.js
+++ b/src/js/i18n/zh-cn.js
@@ -50,7 +50,8 @@
           exporterSelectedAsCsv: '导出已选数据到CSV',
           exporterAllAsPdf: '导出全部数据到PDF',
           exporterVisibleAsPdf: '导出可见数据到PDF',
-          exporterSelectedAsPdf: '导出已选数据到PDF'
+          exporterSelectedAsPdf: '导出已选数据到PDF',
+          clearAllFilters: '清除所有过滤器'
         },
         importer: {
           noHeaders: '无法获取列名，确定文件包含表头？',

--- a/src/js/i18n/zh-tw.js
+++ b/src/js/i18n/zh-tw.js
@@ -50,7 +50,8 @@
           exporterSelectedAsCsv: '導出已選數據到CSV',
           exporterAllAsPdf: '導出全部數據到PDF',
           exporterVisibleAsPdf: '導出可見數據到PDF',
-          exporterSelectedAsPdf: '導出已選數據到PDF'
+          exporterSelectedAsPdf: '導出已選數據到PDF',
+          clearAllFilters: '清除所有过滤器'
         },
         importer: {
           noHeaders: '無法獲取列名，確定文件包含表頭？',

--- a/test/unit/core/directives/ui-grid-column-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-column-menu.spec.js
@@ -1,10 +1,10 @@
 describe('ui-grid-column-menu uiGridColumnMenuService', function () {
   var uiGridColumnMenuService;
   var gridClassFactory;
-  var grid; 
+  var grid;
   var $rootScope;
   var $scope;
-  
+
   beforeEach(module('ui.grid'));
 
   beforeEach( inject(function (_uiGridColumnMenuService_, _gridClassFactory_, _$rootScope_) {
@@ -26,7 +26,7 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function () {
       {col1: '3_1', col2: '3_2', col3: '3_3', col4: '3_4'},
       {col1: '4_1', col2: '4_2', col3: '4_3', col4: '4_4'}
     ];
-    
+
     grid.buildColumns();
     grid.modifyRows(grid.options.data);
     grid.setVisibleRows(grid.rows);
@@ -38,90 +38,90 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function () {
       var uiGridCtrlMock = { grid: grid };
       uiGridColumnMenuService.initialize( $scope, uiGridCtrlMock );
 
-      expect( uiGridCtrlMock.columnMenuScope ).toEqual( $scope );      
+      expect( uiGridCtrlMock.columnMenuScope ).toEqual( $scope );
       expect( $scope.grid ).toEqual( grid );
       expect( $scope.menuShown ).toEqual( false );
     });
-  }); 
+  });
 
 
   describe('setColMenuItemWatch: ', function () {
     it('sets the watch, col.menuItems added and noticed by the watch', function () {
       $scope.col = { uid: 'ui-grid-01x' };
-      $scope.defaultMenuItems = [ 
-        { title: 'a menu item' } 
+      $scope.defaultMenuItems = [
+        { title: 'a menu item' }
       ];
-      
+
       uiGridColumnMenuService.setColMenuItemWatch( $scope );
-      
+
       expect( $scope.menuItems ).toEqual( undefined );
-      
-      $scope.col.menuItems = [ 
-        { title: 'a different menu item'} 
+
+      $scope.col.menuItems = [
+        { title: 'a different menu item'}
       ];
-      
+
       $scope.$digest();
-      
+
       expect( $scope.menuItems ).toEqual( [
-        { title: 'a menu item' }, 
-        { title: 'a different menu item', context: jasmine.any(Object) } 
+        { title: 'a menu item' },
+        { title: 'a different menu item', context: jasmine.any(Object) }
       ] );
     });
-  }); 
+  });
 
 
   describe('sortable: ', function () {
     it('everything present: sortable', function () {
       $scope.col = { uid: 'ui-grid-01x', enableSorting: true };
       $scope.grid = {options: { enableSorting: true } };
-      
+
       expect( uiGridColumnMenuService.sortable( $scope ) ).toEqual( true );
     });
 
     it('grid.options missing', function () {
       $scope.col = { uid: 'ui-grid-01x', enableSorting: true };
       $scope.grid = {options: { } };
-      
+
       expect( uiGridColumnMenuService.sortable( $scope ) ).toEqual( false );
     });
 
     it('col missing', function () {
       $scope.grid = {options: { enableSorting: true } };
-      
+
       expect( uiGridColumnMenuService.sortable( $scope ) ).toEqual( false );
     });
 
     it('col enable sorting false', function () {
       $scope.col = { uid: 'ui-grid-01x', enableSorting: false };
       $scope.grid = {options: { enableSorting: true } };
-      
+
       expect( uiGridColumnMenuService.sortable( $scope ) ).toEqual( false );
     });
-  }); 
+  });
 
 
   describe('isActiveSort: ', function () {
     it('everything present: is active', function () {
       $scope.col = { uid: 'ui-grid-01x', sort: { direction: 'asc'} };
-      
+
       expect( uiGridColumnMenuService.isActiveSort( $scope, 'asc' ) ).toEqual( true );
     });
 
     it('everything present: is not active', function () {
       $scope.col = { uid: 'ui-grid-01x', sort: { direction: 'asc'} };
-      
+
       expect( uiGridColumnMenuService.isActiveSort( $scope, 'desc' ) ).toEqual( false );
     });
 
     it('direction missing', function () {
       $scope.col = { uid: 'ui-grid-01x', sort: { } };
-      
+
       expect( uiGridColumnMenuService.isActiveSort( $scope, 'desc' ) ).toEqual( false );
     });
 
     it('sort missing', function () {
       $scope.col = { uid: 'ui-grid-01x' };
-      
+
       expect( uiGridColumnMenuService.isActiveSort( $scope, 'desc' ) ).toEqual( false );
     });
 
@@ -129,34 +129,34 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function () {
       expect( uiGridColumnMenuService.isActiveSort( $scope, 'desc' ) ).toEqual( false );
     });
   });
-  
-  
+
+
   describe('suppressRemoveSort: ', function () {
     it('everything present: is suppressed', function () {
       $scope.col = { uid: 'ui-grid-01x', suppressRemoveSort: true };
-      
+
       expect( uiGridColumnMenuService.suppressRemoveSort( $scope ) ).toEqual( true );
-    });  
+    });
 
     it('not set: is not suppressed', function () {
       $scope.col = { uid: 'ui-grid-01x' };
-      
+
       expect( uiGridColumnMenuService.suppressRemoveSort( $scope ) ).toEqual( false );
-    });  
+    });
   });
-  
+
 
   describe('hideable: ', function () {
     it('everything present: is not hideable', function () {
       $scope.col = { uid: 'ui-grid-01x', colDef: { enableHiding: false } };
-      
+
       expect( uiGridColumnMenuService.hideable( $scope ) ).toEqual( false );
-    });  
+    });
 
     it('colDef missing: is  hideable', function () {
       $scope.col = { uid: 'ui-grid-01x' };
-      
+
       expect( uiGridColumnMenuService.hideable( $scope ) ).toEqual( true );
-    });  
+    });
   });
 });

--- a/test/unit/core/directives/ui-grid-menu-button.spec.js
+++ b/test/unit/core/directives/ui-grid-menu-button.spec.js
@@ -99,12 +99,12 @@ describe('ui-grid-menu-button uiGridGridMenuService', function () {
       uiGridGridMenuService.initialize( $scope, grid );
     });
 
-    it('nothing in any config', function () {
+    it('nothing in any config should have one element (ClearFilters)', function () {
       grid.options.gridMenuShowHideColumns = false;
 
       var menuItems = uiGridGridMenuService.getMenuItems( $scope );
 
-      expect( menuItems ).toEqual( [] );
+      expect( menuItems.length ).toEqual( 1);
     });
 
     it('grab bag of stuff', function () {
@@ -117,26 +117,28 @@ describe('ui-grid-menu-button uiGridGridMenuService', function () {
 
       var menuItems = uiGridGridMenuService.getMenuItems( $scope );
 
-      expect( menuItems.length ).toEqual(11, 'Should be 11 items, 2 from customItems, 2 from registered, 1 columns header, and 2x3 columns that allow hiding');
+      expect( menuItems.length ).toEqual(12, 'Should be 12 items, 2 from customItems, 2 from registered, 1 columns header, and 2x3 columns that allow hiding');
       expect( menuItems[0].title ).toEqual('x', 'Menu item 0 should be from register');
       expect( menuItems[1].title ).toEqual('y', 'Menu item 1 should be from register');
       expect( menuItems[2].title ).toEqual('z', 'Menu item 2 should be from customItem');
       expect( menuItems[3].title ).toEqual('a', 'Menu item 3 should be from customItem');
 
-      expect( menuItems[4].title ).toEqual('Columns:', 'Menu item 4 should be header');
-      expect( menuItems[5].title.toLowerCase() ).toEqual('fn_col1', 'Menu item 5 should be col1');
-      expect( menuItems[6].title.toLowerCase() ).toEqual('fn_col1', 'Menu item 6 should be col1');
-      expect( menuItems[7].title.toLowerCase() ).toEqual('fn_col3', 'Menu item 7 should be col3');
-      expect( menuItems[8].title.toLowerCase() ).toEqual('fn_col3', 'Menu item 8 should be col3');
-      expect( menuItems[9].title.toLowerCase() ).toEqual('fn_col4', 'Menu item 9 should be col4');
-      expect( menuItems[10].title.toLowerCase() ).toEqual('fn_col4', 'Menu item 10 should be col4');
+      //expect( menuItems[4].title ).toEqual('Columns:', 'Menu item 4 should be header');
+      expect( menuItems[4].title ).toEqual('Clear all filters', 'Menu item 4 Clear all filters');
+      expect( menuItems[5].title ).toEqual('Columns:', 'Menu item 5 should be header');
+      expect( menuItems[6].title.toLowerCase() ).toEqual('fn_col1', 'Menu item 5 should be col1');
+      expect( menuItems[7].title.toLowerCase() ).toEqual('fn_col1', 'Menu item 6 should be col1');
+      expect( menuItems[8].title.toLowerCase() ).toEqual('fn_col3', 'Menu item 7 should be col3');
+      expect( menuItems[9].title.toLowerCase() ).toEqual('fn_col3', 'Menu item 8 should be col3');
+      expect( menuItems[10].title.toLowerCase() ).toEqual('fn_col4', 'Menu item 9 should be col4');
+      expect( menuItems[11].title.toLowerCase() ).toEqual('fn_col4', 'Menu item 10 should be col4');
 
-      expect( menuItems[5].context.gridCol ).toEqual( grid.columns[0], 'column hide/show menus should have gridCol');
       expect( menuItems[6].context.gridCol ).toEqual( grid.columns[0], 'column hide/show menus should have gridCol');
-      expect( menuItems[7].context.gridCol ).toEqual( grid.columns[2], 'column hide/show menus should have gridCol');
+      expect( menuItems[7].context.gridCol ).toEqual( grid.columns[0], 'column hide/show menus should have gridCol');
       expect( menuItems[8].context.gridCol ).toEqual( grid.columns[2], 'column hide/show menus should have gridCol');
-      expect( menuItems[9].context.gridCol ).toEqual( grid.columns[3], 'column hide/show menus should have gridCol');
+      expect( menuItems[9].context.gridCol ).toEqual( grid.columns[2], 'column hide/show menus should have gridCol');
       expect( menuItems[10].context.gridCol ).toEqual( grid.columns[3], 'column hide/show menus should have gridCol');
+      expect( menuItems[11].context.gridCol ).toEqual( grid.columns[3], 'column hide/show menus should have gridCol');
 
     });
 
@@ -150,9 +152,9 @@ describe('ui-grid-menu-button uiGridGridMenuService', function () {
 
       var menuItems = uiGridGridMenuService.getMenuItems( $scope );
 
-      expect( menuItems.length ).toEqual(9, 'Should be 9 items, 1 columns header, and 2x4 columns that allow hiding');
-      expect( menuItems[0].title ).toEqual('Columns:', 'Menu item 0 should be header');
-      expect( menuItems[1].title ).toEqual('', 'Promise not resolved');
+      expect( menuItems.length ).toEqual(10, 'Should be 10 items, 1 columns header, 2x4 columns that allow hiding and clear all filters');
+      expect( menuItems[0].title ).toEqual('Clear all filters', 'Menu item 0 should be Clear all filters');
+      expect( menuItems[1].title ).toEqual('Columns:', 'Menu item 1 should be header');
       expect( menuItems[2].title ).toEqual('', 'Promise not resolved');
       expect( menuItems[3].title ).toEqual('', 'Promise not resolved');
       expect( menuItems[4].title ).toEqual('', 'Promise not resolved');
@@ -160,22 +162,24 @@ describe('ui-grid-menu-button uiGridGridMenuService', function () {
       expect( menuItems[6].title ).toEqual('', 'Promise not resolved');
       expect( menuItems[7].title ).toEqual('', 'Promise not resolved');
       expect( menuItems[8].title ).toEqual('', 'Promise not resolved');
+      expect( menuItems[9].title ).toEqual('', 'Promise not resolved');
 
       promises.forEach( function( promise, index ) {
         promise.resolve('resolve_' + index);
       });
       $scope.$digest();
 
-      expect( menuItems.length ).toEqual(9, 'Should be 9 items, 1 columns header, and 2x4 columns that allow hiding');
-      expect( menuItems[0].title ).toEqual('Columns:', 'Menu item 0 should be header');
-      expect( menuItems[1].title ).toEqual('resolve_0', 'Promise now resolved');
-      expect( menuItems[2].title ).toEqual('resolve_1', 'Promise now resolved');
-      expect( menuItems[3].title ).toEqual('resolve_2', 'Promise now resolved');
-      expect( menuItems[4].title ).toEqual('resolve_3', 'Promise now resolved');
-      expect( menuItems[5].title ).toEqual('resolve_4', 'Promise now resolved');
-      expect( menuItems[6].title ).toEqual('resolve_5', 'Promise now resolved');
-      expect( menuItems[7].title ).toEqual('resolve_6', 'Promise now resolved');
-      expect( menuItems[8].title ).toEqual('resolve_7', 'Promise now resolved');
+      expect( menuItems.length ).toEqual(10, 'Should be 10 items, 1 columns header, 2x4 columns that allow hiding and Clean all filters');
+      expect( menuItems[0].title ).toEqual('Clear all filters', 'Menu item 0 should be Clear all filters');
+      expect( menuItems[1].title ).toEqual('Columns:', 'Menu item 0 should be header');
+      expect( menuItems[2].title ).toEqual('resolve_0', 'Promise now resolved');
+      expect( menuItems[3].title ).toEqual('resolve_1', 'Promise now resolved');
+      expect( menuItems[4].title ).toEqual('resolve_2', 'Promise now resolved');
+      expect( menuItems[5].title ).toEqual('resolve_3', 'Promise now resolved');
+      expect( menuItems[6].title ).toEqual('resolve_4', 'Promise now resolved');
+      expect( menuItems[7].title ).toEqual('resolve_5', 'Promise now resolved');
+      expect( menuItems[8].title ).toEqual('resolve_6', 'Promise now resolved');
+      expect( menuItems[9].title ).toEqual('resolve_7', 'Promise now resolved');
     });
   });
 


### PR DESCRIPTION
I add a new menu label action call "Clear all filters". This action clear all existing filters in the grid. To enable you have to have enableFiltering = true.