### PR TITLE
fix(edit): editable cell template fix

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -784,9 +784,9 @@
                 deregOnEndCellEdit();
               });
 
-              $scope.$broadcast(uiGridEditConstants.events.BEGIN_CELL_EDIT, triggerEvent);
               $timeout(function () {
                 //execute in a timeout to give any complex editor templates a cycle to completely render
+				$scope.$broadcast(uiGridEditConstants.events.BEGIN_CELL_EDIT, triggerEvent);
                 $scope.grid.api.edit.raise.beginCellEdit($scope.row.entity, $scope.col.colDef, triggerEvent);
               });
             }


### PR DESCRIPTION
Fix cell editing for editable cell templates that contain multiple possible "editors"
(ex: a template that renders either an input or a select by using ng-if directives).

Plunker demonstrating the issue resolved by this fix:
http://plnkr.co/edit/8IuMTZAqFEzrOsBPBJoQ?p=preview
