### PR TITLE
fix missleading comment in row edit documents

### DIFF
--- a/misc/tutorial/205_row_editable.ngdoc
+++ b/misc/tutorial/205_row_editable.ngdoc
@@ -31,7 +31,7 @@ The basic method of operation is that whenever a cell is edited (identified usin
 event) an `isDirty` flag is set on the row, and a `saveTimer` is set.  If another cell in the same row commences
 editing within 2 seconds (or other configurable time), then the timer will be destroyed again.  Otherwise
 upon the timer completing the row will be set to a status of `isSaving` and greyed out, and the `saveRow`
-event will be called.  The function called by this event must return a promise, and the rowedit feature
+event will be called.  The function called by this event must call `rowEdit.setSavePromise`, and the rowedit feature
 will wait on that promise.
 
 If the cellNav feature is also enabled, then a setFocus on a cell within the row is sufficient to delay


### PR DESCRIPTION
in the line edited, the function that's being referred too must call setSavePromise, returning a promise as previously stated does not do anything as the result from events is ignored and not accessible to the caller.