### PR TITLE
Remove code triggering scroll on each menu select

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -247,13 +247,6 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
 
               if ( !$scope.leaveOpen ){
                 $scope.$emit('hide-menu');
-              } else {
-                /*
-                 * XXX: Fix after column refactor
-                 * Ideally the focus would remain on the item.
-                 * However, since there are two menu items that have their 'show' property toggled instead. This is a quick fix.
-                 */
-                gridUtil.focus.bySelector(angular.element(gridUtil.closestElm($elm, ".ui-grid-menu-items")), 'button[type=button]', true);
               }
             }
           };


### PR DESCRIPTION
Each time toggling column visibility with the top right menu the menu is scrolled to the top. This gets impossibly annoying when having 20+ menu items. Once this code (that is mentioned as a "quick fix") is removed it stops scrolling the menu to the top when showing/hiding a column.
