### PR TITLE
fix(infinite-scroll): Remove returns of adjustInfiniteScrollPosition.

### DIFF
--- a/src/features/infinite-scroll/js/infinite-scroll.js
+++ b/src/features/infinite-scroll/js/infinite-scroll.js
@@ -125,12 +125,11 @@
                * infinite scroll events upward
                * @param {boolean} scrollDown flag that there are pages downwards, so
                * fire infinite scroll events downward
-               * @returns {promise} promise that is resolved when the scroll reset is complete
                */
               resetScroll: function( scrollUp, scrollDown ) {
                 service.setScrollDirections( grid, scrollUp, scrollDown);
 
-                return service.adjustInfiniteScrollPosition(grid, 0);
+                service.adjustInfiniteScrollPosition(grid, 0);
               },
 
 
@@ -403,7 +402,6 @@
        * @description This function fires 'needLoadMoreData' or 'needLoadMoreDataTop' event based on scrollDirection
        * @param {Grid} grid the grid we're working on
        * @param {number} scrollTop the position through the grid that we want to scroll to
-       * @returns {promise} a promise that is resolved when the scrolling finishes
        */
       adjustInfiniteScrollPosition: function (grid, scrollTop) {
         var scrollEvent = new ScrollEvent(grid, null, null, 'ui.grid.adjustInfiniteScrollPosition'),
@@ -437,7 +435,6 @@
        * infinite scroll events upward
        * @param {boolean} scrollDown flag that there are pages downwards, so
        * fire infinite scroll events downward
-       * @returns {promise} a promise that is resolved when the scrolling finishes
        */
       dataRemovedTop: function( grid, scrollUp, scrollDown ) {
         var newVisibleRows, oldTop, newTop, rowHeight;
@@ -451,7 +448,7 @@
         // of rows removed
         newTop = oldTop - ( grid.infiniteScroll.previousVisibleRows - newVisibleRows )*rowHeight;
 
-        return service.adjustInfiniteScrollPosition( grid, newTop );
+        service.adjustInfiniteScrollPosition( grid, newTop );
       },
 
       /**
@@ -474,7 +471,7 @@
 
         newTop = grid.infiniteScroll.prevScrollTop;
 
-        return service.adjustInfiniteScrollPosition( grid, newTop );
+        service.adjustInfiniteScrollPosition( grid, newTop );
       }
     };
     return service;


### PR DESCRIPTION
Update uiGridInfiniteScrollService methods so they do **not** return promise of `adjustInfiniteScrollPosition` when `adjustInfiniteScrollPosition` does not itself return a promise.  Also updated documentation to match code changes.

Seems to be discrepancies between scroll events returning promises and not returning promises.  I think it's not a bad idea to return promises but `adjustInfiniteScrollPosition` calls `grid.scrollContainers` which doesn't return a promise so the promise chain doesn't actually exist. 
