### PR TITLE
fix(pagination): fix pager select not showing 3 digits on some browsers

### DIFF
--- a/src/features/pagination/less/pagination.less
+++ b/src/features/pagination/less/pagination.less
@@ -94,7 +94,7 @@
     #ui-grid-twbs > .form-control;
     #ui-grid-twbs > .input-sm ();
     height: 26px;
-    width: 60px;
+    width: 67px;
     display: inline;
   }
 


### PR DESCRIPTION
In Chrome/IE11 on Windows the pager select wasn't showing more than 2 digits

Fix for #4380