### PR TITLE
Clean up format of modifyRows function

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1086,7 +1086,8 @@ angular.module('ui.grid')
    *     create newRow
    *   append to the newRows and add to newHash
    *   run the processors
-   *
+   * ```
+   * 
    * Rows are identified using the hashKey if configured.  If not configured, then rows
    * are identified using the gridOptions.rowEquality function
    * 


### PR DESCRIPTION
Hopefully this displays the pseudo-code as intended.  Not sure if Markdown code block start and end syntax is supported in the help guide renderer.