### PR TITLE
docs: Fix incorrect parameters of cellClass and headerCellClass

### DIFF
--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -561,7 +561,7 @@ angular.module('ui.grid')
      * @name cellClass
      * @propertyOf ui.grid.class:GridOptions.columnDef
      * @description cellClass can be a string specifying the class to append to a cell
-     * or it can be a function(row,rowRenderIndex, col, colRenderIndex) that returns a class name
+     * or it can be a function(grid, row, col, rowRenderIndex, colRenderIndex) that returns a class name
      *
      */
     self.cellClass = colDef.cellClass;
@@ -571,7 +571,7 @@ angular.module('ui.grid')
      * @name headerCellClass
      * @propertyOf ui.grid.class:GridOptions.columnDef
      * @description headerCellClass can be a string specifying the class to append to a cell
-     * or it can be a function(row,rowRenderIndex, col, colRenderIndex) that returns a class name
+     * or it can be a function(grid, row, col, rowRenderIndex, colRenderIndex) that returns a class name
      *
      */
     self.headerCellClass = colDef.headerCellClass;


### PR DESCRIPTION
As part of #4544 (where I updated documentation of footerCellClass), forgot to do the same for cellClass and headerCellClass. Parameters were incorrect in the documentation as well for these.
Reference to code:
https://github.com/angular-ui/ui-grid/blob/master/src/js/core/directives/ui-grid-header-cell.js#L219 (for headerCellClass)
https://github.com/angular-ui/ui-grid/blob/master/src/js/core/directives/ui-grid-cell.js#L56 (for cellClass)