### PR TITLE
Fix bug: expectRowCount will get doubled row count if there're pinned columns

### DIFF
--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -149,7 +149,7 @@ module.exports = {
   */
   expectRowCount: function( gridId, expectedNumRows ) {
 
-    var rows = this.getGrid( gridId ).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index') );
+    var rows = this.getGrid( gridId ).element( by.css('.ui-grid-render-container-body')).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index') );
     expect(rows.count()).toEqual(expectedNumRows);
   },
 


### PR DESCRIPTION
There's a bug in `gridTestUtils.expectRowCount` when there are pinned columns. It will get doubled row counts, one for pinned(in `.ui-grid-render-container-left`), the other for main(in `.ui-grid-render-container-body`).
This commit solves the issue.