### PR TITLE
re-order styles for tree-header-row override

### DIFF
--- a/src/features/tree-view/less/tree-view.less
+++ b/src/features/tree-view/less/tree-view.less
@@ -3,6 +3,6 @@
 .ui-grid-tree-header-row {
   font-weight: bold !important;
 }
-.ui-grid-tree-header-row .ui-grid-row-header-cell.ui-grid-disable-selection.ui-grid-cell {
+.ui-grid-tree-header-row .ui-grid-cell.ui-grid-disable-selection.ui-grid-row-header-cell {
   pointer-events: all;
 }


### PR DESCRIPTION
In fix #4760 an override was introduced to allow clicking on the tree-expansion when row selection is on.  

The generated code with the grid options:

    enableRowSelection: true,
    enableFullRowSelection: true,
    enableRowHeaderSelection: false,

render each cell with the following classes:

    class="ui-grid-cell ng-scope ui-grid-disable-selection ui-grid-coluiGrid-0007 ui-grid-row-header-cell"

so, the order of these classes needs to have `ui-grid-cell` first, followed by `ui-grid-disable-selection` then `ui-grid-row-header-cell` in order for this override to work

