### PR TITLE
- Fixed modifyRows when using enableRowHashing option

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1112,7 +1112,11 @@ angular.module('ui.grid')
       var newRow;
       if ( self.options.enableRowHashing ){
         // if hashing is enabled, then this row will be in the hash if we already know about it
-        newRow = oldRowHash.get( newEntity );
+        var oldRow = oldRowHash.get( newEntity );
+        if ( oldRow ) {
+          newRow = oldRow;
+          newRow.entity = newEntity;
+        }
       } else {
         // otherwise, manually search the oldRows to see if we can find this row
         newRow = self.getRow(newEntity, oldRows);


### PR DESCRIPTION
- When using enableRowHashing (which is set right now to true as default), modifyRows match the old and the new row but not using the new entity at all.
