### PR TITLE
add preferredSortDirection column option

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1921,7 +1921,8 @@ angular.module('ui.grid')
    * Emits the sortChanged event whenever the sort criteria are changed.
    * @param {GridColumn} column Column to set the sorting on
    * @param {uiGridConstants.ASC|uiGridConstants.DESC} [direction] Direction to sort by, either descending or ascending.
-   *   If not provided, the column will iterate through the sort directions: ascending, descending, unsorted.
+   *   If not provided, the column will iterate through the sort directions: preferred, not-preferred, unsorted.
+   *   The default preferredSortDirection is ascending.
    * @param {boolean} [add] Add this column to the sorting. If not provided or set to `false`, the Grid will reset any existing sorting and sort
    *   by this column only
    * @returns {Promise} A resolved promise that supplies the column.
@@ -1956,18 +1957,19 @@ angular.module('ui.grid')
 
     if (!direction) {
       // Figure out the sort direction
-      if (column.sort.direction && column.sort.direction === uiGridConstants.ASC) {
-        column.sort.direction = uiGridConstants.DESC;
+      var otherDirection = column.preferredSortDirection === uiGridConstants.ASC ? uiGridConstants.DESC : uiGridConstants.ASC;
+      if (column.sort.direction && column.sort.direction === column.preferredSortDirection) {
+        column.sort.direction = otherDirection;
       }
-      else if (column.sort.direction && column.sort.direction === uiGridConstants.DESC) {
+      else if (column.sort.direction && column.sort.direction === otherDirection) {
         if ( column.colDef && column.suppressRemoveSort ){
-          column.sort.direction = uiGridConstants.ASC;
+          column.sort.direction = column.preferredSortDirection;
         } else {
           column.sort = {};
         }
       }
       else {
-        column.sort.direction = uiGridConstants.ASC;
+        column.sort.direction = column.preferredSortDirection;
       }
     }
     else {

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -314,6 +314,26 @@ angular.module('ui.grid')
    */
 
   /**
+   * @ngdoc property
+   * @name preferredSortDirection
+   * @propertyOf ui.grid.class:GridColumn
+   * @description Which direction to sort in for the first click on an unsorted
+   * column. Valid values are uiGridConstants.ASC and uiGridConstants.DESC. The
+   * default is uiGridConstants.ASC.
+   *
+   */
+
+  /**
+   * @ngdoc property
+   * @name preferredSortDirection
+   * @propertyOf ui.grid.class:GridOptions.columnDef
+   * @description Which direction to sort in for the first click on an unsorted
+   * column. Valid values are uiGridConstants.ASC and uiGridConstants.DESC. The
+   * default is uiGridConstants.ASC.
+   *
+   */
+
+  /**
    * @ngdoc array
    * @name filters
    * @propertyOf ui.grid.class:GridOptions.columnDef
@@ -650,6 +670,8 @@ angular.module('ui.grid')
     // Turn on sorting by default
     self.enableSorting = typeof(colDef.enableSorting) !== 'undefined' ? colDef.enableSorting : true;
     self.sortingAlgorithm = colDef.sortingAlgorithm;
+
+    self.preferredSortDirection = colDef.preferredSortDirection === uiGridConstants.DESC ? uiGridConstants.DESC : uiGridConstants.ASC;
 
     /**
      * @ngdoc boolean

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -713,8 +713,36 @@ describe('Grid factory', function () {
       expect( column.sort.priority ).toEqual(1);
     });
 
+    it( 'if sort is currently null, and preferredSortDirection is DESC, then should toggle to DESC, and reset priority', function() {
+      column.preferredSortDirection = uiGridConstants.DESC;
+      column.sort = {direction: null};
+      grid.sortColumn( column, false );
+      
+      expect( column.sort.direction ).toEqual(uiGridConstants.DESC);
+      expect( column.sort.priority ).toEqual(1);
+    });
+
     it( 'if sort is currently ASC, then should toggle to DESC, and reset priortiy', function() {
       column.sort = {direction: uiGridConstants.ASC, priority: 2};
+      grid.sortColumn( column, false );
+      
+      expect( column.sort.direction ).toEqual(uiGridConstants.DESC);
+      expect( column.sort.priority ).toEqual(1);
+    });
+
+    it( 'if sort is currently ASC, and preferredSortDirection is DESC, and suppressRemoveSort is undefined, then should toggle to null, and remove priority', function() {
+      column.preferredSortDirection = uiGridConstants.DESC;
+      column.sort = {direction: uiGridConstants.ASC};
+      grid.sortColumn( column, false );
+      
+      expect( column.sort.direction ).toEqual(null);
+      expect( column.sort.priority ).toEqual(null);
+    });
+
+    it( 'if sort is currently ASC, and preferredSortDirection is DESC, and suppressRemoveSort is true, then should toggle to DESC, and reset priority', function() {
+      column.preferredSortDirection = uiGridConstants.DESC;
+      column.sort = {direction: uiGridConstants.ASC};
+      column.suppressRemoveSort = true;
       grid.sortColumn( column, false );
       
       expect( column.sort.direction ).toEqual(uiGridConstants.DESC);
@@ -727,6 +755,15 @@ describe('Grid factory', function () {
       
       expect( column.sort.direction ).toEqual(null);
       expect( column.sort.priority ).toEqual(null);
+    });
+
+    it( 'if sort is currently DESC, and preferredSortDirection is DESC, then should toggle to ASC, and reset priority', function() {
+      column.preferredSortDirection = uiGridConstants.DESC;
+      column.sort = {direction: uiGridConstants.DESC};
+      grid.sortColumn( column, false );
+      
+      expect( column.sort.direction ).toEqual(uiGridConstants.ASC);
+      expect( column.sort.priority ).toEqual(1);
     });
 
     it( 'if sort is currently DESC, and suppressRemoveSort is null, then should toggle to null, and remove priority', function() {


### PR DESCRIPTION
This implements the "default sort direction" feature requested in #4242. The columnDef now accepts a new option called "preferredSortDirection" which controls the initial sorting direction when clicking on an unsorted column. Previously this would always be uiGridConstants.ASC.

Please let me know if there's anything I could improve about this PR :-)