### PR TITLE
fix the moveGroupColumn bug, return original columns instead of null

### DIFF
--- a/src/features/grouping/js/grouping.js
+++ b/src/features/grouping/js/grouping.js
@@ -608,7 +608,7 @@
        */
       moveGroupColumns: function( grid, columns, rows ){
         if ( grid.options.moveGroupColumns === false){
-          return;
+          return columns;
         }
 
         columns.forEach( function(column, index){


### PR DESCRIPTION
fix issue #4315 ,
simply return the original columns array, instead of null.