### PR TITLE
Make the expand all button visibility optional

### DIFF
--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -271,7 +271,12 @@
                   width: uiGridCtrl.grid.options.expandableRowHeaderWidth || 40
                 };
                 expandableRowHeaderColDef.cellTemplate = $templateCache.get('ui-grid/expandableRowHeader');
-                expandableRowHeaderColDef.headerCellTemplate = $templateCache.get('ui-grid/expandableTopRowHeader');
+                 if ( uiGridCtrl.grid.options.showExpandAllButton !== false ) {
++                    expandableRowHeaderColDef.headerCellTemplate = $templateCache.get('ui-grid/expandableTopRowHeader');
++                } 
++                else {
++                      expandableRowHeaderColDef.headerCellTemplate='<div style="cursor:none;"></div>';
++                }
                 uiGridCtrl.grid.addRowHeaderColumn(expandableRowHeaderColDef);
               }
               uiGridExpandableService.initializeGrid(uiGridCtrl.grid);


### PR DESCRIPTION
The Expand all button can be hidden with the flag - "showExpandAllButton" on the grid options