### PR TITLE
fix(edit): emit blur event on stopEdit

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -974,6 +974,7 @@
                 $scope.deepEdit = false;
 
                 $scope.stopEdit = function (evt) {
+                  evt.target.blur();
                   if ($scope.inputForm && !$scope.inputForm.$valid) {
                     evt.stopPropagation();
                     $scope.$emit(uiGridEditConstants.events.CANCEL_CELL_EDIT);


### PR DESCRIPTION
Using a custom template with `ng-model-options={ updateOn: 'blur' }` is not working. #4058 attempted to fix it, but the problem is that with the custom handling of key events, the blur event never gets emitted for the edit cell using TAB or ENTER for example. This seems to fix it and I don't see why it would have adverse effects (other than potentially emitting 'blur' more than once).