### PR TITLE
skip redraw if column original position = new position

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -168,6 +168,9 @@
         });
       },
       redrawColumnAtPosition: function (grid, originalPosition, newPosition) {
+        if (originalPosition === newPosition) {
+          return;
+        }
 
         var columns = grid.columns;
 


### PR DESCRIPTION
redrawColumnAtPosition is called whenever you try to drag and move a column from one location to another.  However, if you move it and place it back in the same place, we should not trigger a full grid redraw.  There are already 2 conditions for when `originalPosition > newPostion` and when `newPostion > originalPosition`, but there is no case for when `originalPosition === newPosition` which should essentially mean... do nothing.

This PR will do just that.  Check to see if the column did not move, and return.  Therefore not raising any dataChanged or columnPositionChanged events. 