### PR TITLE
fix(header): change overflow to auto

### DIFF
--- a/src/less/header.less
+++ b/src/less/header.less
@@ -14,7 +14,7 @@
     position: relative;
     // border-bottom: 1px solid @borderColor; // #D4D4D4
 
-    overflow: hidden;  // Disable so menus show up
+    overflow: auto; // set to auto, so that header will show up on Chrome 45
     font-weight: bold;
 
     // .gradient(@headerBackgroundColor, @headerGradientStart, @headerGradientStop);


### PR DESCRIPTION
The header will not show up in Chrome 45. Header will now show up in all browsers.

Closes #4376.