### PR TITLE
fix(infinite-scroll): load more data if needed

### DIFF
--- a/src/features/infinite-scroll/js/infinite-scroll.js
+++ b/src/features/infinite-scroll/js/infinite-scroll.js
@@ -368,6 +368,12 @@
 
           newVisibleRows = grid.getVisibleRowCount();
 
+          // in case not enough data is loaded to enable scroller - load more data
+          var canvasHeight = rowHeight * newVisibleRows;
+          if (grid.infiniteScroll.scrollDown && (viewportHeight > canvasHeight)) {
+            grid.api.infiniteScroll.raise.needLoadMoreData();
+          }
+
           if ( grid.infiniteScroll.direction === uiGridConstants.scrollDirection.UP ){
             oldTop = grid.infiniteScroll.prevScrollTop || 0;
             newTop = oldTop + (newVisibleRows - grid.infiniteScroll.previousVisibleRows)*rowHeight;


### PR DESCRIPTION
detect if more data needs to be loaded after the initial load. Before if
not enough data was loaded to enable scrolling, no more data would be
loaded. Resolves issue [4363](https://github.com/angular-ui/ui-grid/issues/4363)