### PR TITLE
Update README.md to reflect minimal angular version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can use [rawgit.com](https://rawgit.com/)'s cdn url to access the files in t
 
 # Angular Compatibility
 
-UI-Grid is currently compatible with Angular versions ranging from 1.2.x to 1.4.x.
+UI-Grid is currently compatible with Angular versions ranging from 1.2.16 to 1.4.x.
 
 # Feature Stability
 


### PR DESCRIPTION
seems like grid-ui is not supporting angular 1.2.0? 
update minimal angular version to 1.2.16