### PR TITLE
fix(Tree View) Row expansion when Tree View and Select both enabled

### DIFF
--- a/src/features/tree-view/less/tree-view.less
+++ b/src/features/tree-view/less/tree-view.less
@@ -3,3 +3,6 @@
 .ui-grid-tree-header-row {
   font-weight: bold !important;
 }
+.ui-grid-tree-header-row .ui-grid-row-header-cell.ui-grid-disable-selection.ui-grid-cell {
+  pointer-events: all;
+}


### PR DESCRIPTION
https://github.com/angular-ui/ui-grid/issues/4607
When Tree View and Select are both enabled, the Tree View expand button
did not work. The Tree View expand button was in a cell header class
who's click events are disabled. Enabling the pointer events on the
tree-header-row class resolves the issue.
