### PR TITLE
fix(core): Return promise from `handleWindowResize` method

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1503,6 +1503,7 @@ angular.module('ui.grid')
    * @name handleWindowResize
    * @methodOf ui.grid.class:Grid
    * @description Triggered when the browser window resizes; automatically resizes the grid
+   * @returns {Promise} A resolved promise once the window resize has completed.
    */
   Grid.prototype.handleWindowResize = function handleWindowResize($event) {
     var self = this;
@@ -1510,7 +1511,7 @@ angular.module('ui.grid')
     self.gridWidth = gridUtil.elementWidth(self.element);
     self.gridHeight = gridUtil.elementHeight(self.element);
 
-    self.queueRefresh();
+    return self.queueRefresh();
   };
 
   /**


### PR DESCRIPTION
Current documentation says Grid.prototype.handleWindowResize returns a Promise (https://github.com/angular-ui/ui-grid/blob/fe00489/src/js/core/factories/Grid.js#L263) but in fact the internal Grid.prototype.handleWindowResize method was never returning the Grid.prototype.queueRefresh promise (https://github.com/angular-ui/ui-grid/blob/fe00489/src/js/core/factories/Grid.js#L1513). This fix allows ui-grid users to wait until the grid is correctly sized before performing certain actions (like scrolling) which require an accurately-sized grid.