### PR TITLE
Don't always disable rowHeaderSelection for fullRowSelection

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -893,7 +893,10 @@
 
             function registerRowSelectionEvents() {
               if ($scope.grid.options.enableRowSelection && $scope.grid.options.enableFullRowSelection) {
-                $elm.addClass('ui-grid-disable-selection');
+                if (!$scope.grid.options.enableRowHeaderSelection){
+                  $elm.addClass('ui-grid-disable-selection');
+                }
+
                 $elm.on('touchstart', touchStart);
                 $elm.on('touchend', touchEnd);
                 $elm.on('click', selectCells);


### PR DESCRIPTION
I might be missing something obvious - and feel free to point it out - but it seems very strange to me that if you enable "full row selection", there is no way to click the row header anymore. 

It feels against the spirit of "full row", and also surprises many users trying to select/deselect rows. 

Regardless of that belief, it makes an explicit `enableRowHeaderSelection: true` setting not work. 

(Simpler fix would be just removing the `addClass('ui-grid-disable-selection')` line, but I expect it's there for a reason? If there's not a use-case for disabling them, I'd be happy to amend the commit to simply remove the lines.)