### PR TITLE
fix(pagination): avoid initial double firing of `paginationChanged`

### DIFF
--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -375,7 +375,7 @@
           var deregT = $scope.$watch('grid.options.totalItems + grid.options.paginationPageSize', setShowing);
 
           var deregP = $scope.$watch('grid.options.paginationCurrentPage + grid.options.paginationPageSize', function (newValues, oldValues) {
-              if (newValues === oldValues) {
+              if (newValues === oldValues || oldValues === undefined) {
                 return;
               }
 


### PR DESCRIPTION
When initially loading a grid with `ui.grid.pagination` and **external pagination** enabled, **paginationChanged** is triggered twice since the watcher values transition from `undefined` to the **initial value**

Found while developing a `pageSize` feature on an alternate pagination project: https://github.com/michaelbromley/angularUtils/issues/212