### PR TITLE
fix(uiGrid): Fix race condition in data watcher

### DIFF
--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -78,6 +78,8 @@
         }
       }
 
+      var mostRecentData;
+
       function dataWatchFunction(newData) {
         // gridUtil.logDebug('dataWatch fired');
         var promises = [];
@@ -89,6 +91,8 @@
             newData = $scope.uiGrid.data;
           }
         }
+
+        mostRecentData = newData;
 
         if (newData) {
           // columns length is greater than the number of row header columns, which don't count because they're created automatically
@@ -118,7 +122,8 @@
           }
 
           $q.all(promises).then(function() {
-            self.grid.modifyRows(newData)
+            // use most recent data, rather than the potentially outdated data passed into watcher handler
+            self.grid.modifyRows(mostRecentData)
               .then(function () {
                 // if (self.viewport) {
                   self.grid.redrawInPlace(true);


### PR DESCRIPTION
I introduced a guard to reduce some unnecessary calls to `buildColumns` and `preCompileCellTemplates` each time data is changed. 

As a result, the `$q.all` promise in `dataWatchFunction` could resolve **before** promises created in previous calls. This is because an empty array of promises can be passed to `$q.all` the method now. This unearthed an issue where `modifyRows` could be passed outdated data from previous `dataWatchFunction` calls, rather than the most recent call.

Fixes #4532, issue introduced by #4428.