### PR TITLE
Restore method returns promise to allow execution when grid is restored

### DIFF
--- a/src/features/saveState/js/saveState.js
+++ b/src/features/saveState/js/saveState.js
@@ -86,7 +86,7 @@
                  * @param {object} state the state that should be restored into the grid
                  */
                 restore: function ( $scope, state) {
-                  service.restore(grid, $scope, state);
+                  return service.restore(grid, $scope, state);
                 }
               }
             }
@@ -323,7 +323,7 @@
             service.restoreTreeView( grid, state.treeView );
           }
 
-          grid.refresh();
+          return grid.queueGridRefresh();
         },
 
 

--- a/src/features/saveState/test/saveState.spec.js
+++ b/src/features/saveState/test/saveState.spec.js
@@ -409,9 +409,9 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
 
       expect( onSortChangedHook.calls.length ).toEqual( 1 );
 
-      expect( onSortChangedHook ).toHaveBeenCalledWith( 
-        grid, 
-        [ grid.getOnlyDataColumns()[3], grid.getOnlyDataColumns()[2] ] 
+      expect( onSortChangedHook ).toHaveBeenCalledWith(
+        grid,
+        [ grid.getOnlyDataColumns()[3], grid.getOnlyDataColumns()[2] ]
       );
     });
 
@@ -744,5 +744,14 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
       expect( grid.api.core.scrollTo ).not.toHaveBeenCalled();
       expect( grid.api.cellNav.scrollToFocus ).toHaveBeenCalledWith( grid.rows[2].entity, grid.options.columnDefs[3] );
     });
+  });
+
+  it('returns promise after grid is refreshed', function() {
+    uiGridSelectionService.initializeGrid(grid);
+
+    var result = null;
+    uiGridSaveStateService.restoreSelection( grid, [ ]).then(function() { result = 'success'; });
+
+    expect( result === 'success' );
   });
 });


### PR DESCRIPTION
When using external filter / sort, it is necessary to reload data after filter / sort setting is restored. What I am missing in current implementation is the possibility of callback when the restore is completed. It triggers filter / sort changed events, but I cannot use it as it generates event for every single change to the filter and one for the sort. Maybe I am completely wrong with my proposal, what would be the proposed approach than?