### PR TITLE
Hide header in CSV export. #4307

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -606,7 +606,7 @@
         csvExport: function (grid, rowTypes, colTypes) {
           var self = this;
           this.loadAllDataIfNeeded(grid, rowTypes, colTypes).then(function() {
-            var exportColumnHeaders = self.getColumnHeaders(grid, colTypes);
+            var exportColumnHeaders = grid.options.showHeader ? self.getColumnHeaders(grid, colTypes) : [];
             var exportData = self.getData(grid, rowTypes, colTypes);
             var csvContent = self.formatAsCsv(exportColumnHeaders, exportData, grid.options.exporterCsvColumnSeparator);
 
@@ -810,7 +810,7 @@
 
           var bareHeaders = exportColumnHeaders.map(function(header){return { value: header.displayName };});
 
-          var csv = self.formatRowAsCsv(this, separator)(bareHeaders) + '\n';
+          var csv = bareHeaders.length > 0 ? (self.formatRowAsCsv(this, separator)(bareHeaders) + '\n') : '';
 
           csv += exportData.map(this.formatRowAsCsv(this, separator)).join('\n');
 

--- a/src/features/exporter/test/exporter.spec.js
+++ b/src/features/exporter/test/exporter.spec.js
@@ -284,7 +284,7 @@ describe('ui.grid.exporter uiGridExporterService', function () {
       var separator = ',';
 
       expect(uiGridExporterService.formatAsCsv(columnHeaders, data, separator)).toEqual(
-        "\n"
+        ""
       );
     });
 


### PR DESCRIPTION
The CSV export should now show/hide the header values depending on the value chosen for the showHeader grid option.  