### PR TITLE
Fix For Windows 10 Exporter

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -884,14 +884,8 @@
          * @description Checks whether current browser is IE and returns it's version if it is
         */
         isIE: function () {
-          var match = navigator.userAgent.search(/(?:Edge|MSIE|Trident\/.*; rv:)/);
-          var isIE = false;
-
-          if (match !== -1) {
-            isIE = true;
-          }
-
-          return isIE;
+          var match = navigator.userAgent.match(/(?:MSIE |Trident\/.*; rv:)(\d+)/);
+          return match ? parseInt(match[1]) : false;
         },
 
 
@@ -1021,24 +1015,14 @@
           var rawFile;
           var ieVersion;
 
-          ieVersion = this.isIE(); // This is now a boolean value
+          ieVersion = this.isIE();
           var doc = pdfMake.createPdf(docDefinition);
           var blob;
 
           doc.getBuffer( function (buffer) {
             blob = new Blob([buffer]);
 
-            // IE10+
-            if (navigator.msSaveBlob) {
-              return navigator.msSaveBlob(
-                blob, fileName
-              );
-            }
-
-            // Previously:  && ieVersion < 10
-            // ieVersion now returns a boolean for the
-            // sake of sanity. We just check `msSaveBlob` first.
-            if (ieVersion) {
+            if (ieVersion && ieVersion < 10) {
               var frame = D.createElement('iframe');
               document.body.appendChild(frame);
 
@@ -1050,6 +1034,13 @@
 
               document.body.removeChild(frame);
               return true;
+            }
+
+            // IE10+
+            if (navigator.msSaveBlob) {
+              return navigator.msSaveBlob(
+                blob, fileName
+              );
             }
           });
         },

--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -884,8 +884,14 @@
          * @description Checks whether current browser is IE and returns it's version if it is
         */
         isIE: function () {
-          var match = navigator.userAgent.match(/(?:MSIE |Trident\/.*; rv:)(\d+)/);
-          return match ? parseInt(match[1]) : false;
+          var match = navigator.userAgent.search(/(?:Edge|MSIE|Trident\/.*; rv:)/);
+          var isIE = false;
+
+          if (match !== -1) {
+            isIE = true;
+          }
+
+          return isIE;
         },
 
 
@@ -1015,14 +1021,24 @@
           var rawFile;
           var ieVersion;
 
-          ieVersion = this.isIE();
+          ieVersion = this.isIE(); // This is now a boolean value
           var doc = pdfMake.createPdf(docDefinition);
           var blob;
 
           doc.getBuffer( function (buffer) {
             blob = new Blob([buffer]);
 
-            if (ieVersion && ieVersion < 10) {
+            // IE10+
+            if (navigator.msSaveBlob) {
+              return navigator.msSaveBlob(
+                blob, fileName
+              );
+            }
+
+            // Previously:  && ieVersion < 10
+            // ieVersion now returns a boolean for the
+            // sake of sanity. We just check `msSaveBlob` first.
+            if (ieVersion) {
               var frame = D.createElement('iframe');
               document.body.appendChild(frame);
 
@@ -1034,13 +1050,6 @@
 
               document.body.removeChild(frame);
               return true;
-            }
-
-            // IE10+
-            if (navigator.msSaveBlob) {
-              return navigator.msSaveBlob(
-                blob, fileName
-              );
             }
           });
         },


### PR DESCRIPTION
This is a fix for the Windows 10 users. Instead of using `.match` we
use `.search` which runs a boolean value. I noticed you guys were
trying to get the exact version of IE and that isn’t going to work for
Windows 10 users. I instead use the boolean value later to see if we
are even in IE. the `navigator.msSaveBlob` is a function in IE 10+ and
Edge so knowing that I can call that first and IE9 might possibly not
blow up. I haven’t gotten to officially test IE9 yet. If anything, this
PR is strictly a proof of concept. Feel free to message me with any
questions!

— I don’t know how to use the new GUI for Github on the desktop, so excuse the multiple reverse commits it had me under the impression I was sending these to the main branch which wouldn’t be possible.