### PR TITLE
Fix row width being shorter than header

### DIFF
--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -631,7 +631,7 @@ angular.module('ui.grid')
 
       } else if (gridUtil.endsWith(column.width, "%")) {
         // percentage width, set to percentage of the viewport
-        width = parseInt(parseInt(column.width.replace(/%/g, ''), 10) / 100 * availableWidth);
+        width = parseFloat(parseInt(column.width.replace(/%/g, ''), 10) / 100 * availableWidth);
 
         if ( width > column.maxWidth ){
           width = column.maxWidth;


### PR DESCRIPTION
example:
when the grid's total width is 150px, and we set column 1 to 25% and column 2 to 75%, column 1 will get rounded to 37px and column 2 will get rounded to 112px, leaving a 1px difference between the rows and the header. after fix, the column 1 will be 37.5px, column 2 will be 112.5px