### PR TITLE
fix(cellNav): Error when field defined with number

### DIFF
--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -67,8 +67,8 @@
        *          If the column has a cellFilter this will NOT return the filtered value.
        */
       RowCol.prototype.getIntersectionValueRaw = function(){
-        var getter = $parse(this.col.field);
-        var context = this.row.entity;
+        var getter = $parse(this.row.getEntityQualifiedColField(this.col));
+        var context = this.row;
         return getter(context);
       };
       /**


### PR DESCRIPTION
Cell nav was throwing an error when you had a field defined like `'1.b'`
Resolved by using the `getQualifiedColField` method on the gridRow.

Closes #4258