### PR TITLE
Add selection PublicApi method to expose selected count

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -294,6 +294,15 @@
                 },
                 /**
                  * @ngdoc function
+                 * @name getSelectedCount
+                 * @methodOf  ui.grid.selection.api:PublicApi
+                 * @description returns the number of rows selected
+                 */
+                getSelectedCount: function () {
+                  return grid.selection.selectedCount;
+                },
+                /**
+                 * @ngdoc function
                  * @name setMultiSelect
                  * @methodOf  ui.grid.selection.api:PublicApi
                  * @description Sets the current gridOption.multiSelect to true or false

--- a/src/features/selection/test/uiGridSelectionService.spec.js
+++ b/src/features/selection/test/uiGridSelectionService.spec.js
@@ -88,6 +88,13 @@ describe('ui.grid.selection uiGridSelectionService', function () {
       expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(0);
     });
 
+    it('should update selectedCount', function () {
+      uiGridSelectionService.toggleRowSelection(grid, grid.rows[0]);
+      expect(grid.api.selection.getSelectedCount()).toBe(1);
+      uiGridSelectionService.clearSelectedRows(grid);
+      expect(grid.api.selection.getSelectedCount()).toBe(0);
+    });
+
     it('should utilize public apis', function () {
       grid.api.selection.toggleRowSelection(grid.rows[0].entity);
       expect(uiGridSelectionService.getSelectedRows(grid).length).toBe(1);


### PR DESCRIPTION
This method would help in implementations that show the number of selected items in a different way that the bottom info-bar.

Previously, the only ways to get the number of items are selected are less than ideal:

1) Call `getSelectedGridRows().length` on the API - this is slow because `getSelectedGridRows()` calls a filter on the entire dataset - which would be a performance drag if called every `$digest` cycle. One can avoid calling it on every cycle by binding a function that calls it to both `rowSelectionChanged`, and `rowSelectionChangedBatch`, but the resulting code is way less clear than simply `api.selection. getSelectedCount()`

Or 2) Render and hide the info bar, and try to parse its number. This should be avoided, as it's a hacky solution.

Since the number is already being held (and used internally), providing the number is trivial; so it seems like a good candidate for the API.