### PR TITLE
feat(core): Adds sort priority number to header

### DIFF
--- a/src/less/header.less
+++ b/src/less/header.less
@@ -79,6 +79,11 @@
   .sortable {
     cursor: pointer;
   }
+
+  // Moves the sort priority number closer to the icon
+  .ui-grid-sort-priority-number {
+    margin-left: -8px;
+  }
 }
 
 // Make vertical bar in header row fill the height of the cell completely

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -22,8 +22,11 @@
        ng-class="{ 'ui-grid-icon-up-dir': col.sort.direction == asc, 'ui-grid-icon-down-dir': col.sort.direction == desc, 'ui-grid-icon-blank': !col.sort.direction }"
        title="{{col.sort.priority ? i18n.headerCell.priority + ' ' + col.sort.priority : null}}"
        aria-hidden="true">
-       &nbsp;
      </i>
+     <sub
+       class="ui-grid-sort-priority-number">
+       {{col.sort.priority + 1}}
+     </sub>
     </span>
   </div>
 


### PR DESCRIPTION
The headers now show the sort priority of the column.
This is done using a subscript tag that is pulled closer to the sort
direction icon.
![New Sort Icons](https://cloud.githubusercontent.com/assets/1323708/9460714/cc9611ba-4ad6-11e5-8479-755cb6a84a86.png)