### PR TITLE
fix(core): Sort Priority Zero Based

### DIFF
--- a/src/features/saveState/test/saveState.spec.js
+++ b/src/features/saveState/test/saveState.spec.js
@@ -409,9 +409,9 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
 
       expect( onSortChangedHook.calls.length ).toEqual( 1 );
 
-      expect( onSortChangedHook ).toHaveBeenCalledWith( 
-        grid, 
-        [ grid.getOnlyDataColumns()[3], grid.getOnlyDataColumns()[2] ] 
+      expect( onSortChangedHook ).toHaveBeenCalledWith(
+        grid,
+        [ grid.getOnlyDataColumns()[2], grid.getOnlyDataColumns()[3] ]
       );
     });
 

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -397,7 +397,7 @@ angular.module('ui.grid')
      * @methodOf  ui.grid.core.api:PublicApi
      * @description The visibility of a column has changed,
      * the column itself is passed out as a parameter of the event.
-     * 
+     *
      * @param {$scope} scope The scope of the controller. This is used to deregister this event when the scope is destroyed.
      * @param {Function} callBack Will be called when the event is emited. The function passes back the GridCol that has changed.
      *
@@ -1087,17 +1087,17 @@ angular.module('ui.grid')
    *   append to the newRows and add to newHash
    *   run the processors
    * ```
-   * 
+   *
    * Rows are identified using the hashKey if configured.  If not configured, then rows
    * are identified using the gridOptions.rowEquality function
-   * 
+   *
    * This method is useful when trying to select rows immediately after loading data without
    * using a $timeout/$interval, e.g.:
-   * 
+   *
    *   $scope.gridOptions.data =  someData;
    *   $scope.gridApi.grid.modifyRows($scope.gridOptions.data);
    *   $scope.gridApi.selection.selectRow($scope.gridOptions.data[0]);
-   * 
+   *
    * OR to persist row selection after data update (e.g. rows selected, new data loaded, want
    * originally selected rows to be re-selected))
    */
@@ -1876,12 +1876,12 @@ angular.module('ui.grid')
         p = 0;
 
     self.columns.forEach(function (col) {
-      if (col.sort && col.sort.priority && col.sort.priority > p) {
-        p = col.sort.priority;
+      if (col.sort && col.sort.priority !== undefined && col.sort.priority >= p) {
+        p = col.sort.priority + 1;
       }
     });
 
-    return p + 1;
+    return p;
   };
 
   /**
@@ -1960,7 +1960,7 @@ angular.module('ui.grid')
 
     if (!add) {
       self.resetColumnSorting(column);
-      column.sort.priority = 0;
+      column.sort.priority = undefined;
       // Get the actual priority since there may be columns which have suppressRemoveSort set
       column.sort.priority = self.getNextColumnSortPriority();
     }

--- a/src/js/core/services/rowSorter.js
+++ b/src/js/core/services/rowSorter.js
@@ -5,14 +5,14 @@ var module = angular.module('ui.grid');
 /**
  * @ngdoc object
  * @name ui.grid.class:RowSorter
- * @description RowSorter provides the default sorting mechanisms, 
- * including guessing column types and applying appropriate sort 
+ * @description RowSorter provides the default sorting mechanisms,
+ * including guessing column types and applying appropriate sort
  * algorithms
- * 
- */ 
+ *
+ */
 
 module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGridConstants) {
-  var currencyRegexStr = 
+  var currencyRegexStr =
     '(' +
     uiGridConstants.CURRENCY_SYMBOLS
       .map(function (a) { return '\\' + a; }) // Escape all the currency symbols ($ at least will jack up this regex)
@@ -95,7 +95,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    * @methodOf ui.grid.class:RowSorter
    * @name basicSort
    * @description Sorts any values that provide the < method, including strings
-   * or numbers.  Handles nulls and undefined through calling handleNulls 
+   * or numbers.  Handles nulls and undefined through calling handleNulls
    * @param {object} a sort value a
    * @param {object} b sort value b
    * @returns {number} normal sort function, returns -ve, 0, +ve
@@ -120,7 +120,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    * @ngdoc method
    * @methodOf ui.grid.class:RowSorter
    * @name sortNumber
-   * @description Sorts numerical values.  Handles nulls and undefined through calling handleNulls 
+   * @description Sorts numerical values.  Handles nulls and undefined through calling handleNulls
    * @param {object} a sort value a
    * @param {object} b sort value b
    * @returns {number} normal sort function, returns -ve, 0, +ve
@@ -139,8 +139,8 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    * @ngdoc method
    * @methodOf ui.grid.class:RowSorter
    * @name sortNumberStr
-   * @description Sorts numerical values that are stored in a string (i.e. parses them to numbers first).  
-   * Handles nulls and undefined through calling handleNulls 
+   * @description Sorts numerical values that are stored in a string (i.e. parses them to numbers first).
+   * Handles nulls and undefined through calling handleNulls
    * @param {object} a sort value a
    * @param {object} b sort value b
    * @returns {number} normal sort function, returns -ve, 0, +ve
@@ -154,36 +154,36 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
           numB, // The parsed number form of 'b'
           badA = false,
           badB = false;
-  
+
       // Try to parse 'a' to a float
       numA = parseFloat(a.replace(/[^0-9.-]/g, ''));
-  
+
       // If 'a' couldn't be parsed to float, flag it as bad
       if (isNaN(numA)) {
           badA = true;
       }
-  
+
       // Try to parse 'b' to a float
       numB = parseFloat(b.replace(/[^0-9.-]/g, ''));
-  
+
       // If 'b' couldn't be parsed to float, flag it as bad
       if (isNaN(numB)) {
           badB = true;
       }
-  
+
       // We want bad ones to get pushed to the bottom... which effectively is "greater than"
       if (badA && badB) {
           return 0;
       }
-  
+
       if (badA) {
           return 1;
       }
-  
+
       if (badB) {
           return -1;
       }
-  
+
       return numA - numB;
     }
   };
@@ -193,7 +193,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    * @ngdoc method
    * @methodOf ui.grid.class:RowSorter
    * @name sortAlpha
-   * @description Sorts string values. Handles nulls and undefined through calling handleNulls 
+   * @description Sorts string values. Handles nulls and undefined through calling handleNulls
    * @param {object} a sort value a
    * @param {object} b sort value b
    * @returns {number} normal sort function, returns -ve, 0, +ve
@@ -205,7 +205,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
     } else {
       var strA = a.toString().toLowerCase(),
           strB = b.toString().toLowerCase();
-  
+
       return strA === strB ? 0 : strA.localeCompare(strB);
     }
   };
@@ -234,7 +234,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
       }
       var timeA = a.getTime(),
           timeB = b.getTime();
-  
+
       return timeA === timeB ? 0 : (timeA < timeB ? -1 : 1);
     }
   };
@@ -244,8 +244,8 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    * @ngdoc method
    * @methodOf ui.grid.class:RowSorter
    * @name sortBool
-   * @description Sorts boolean values, true is considered larger than false. 
-   * Handles nulls and undefined through calling handleNulls 
+   * @description Sorts boolean values, true is considered larger than false.
+   * Handles nulls and undefined through calling handleNulls
    * @param {object} a sort value a
    * @param {object} b sort value b
    * @returns {number} normal sort function, returns -ve, 0, +ve
@@ -258,7 +258,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
       if (a && b) {
         return 0;
       }
-  
+
       if (!a && !b) {
         return 0;
       }
@@ -273,17 +273,17 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    * @ngdoc method
    * @methodOf ui.grid.class:RowSorter
    * @name getSortFn
-   * @description Get the sort function for the column.  Looks first in 
+   * @description Get the sort function for the column.  Looks first in
    * rowSorter.colSortFnCache using the column name, failing that it
    * looks at col.sortingAlgorithm (and puts it in the cache), failing that
    * it guesses the sort algorithm based on the data type.
-   * 
+   *
    * The cache currently seems a bit pointless, as none of the work we do is
    * processor intensive enough to need caching.  Presumably in future we might
    * inspect the row data itself to guess the sort function, and in that case
    * it would make sense to have a cache, the infrastructure is in place to allow
    * that.
-   * 
+   *
    * @param {Grid} grid the grid to consider
    * @param {GridCol} col the column to find a function for
    * @param {array} rows an array of grid rows.  Currently unused, but presumably in future
@@ -336,7 +336,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    * @description Used where multiple columns are present in the sort criteria,
    * we determine which column should take precedence in the sort by sorting
    * the columns based on their sort.priority
-   * 
+   *
    * @param {gridColumn} a column a
    * @param {gridColumn} b column b
    * @returns {number} normal sort function, returns -ve, 0, +ve
@@ -358,11 +358,11 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
       }
     }
     // Only A has a priority
-    else if (a.sort.priority || a.sort.priority === 0) {
+    else if (a.sort.priority || a.sort.priority === undefined) {
       return -1;
     }
     // Only B has a priority
-    else if (b.sort.priority || b.sort.priority === 0) {
+    else if (b.sort.priority || b.sort.priority === undefined) {
       return 1;
     }
     // Neither has a priority
@@ -379,14 +379,14 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    * @description Prevents the internal sorting from executing.  Events will
    * still be fired when the sort changes, and the sort information on
    * the columns will be updated, allowing an external sorter (for example,
-   * server sorting) to be implemented.  Defaults to false. 
-   * 
+   * server sorting) to be implemented.  Defaults to false.
+   *
    */
   /**
    * @ngdoc method
    * @methodOf ui.grid.class:RowSorter
    * @name sort
-   * @description sorts the grid 
+   * @description sorts the grid
    * @param {Object} grid the grid itself
    * @param {array} rows the rows to be sorted
    * @param {array} columns the columns in which to look
@@ -398,7 +398,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
     if (!rows) {
       return;
     }
-    
+
     if (grid.options.useExternalSorting){
       return rows;
     }
@@ -460,7 +460,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
         idx++;
       }
 
-      // Chrome doesn't implement a stable sort function.  If our sort returns 0 
+      // Chrome doesn't implement a stable sort function.  If our sort returns 0
       // (i.e. the items are equal), and we're at the last sort column in the list,
       // then return the previous order using our custom
       // index variable
@@ -477,13 +477,13 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
     };
 
     var newRows = rows.sort(rowSortFn);
-    
+
     // remove the custom index field on each row, used to make a stable sort out of unstable sorts (e.g. Chrome)
     var clearIndex = function( row, idx ){
        delete row.entity.$$uiGridIndex;
     };
     rows.forEach(clearIndex);
-    
+
     return newRows;
   };
 

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -21,13 +21,13 @@
       aria-label="{{getSortDirectionAriaLabel()}}">
       <i
        ng-class="{ 'ui-grid-icon-up-dir': col.sort.direction == asc, 'ui-grid-icon-down-dir': col.sort.direction == desc, 'ui-grid-icon-blank': !col.sort.direction }"
-       title="{{isSortPriorityVisible() ? i18n.headerCell.priority + ' ' + col.sort.priority : null}}"
+       title="{{isSortPriorityVisible() ? i18n.headerCell.priority + ' ' + ( col.sort.priority + 1 )  : null}}"
        aria-hidden="true">
      </i>
      <sub
        ui-grid-visible="isSortPriorityVisible()"
        class="ui-grid-sort-priority-number">
-       {{col.sort.priority}}
+       {{col.sort.priority + 1}}
      </sub>
     </span>
   </div>

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -134,7 +134,7 @@ describe('Grid factory', function () {
         });
       });
     });
-    
+
     describe(', when one is broken and does not return an array, ', function () {
       beforeEach(function () {
         grid.removeRowsProcessor(testObj.proc1);
@@ -174,17 +174,17 @@ describe('Grid factory', function () {
       }).toThrow();
     });
   });
-  
+
   describe('row builder', function () {
     function testObj () { }
-    
+
     it('should return a defined gridOptions', function () {
       var testRowBuilder = function (row, gridOptions) {
         expect(gridOptions).toBeDefined();
       };
       var row = new GridRow({str:'abc'}, 0, grid);
       testObj.testRowBuilder = jasmine.createSpy('testRowBuilder').andCallFake(testRowBuilder);
-      grid.registerRowBuilder(testObj.testRowBuilder);  
+      grid.registerRowBuilder(testObj.testRowBuilder);
       grid.processRowBuilders(row);
       expect(testObj.testRowBuilder).toHaveBeenCalled();
     });
@@ -204,7 +204,7 @@ describe('Grid factory', function () {
       grid.createLeftContainer();
       expect(grid.renderContainers.left).toBe(left);
     });
-    
+
     it('should create a right render container', function () {
       expect(grid.renderContainers.right).not.toBeDefined();
       grid.createRightContainer();
@@ -217,8 +217,8 @@ describe('Grid factory', function () {
 
 
   });
-  
-  
+
+
 
   describe('buildColumns', function() {
     it('guess correct column types when not specified', function() {
@@ -264,7 +264,7 @@ describe('Grid factory', function () {
       expect(grid1.getColumn('bool').colDef.type).toBe('boolean');
       expect(grid1.getColumn('obj').colDef.type).toBe('object');
     });
-    
+
     it('add columns at the correct position - middle', function() {
       var grid1 = new Grid({ id: 3 });
 
@@ -276,13 +276,13 @@ describe('Grid factory', function () {
         {name:'5'}
       ];
       grid1.buildColumns();
-      
+
       expect(grid1.columns[0].name).toEqual('1');
       expect(grid1.columns[1].name).toEqual('2');
       expect(grid1.columns[2].name).toEqual('3');
       expect(grid1.columns[3].name).toEqual('4');
       expect(grid1.columns[4].name).toEqual('5');
-      
+
       grid1.options.columnDefs.splice(3, 0, {name: '3.5'});
       grid1.buildColumns();
 
@@ -291,7 +291,7 @@ describe('Grid factory', function () {
       expect(grid1.columns[2].name).toEqual('3');
       expect(grid1.columns[3].name).toEqual('3.5');
       expect(grid1.columns[4].name).toEqual('4');
-      expect(grid1.columns[5].name).toEqual('5');      
+      expect(grid1.columns[5].name).toEqual('5');
     });
 
     it('should respect the row header', function() {
@@ -350,13 +350,13 @@ describe('Grid factory', function () {
         {name:'5'}
       ];
       grid1.buildColumns();
-      
+
       expect(grid1.columns[0].name).toEqual('1');
       expect(grid1.columns[1].name).toEqual('2');
       expect(grid1.columns[2].name).toEqual('3');
       expect(grid1.columns[3].name).toEqual('4');
       expect(grid1.columns[4].name).toEqual('5');
-      
+
       grid1.options.columnDefs.unshift({name: '0.5'});
       grid1.buildColumns();
 
@@ -365,7 +365,7 @@ describe('Grid factory', function () {
       expect(grid1.columns[2].name).toEqual('2');
       expect(grid1.columns[3].name).toEqual('3');
       expect(grid1.columns[4].name).toEqual('4');
-      expect(grid1.columns[5].name).toEqual('5');      
+      expect(grid1.columns[5].name).toEqual('5');
     });
 
     it('add columns at the correct position - end', function() {
@@ -379,13 +379,13 @@ describe('Grid factory', function () {
         {name:'5'}
       ];
       grid1.buildColumns();
-      
+
       expect(grid1.columns[0].name).toEqual('1');
       expect(grid1.columns[1].name).toEqual('2');
       expect(grid1.columns[2].name).toEqual('3');
       expect(grid1.columns[3].name).toEqual('4');
       expect(grid1.columns[4].name).toEqual('5');
-      
+
       grid1.options.columnDefs.push({name: '5.5'});
       grid1.buildColumns();
 
@@ -394,7 +394,7 @@ describe('Grid factory', function () {
       expect(grid1.columns[2].name).toEqual('3');
       expect(grid1.columns[3].name).toEqual('4');
       expect(grid1.columns[4].name).toEqual('5');
-      expect(grid1.columns[5].name).toEqual('5.5');      
+      expect(grid1.columns[5].name).toEqual('5.5');
     });
 
     describe('when adding the same field multiple times', function () {
@@ -440,14 +440,14 @@ describe('Grid factory', function () {
 
       expect(grid.rows.length).toBe(1);
       expect(grid.rows[0].entity.str).toBe('abc');
-      
+
       dataRows.splice(0,0,{str:'cba'});
       grid.modifyRows(dataRows);
-      
+
       expect(grid.rows.length).toBe(2);
       expect(grid.rows[0].entity.str).toBe('cba');
     });
-    
+
     it('should swap', function() {
       var dataRows = [{str:'abc'},{str:'cba'}];
       var grid = new Grid({ id: 1 });
@@ -461,11 +461,11 @@ describe('Grid factory', function () {
       dataRows[0] = dataRows[1];
       dataRows[1] = tmpRow;
       grid.modifyRows(dataRows);
-      
+
       expect(grid.rows[0].entity.str).toBe('cba');
       expect(grid.rows[1].entity.str).toBe('abc');
     });
-    
+
     it('should delete and insert new in the middle', function() {
       var dataRows = [{str:'abc'},{str:'cba'},{str:'bac'}];
       var grid = new Grid({ id: 1 });
@@ -479,13 +479,13 @@ describe('Grid factory', function () {
 
       dataRows[1] = {str:'xyz'};
       grid.modifyRows(dataRows);
-      
+
       expect(grid.rows.length).toBe(3);
       expect(grid.rows[0].entity.str).toBe('abc');
       expect(grid.rows[1].entity.str).toBe('xyz');
       expect(grid.rows[2].entity.str).toBe('bac');
     });
-    
+
     /*
      * No longer trying to keep order of sort - we run rowsProcessors
      * immediately after anyway, which will resort.
@@ -503,7 +503,7 @@ describe('Grid factory', function () {
       expect(grid.rows[2].entity.str).toBe('bac');
 
       grid.sortColumn(grid.columns[0]);
-      
+
       dataRows.splice(0,0,{str:'xyz'});
       grid.modifyRows(dataRows);
       expect(grid.rows.length).toBe(4);
@@ -705,26 +705,26 @@ describe('Grid factory', function () {
         expect(e.message).toContain('No column parameter provided', 'exception contains column name');
       }
     });
-    
+
     it( 'if sort is currently null, then should toggle to ASC, and reset priority', function() {
       grid.sortColumn( column, false );
-      
+
       expect( column.sort.direction ).toEqual(uiGridConstants.ASC);
-      expect( column.sort.priority ).toEqual(1);
+      expect( column.sort.priority ).toEqual(0);
     });
 
     it( 'if sort is currently ASC, then should toggle to DESC, and reset priortiy', function() {
       column.sort = {direction: uiGridConstants.ASC, priority: 2};
       grid.sortColumn( column, false );
-      
+
       expect( column.sort.direction ).toEqual(uiGridConstants.DESC);
-      expect( column.sort.priority ).toEqual(1);
+      expect( column.sort.priority ).toEqual(0);
     });
 
     it( 'if sort is currently DESC, and suppressRemoveSort is undefined, then should toggle to null, and remove priority', function() {
       column.sort = {direction: uiGridConstants.DESC, priority: 1};
       grid.sortColumn( column, false );
-      
+
       expect( column.sort.direction ).toEqual(null);
       expect( column.sort.priority ).toEqual(null);
     });
@@ -732,7 +732,7 @@ describe('Grid factory', function () {
     it( 'if sort is currently DESC, and suppressRemoveSort is null, then should toggle to null, and remove priority', function() {
       column.sort = {direction: uiGridConstants.DESC, priority: 1, suppressRemoveSort: null};
       grid.sortColumn( column, false );
-      
+
       expect( column.sort.direction ).toEqual(null);
       expect( column.sort.priority ).toEqual(null);
     });
@@ -740,7 +740,7 @@ describe('Grid factory', function () {
     it( 'if sort is currently DESC, and suppressRemoveSort is false, then should toggle to null, and remove priority', function() {
       column.sort = {direction: uiGridConstants.DESC, priority: 1, suppressRemoveSort: false};
       grid.sortColumn( column, false );
-      
+
       expect( column.sort.direction ).toEqual(null);
       expect( column.sort.priority ).toEqual(null);
     });
@@ -749,9 +749,9 @@ describe('Grid factory', function () {
       column.sort = {direction: uiGridConstants.DESC, priority: 2};
       column.suppressRemoveSort = true;
       grid.sortColumn( column, false );
-      
+
       expect( column.sort.direction ).toEqual(uiGridConstants.ASC);
-      expect( column.sort.priority ).toEqual(1);
+      expect( column.sort.priority ).toEqual(0);
     });
 
     it( 'if another column has a sort, that sort should be removed', function() {
@@ -759,9 +759,9 @@ describe('Grid factory', function () {
       grid.columns.push( priorColumn );
 
       grid.sortColumn( column, false );
-      
+
       expect( column.sort.direction ).toEqual(uiGridConstants.ASC);
-      expect( column.sort.priority ).toEqual(1);
+      expect( column.sort.priority ).toEqual(0);
       expect( priorColumn.sort ).toEqual({});
     });
 
@@ -770,7 +770,7 @@ describe('Grid factory', function () {
       grid.columns.push( priorColumn );
 
       grid.sortColumn( column, true );
-      
+
       expect( column.sort.direction ).toEqual(uiGridConstants.ASC);
       expect( column.sort.priority ).toEqual(2);
       expect( priorColumn.sort ).toEqual({ direction: uiGridConstants.ASC, priority: 1});
@@ -781,7 +781,7 @@ describe('Grid factory', function () {
       grid.columns.push( priorColumn );
 
       grid.sortColumn( column, false );
-      
+
       expect( column.sort.direction ).toEqual(uiGridConstants.ASC);
       expect( column.sort.priority ).toEqual(2);
       expect( priorColumn.sort ).toEqual({ direction: uiGridConstants.ASC, priority: 1});
@@ -794,7 +794,7 @@ describe('Grid factory', function () {
       grid.sortColumn( column, false );
 
       expect( column.sort.direction ).toEqual(uiGridConstants.DESC);
-      expect( column.sort.priority ).toEqual(1);
+      expect( column.sort.priority ).toEqual(0);
     });
 
     it( 'if sortDirectionCycle is null-DESC-ASC, and sort is currently ASC, then should toggle to null, and remove priority', function() {
@@ -814,7 +814,7 @@ describe('Grid factory', function () {
       grid.sortColumn( column, false );
 
       expect( column.sort.direction ).toEqual(uiGridConstants.DESC);
-      expect( column.sort.priority ).toEqual(1);
+      expect( column.sort.priority ).toEqual(0);
     });
 
     it( 'if sortDirectionCycle is DESC-null-ASC, and sort is currently DESC, and suppressRemoveSort is true, then should toggle to ASC, and reset priority', function() {
@@ -825,11 +825,11 @@ describe('Grid factory', function () {
       grid.sortColumn( column, false );
 
       expect( column.sort.direction ).toEqual(uiGridConstants.ASC);
-      expect( column.sort.priority ).toEqual(1);
+      expect( column.sort.priority ).toEqual(0);
     });
   });
-  
-  
+
+
   describe( 'data change callbacks', function() {
     it( 'register then deregister data change callback', function() {
       var countCallbacks = function(){
@@ -839,11 +839,11 @@ describe('Grid factory', function () {
         });
         return i;
       };
-      
+
       var prevCount = countCallbacks();
       var deregFunction = grid.registerDataChangeCallback( function() {});
       expect( countCallbacks() ).toEqual( prevCount + 1 );
-      
+
       deregFunction();
       expect( countCallbacks() ).toEqual( prevCount );
     });
@@ -851,25 +851,25 @@ describe('Grid factory', function () {
     describe( 'mix of callbacks being called', function() {
       var called;
       var constants;
-      
+
       beforeEach( function() {
         called = [];
         constants = uiGridConstants.dataChange;
-        
+
         // this function will push it's type into the called array when it's called
         var createCallbackFunction = function( type ){
           return function( grid ){
             called.push( type );
           };
         };
-        
+
         grid.registerDataChangeCallback( createCallbackFunction( constants.ALL ), [constants.ALL] );
         grid.registerDataChangeCallback( createCallbackFunction( constants.ROW ), [constants.ROW] );
         grid.registerDataChangeCallback( createCallbackFunction( constants.EDIT ), [constants.EDIT] );
         grid.registerDataChangeCallback( createCallbackFunction( constants.COLUMN ), [constants.COLUMN] );
         grid.registerDataChangeCallback( createCallbackFunction( constants.COLUMN + constants.EDIT ), [constants.COLUMN, constants.EDIT] );
       });
-      
+
       it( 'call of type ALL', function() {
         grid.callDataChangeCallbacks( constants.ALL );
         expect( called ).toEqual( [ constants.ALL, constants.ROW, constants.EDIT, constants.COLUMN, constants.COLUMN + constants.EDIT]);
@@ -889,7 +889,7 @@ describe('Grid factory', function () {
         grid.callDataChangeCallbacks( constants.COLUMN );
         expect( called ).toEqual( [ constants.ALL, constants.COLUMN, constants.COLUMN + constants.EDIT ]);
       });
-      
+
       it( 'call works via api', function() {
         grid.api.core.notifyDataChange( constants.COLUMN );
         expect( called ).toEqual( [ constants.ALL, constants.COLUMN, constants.COLUMN + constants.EDIT ]);


### PR DESCRIPTION
Before sort priority was a mix of 0 and 1 based.
You could create columns with a sort priority of zero but once the user
clicked on a column to sort it its index would change to 1. There was no
way for the sort index to return to 0 from within the grid's menus.
This mix of 0 and 1 based sorting was confusing and created UI problems
when displaying the sort index in the column header.

Closes #4685
BREAKING CHANGE:
**GridOptions.columnDef.sort.priority** now expects the lowest value
to be 0.
The Grid Header will display a sort priority of 0 as 1.
Using `if(col.sort.priority)` to determine if a column is sorted is no
longer valid as `0 == false`.
Saved grid objects may be affected by this.