### PR TITLE
feat(edit): add a function to retrieve dropdown options

### DIFF
--- a/misc/tutorial/201_editable.ngdoc
+++ b/misc/tutorial/201_editable.ngdoc
@@ -55,6 +55,7 @@ __ColumnDef Options__:
 - `editDropdownValueLabel` (default: `'value'`) Controls the value label in the options array - if your array happens to
   contain `'name'` instead you can use it without having to reprocess the array
 - `editDropdownRowEntityOptionsArrayPath` can be used as an alternative to editDropdownOptionsArray when the contents of the dropdown depend on the entity backing the row.
+- `editDropdownOptionsFunction` can be used as yet another alternative to editDropdownOptionsArray when the contents can be retrieved with a function whose parameters are row entity and column definition.
 - `editDropdownFilter` (default: `''`) Allows you to apply a filter to the values in the edit dropdown options, for example
   if you were using angular-translate you would set this to `'translate'`
 
@@ -93,7 +94,7 @@ $scope.gridOptions.columnDefs = [
       };
     });
 
-    app.controller('MainCtrl', ['$scope', '$http', function ($scope, $http) {
+    app.controller('MainCtrl', ['$scope', '$http', '$timeout', function ($scope, $http, $timeout) {
       $scope.gridOptions = {  };
 
       $scope.storeFile = function( gridRow, gridCol, files ) {
@@ -133,6 +134,22 @@ $scope.gridOptions.columnDefs = [
         { name: 'pet', displayName: 'Pet', width: '20%', editableCellTemplate: 'ui-grid/dropdownEditor',
           editDropdownRowEntityOptionsArrayPath: 'foo.bar[0].options', editDropdownIdLabel: 'value'
         },
+        { name: 'status', displayName: 'Status', width: '20%', editableCellTemplate: 'ui-grid/dropdownEditor',
+          cellFilter: 'mapStatus',
+          editDropdownOptionsFunction: function(rowEntity, colDef) {
+            var single;
+            var married = {id: 3, value: 'Married'};
+            if (rowEntity.gender === 1) {
+              single = {id: 1, value: 'Bachelor'};
+              return [single, married];
+            } else {
+              single = {id: 2, value: 'Nubile'};
+              return $timeout(function() {
+                return [single, married];
+              }, 100);
+            }
+          }
+        },
         { name: 'filename', displayName: 'File', width: '20%', editableCellTemplate: 'ui-grid/fileChooserEditor',
           editFileChooserCallback: $scope.storeFile }
       ];
@@ -170,6 +187,22 @@ $scope.gridOptions.columnDefs = [
       var genderHash = {
         1: 'male',
         2: 'female'
+      };
+
+      return function(input) {
+        if (!input){
+          return '';
+        } else {
+          return genderHash[input];
+        }
+      };
+    })
+    
+    .filter('mapStatus', function() {
+      var genderHash = {
+        1: 'Bachelor',
+        2: 'Nubile',
+        3: 'Married'
       };
 
       return function(input) {


### PR DESCRIPTION
Add a new member to ColumnDef: editDropdownOptionsFunction:
a function returning an array of values in the format
[ {id: xxx, value: xxx} ], which will be used to populate
the edit dropdown.  This can be used when the
dropdown values are dependent on the backing row entity with
some kind of algorithm.
If this property is set then both editDropdownOptionsArray
and editDropdownRowEntityOptionsArrayPath will be ignored.