### PR TITLE
enable to show/hide sorting priority on default grid options

### DIFF
--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -359,7 +359,16 @@ angular.module('ui.grid')
        * Sorting can then be disabled on individual columns using the columnDefs.
        */
       baseOptions.enableSorting = baseOptions.enableSorting !== false;
-
+      
+      /**
+       * @ngdoc boolean
+       * @name enableSortingPriority
+       * @propertyOf ui.grid.class:GridOptions
+       * @description True by default. When enabled, this setting adds to sorted
+       * column a sort priority on the column headers.
+       */
+      baseOptions.enableSortingPriority = baseOptions.enableSortingPriority !== false;
+      
       /**
        * @ngdoc boolean
        * @name enableFiltering

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -25,7 +25,7 @@
        aria-hidden="true">
      </i>
      <sub
-       class="ui-grid-sort-priority-number">
+       class="ui-grid-sort-priority-number" ng-show="grid.options.enableSortingPriority">
        {{col.sort.priority}}
      </sub>
     </span>

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -40,6 +40,7 @@ describe('GridOptions factory', function () {
         wheelScrollThrottle: 70,
         scrollDebounce: 300,
         enableSorting: true,
+        enableSortingPriority: true,
         enableFiltering: false,
         enableColumnMenus: true,
         enableVerticalScrollbar: 1,


### PR DESCRIPTION
enable to show/hide sorting priority on default grid options