### PR TITLE
fix(grouping): Grouping now raises a sort changed event

### DIFF
--- a/src/features/grouping/js/grouping.js
+++ b/src/features/grouping/js/grouping.js
@@ -681,13 +681,13 @@
           column.sort.direction = uiGridConstants.ASC;
         }
 
-        service.tidyPriorities( grid );
-
         column.treeAggregation = { type: uiGridGroupingConstants.aggregation.COUNT, source: 'grouping' };
         column.treeAggregationFn = uiGridTreeBaseService.nativeAggregations()[uiGridGroupingConstants.aggregation.COUNT].aggregationFn;
         column.treeAggregationFinalizerFn = service.groupedFinalizerFn;
 
         grid.api.grouping.raise.groupingChanged(column);
+        // This indirectly calls service.tidyPriorities( grid );
+        grid.api.core.raise.sortChanged(grid, grid.getColumnSorting());
 
         grid.queueGridRefresh();
       },

--- a/src/features/grouping/test/grouping.spec.js
+++ b/src/features/grouping/test/grouping.spec.js
@@ -482,6 +482,51 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
       });
     });
 
+    it('sorts', function(){
+      grid.grouping.groupingHeaderCache = {
+        male: {
+          row: { treeNode: { state: 'collapsed' } },
+          children: {
+            22: { row: { treeNode: { state: 'expanded' } }, children: {} },
+            39: { row: { treeNode: { state: 'collapsed' } }, children: {} }
+          }
+        },
+        female: {
+          row: { treeNode: { state: 'expanded' } },
+          children: {
+            23: { row: { treeNode: { state: 'collapsed' } }, children: {} },
+            38: { row: { treeNode: { state: 'expanded' } }, children: {} }
+          }
+        }
+      };
+
+      spyOn(grid.api.core.raise, 'sortChanged').andCallThrough();
+
+      grid.api.grouping.setGrouping({
+        grouping: [
+          { field: 'col3', colName: 'col3', groupPriority: 0 },
+          { field: 'col2', colName: 'col2', groupPriority: 1 }
+        ],
+        aggregations: [
+          { field: 'col1', colName: 'col1', aggregation: { type: uiGridGroupingConstants.aggregation.COUNT } }
+        ],
+        rowExpandedStates: {
+          male: { state: 'expanded', children: {
+            22: { state: 'collapsed' },
+            38: { state: 'expanded' }
+          } },
+          female: { state: 'expanded', children: {
+            23: { state: 'expanded' },
+            39: { state: 'collapsed' }
+          } }
+        }
+      });
+
+      // Should call sort change twice because we are grouping by two columns
+      expect(grid.api.core.raise.sortChanged.calls.length).toEqual(2);
+
+    });
+
   });
 
 


### PR DESCRIPTION
Grouping was not calling sort changed which meant that external sorting
with grouping wasn't working.
 - Adds a call to raise a `sortChanged` event when grouping.
 - Additionally adds a test to grouping to ensure that this event is
   raised.

Closes #4155