### PR TITLE
fix(core): Fixes sort priority starting at 2

### DIFF
--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -25,7 +25,7 @@
      </i>
      <sub
        class="ui-grid-sort-priority-number">
-       {{col.sort.priority + 1}}
+       {{col.sort.priority}}
      </sub>
     </span>
   </div>


### PR DESCRIPTION
The sort priority was starting at 2 when the headers or menu buttons
were used to sort. Unfortunately, this will show up strangely for users
who use sort priority 0 when configuring the grid settings.