### PR TITLE
Fix InvalidStateError in IE10

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -1010,7 +1010,7 @@
               });
             } catch (e) {
               // Old browser which can't handle it without making it an byte array (ie10) 
-              if (e.name == "InvalidStateError") {
+              if (e.name === "InvalidStateError") {
                 var byteArray = new Uint8Array(buffer);
                 blob = new Blob([byteArray.buffer], {
                   type: 'application/pdf'

--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -1004,8 +1004,19 @@
           var blob;
 
           doc.getBuffer( function (buffer) {
-            blob = new Blob([buffer]);
-
+            try {
+              blob = new Blob([buffer], {
+                type: 'application/pdf'
+              });
+            } catch (e) {
+              // Old browser which can't handle it without making it an byte array (ie10) 
+              if (e.name == "InvalidStateError") {
+                var byteArray = new Uint8Array(buffer);
+                blob = new Blob([byteArray.buffer], {
+                  type: 'application/pdf'
+                });
+              }
+            }
             if (ieVersion && ieVersion < 10) {
               var frame = D.createElement('iframe');
               document.body.appendChild(frame);


### PR DESCRIPTION
Tested in IE10 with pdfmake.js from https://github.com/rouanw/pdfmake/tree/bower because the orginal branch throw an Error

Changes found in: https://github.com/bpampuch/pdfmake/commit/df074b5adb1505fc89918a7963752c7dd791b0eb