### PR TITLE
docs: Fix columnDef.cellClass documentation

### DIFF
--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -551,7 +551,7 @@ angular.module('ui.grid')
      * @name footerCellClass
      * @propertyOf ui.grid.class:GridOptions.columnDef
      * @description footerCellClass can be a string specifying the class to append to a cell
-     * or it can be a function(row,rowRenderIndex, col, colRenderIndex) that returns a class name
+     * or it can be a function(grid, row, col, rowRenderIndex, colRenderIndex) that returns a class name
      *
      */
     self.footerCellClass = colDef.footerCellClass;


### PR DESCRIPTION
In documentation for cellClass function, parameters are incorrect.
In code, cellClass function is called with different parameters and order, see https://github.com/angular-ui/ui-grid/blob/master/src/js/core/directives/ui-grid-cell.js#L56