### PR TITLE
fix(core): Fix columns reverting back to original size after restoring

### DIFF
--- a/src/features/saveState/js/saveState.js
+++ b/src/features/saveState/js/saveState.js
@@ -544,8 +544,9 @@
                 grid.api.core.raise.columnVisibilityChanged(currentCol);
               }
 
-              if ( grid.options.saveWidths ){
+              if ( grid.options.saveWidths && currentCol.width !== columnState.width){
                 currentCol.width = columnState.width;
+                currentCol.hasCustomWidth = true;
               }
 
               if ( grid.options.saveSort &&


### PR DESCRIPTION
There's currently an issue with the grid related to hiding columns and restoring saved column widths.
Here's a Plunker that shows the issue http://plnkr.co/edit/u1BHqBowywYhDhvnfc5R?p=preview
1. setup a grid with resizable columns and enableGridMenu = true, and saving and restoring the column widths from local storage
2. adjust the width of a column (make it big enough so you will notice the change when it reverts back)
3. save the grid state to local storage
4. refresh the page
5. restore the grid state
6. hide a column using the grid menu
once the column is hidden you will see that the column you resized will revert to it's original size. The cause is when column visibility is changed updateColumnDef is called which updates to column width from the columnDef if the column does not have a customWidth (indicated by the hasCustomWidth property) so in order to resolve the issue when restoring the column state we also set hasCustomWidth to true when the widths are different.