### PR TITLE
Fix handleWindowResize Promise

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1503,6 +1503,7 @@ angular.module('ui.grid')
    * @name handleWindowResize
    * @methodOf ui.grid.class:Grid
    * @description Triggered when the browser window resizes; automatically resizes the grid
+   * @returns {Promise} A resolved promise once the window resize has occurred.
    */
   Grid.prototype.handleWindowResize = function handleWindowResize($event) {
     var self = this;
@@ -1510,7 +1511,7 @@ angular.module('ui.grid')
     self.gridWidth = gridUtil.elementWidth(self.element);
     self.gridHeight = gridUtil.elementHeight(self.element);
 
-    self.queueRefresh();
+    return self.queueRefresh();
   };
 
   /**


### PR DESCRIPTION
Current documentation says Grid.prototype.handleWindowResize returns a Promise (https://github.com/angular-ui/ui-grid/blob/fe00489/src/js/core/factories/Grid.js#L263) but in fact the internal `Grid.prototype.handleWindowResize` method was never returning the `Grid.prototype.queueRefresh` promise (https://github.com/angular-ui/ui-grid/blob/fe00489/src/js/core/factories/Grid.js#L1513)

This fix allows ui-grid users to wait until the grid is correctly sized before performing certain actions (like scrolling) which require an accurately-sized grid.

NOTE: My use case is using ui-grid in Flexbox (comes with Material Design project).  Unfortunately, since `ui-grid` uses custom inline `styles` that are created in `refreshCanvas` to size grid's internal `width` and `height`, I can't try to force ui-grid to use `flexbox` via css styles.  Instead, I'm manually calling `handleWindowResize`.  Unfortunately, since current code base doesn't return the Promise correctly I am getting race conditions/timing issues with trying to scroll and select rows immediately after calling `handleWindowResize`.  With a valid promise, I can wait until grid is indeed resized, and then call scroll/select.