### PR TITLE
fix(core): Fix watcher handler columnDefs assignment

### DIFF
--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -67,7 +67,7 @@
 
       function columnDefsWatchFunction(n, o) {
         if (n && n !== o) {
-          self.grid.options.columnDefs = n;
+          self.grid.options.columnDefs = $scope.uiGrid.columnDefs;
           self.grid.buildColumns({ orderByColumnDefs: true })
             .then(function(){
 


### PR DESCRIPTION
If you want to use fastWatch:true for data and columnDefs then the $watch handler needs to work with both fastWatch:true and false (or undefined). When mapping the incoming columnDefs with the internal columnDefs, always use what is on $scope instead of what the watcher is watching because the watcher is watching different things in the two different cases.

https://github.com/angular-ui/ui-grid/issues/3755