### PR TITLE
feat(sort): change sort priority indicator to only show when multiple columns are sorted

### DIFF
--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -31,14 +31,20 @@
               headerCell: i18nService.getSafeText('headerCell'),
               sort: i18nService.getSafeText('sort')
             };
+            $scope.isSortPriorityVisible = function() {
+              //show sort priority if column is sorted and there is at least one other sorted column
+              return $scope.col.sort.priority && $scope.grid.columns.some(function(element, index){
+                  return element.sort.priority && element !== $scope.col;
+                });
+            };
             $scope.getSortDirectionAriaLabel = function(){
               var col = $scope.col;
               //Trying to recreate this sort of thing but it was getting messy having it in the template.
               //Sort direction {{col.sort.direction == asc ? 'ascending' : ( col.sort.direction == desc ? 'descending':'none')}}. {{col.sort.priority ? {{columnPriorityText}} {{col.sort.priority}} : ''}
               var sortDirectionText = col.sort.direction === uiGridConstants.ASC ? $scope.i18n.sort.ascending : ( col.sort.direction === uiGridConstants.DESC ? $scope.i18n.sort.descending : $scope.i18n.sort.none);
               var label = sortDirectionText;
-              //Append the priority if it exists
-              if (col.sort.priority) {
+
+              if ($scope.isSortPriorityVisible()) {
                 label = label + '. ' + $scope.i18n.headerCell.priority + ' ' + col.sort.priority;
               }
               return label;

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -21,10 +21,11 @@
       aria-label="{{getSortDirectionAriaLabel()}}">
       <i
        ng-class="{ 'ui-grid-icon-up-dir': col.sort.direction == asc, 'ui-grid-icon-down-dir': col.sort.direction == desc, 'ui-grid-icon-blank': !col.sort.direction }"
-       title="{{col.sort.priority ? i18n.headerCell.priority + ' ' + col.sort.priority : null}}"
+       title="{{isSortPriorityVisible() ? i18n.headerCell.priority + ' ' + col.sort.priority : null}}"
        aria-hidden="true">
      </i>
      <sub
+       ui-grid-visible="isSortPriorityVisible()"
        class="ui-grid-sort-priority-number">
        {{col.sort.priority}}
      </sub>


### PR DESCRIPTION
Sort priority number indicators were added with #4257.  These look strange when only one column is sorted.  This pull request changes the indicators to only display when multiple columns are sorted.

fixes #4503