### PR TITLE
Fix bug in IE 10+ so that file export has options to save, cancel and…

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -901,7 +901,7 @@
 
           // IE10+
           if (navigator.msSaveBlob) {
-            return navigator.msSaveBlob(
+            return navigator.msSaveOrOpenBlob(
               new Blob(
                 [exporterOlderExcelCompatibility ? "\uFEFF" : '', csvContent],
                 { type: strMimeType } ),


### PR DESCRIPTION
#4230 

Current functionality only offers save and cancel. This change allows open, save and cancel to appear as options when exporting in IE 10+.