### PR TITLE
Update Grid.js modifyRows documentation to match function code

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1065,6 +1065,7 @@ angular.module('ui.grid')
    * @methodOf ui.grid.class:Grid
    * @description creates or removes GridRow objects from the newRawData array.  Calls each registered
    * rowBuilder to further process the row
+   * @param {array} newRawData Modified set of data
    *
    * This method aims to achieve three things:
    * 1. the resulting rows array is in the same order as the newRawData, we'll call
@@ -1088,6 +1089,16 @@ angular.module('ui.grid')
    *
    * Rows are identified using the hashKey if configured.  If not configured, then rows
    * are identified using the gridOptions.rowEquality function
+   * 
+   * This method is useful when trying to select rows immediately after loading data without
+   * using a $timeout/$interval, e.g.:
+   * 
+   *   $scope.gridOptions.data =  someData;
+   *   $scope.gridApi.grid.modifyRows($scope.gridOptions.data);
+   *   $scope.gridApi.selection.selectRow($scope.gridOptions.data[0]);
+   * 
+   * OR to persist row selection after data update (e.g. rows selected, new data loaded, want
+   * originally selected rows to be re-selected))
    */
   Grid.prototype.modifyRows = function modifyRows(newRawData) {
     var self = this;


### PR DESCRIPTION
Current `modifyRows` documentation does not indicate the need to pass `newRawData` parameter.  Also doesn't explain purpose or use of function (e.g. to immediately select rows after load without $timeout/$interval or to persist selection after data load).

Thought I would update this after reading: #2267