### PR TITLE
Fix typos in 'tutorial/216_expandable_grid'.

### DIFF
--- a/misc/tutorial/216_expandable_grid.ngdoc
+++ b/misc/tutorial/216_expandable_grid.ngdoc
@@ -22,9 +22,9 @@ Documentation for the expandable feature is provided in the api documentation, i
   }
 </pre>
 
-rowExpandableTemplate will be template for subgrid and expandableRowHeight will be height of the subgrid, expandableRowScope can be used
-to added variables to scope of expanded grid. These variables can then be access from expandableRowTemplate. The grid api
-provided following events and methods fos subGrids:
+expandableRowTemplate will be the template for subgrid and expandableRowHeight will be the height of the subgrid. expandableRowScope can be used
+to add variables to the scope of expanded grid. These variables can then be accessed from expandableRowTemplate. The grid api
+provides the following events and methods for subGrids:
 
 <pre>
     //rowExpandedStateChanged is fired for each row as its expanded:
@@ -37,7 +37,7 @@ provided following events and methods fos subGrids:
 
 SubGrid nesting can be done upto multiple levels.
 
-In addition to above configuration 'scrollFillerClass' is also available and can be used to style the scroll filler, scroll filler
+In addition to the above configuration, 'scrollFillerClass' is also available and can be used to style the scroll filler. The scroll filler
 appears when you quickly scroll through the grid.
 
 @example


### PR DESCRIPTION
The third paragraph in http://ui-grid.info/docs/#/tutorial/216_expandable_grid has a number of typos. This pull request provides some edits that should improve readability.