### PR TITLE
Prevent selection triggering on plus/minus click

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -856,6 +856,11 @@
             //});
 
             var selectCells = function(evt){
+              // if you click on expandable icon doesn't trigger selection
+              if (evt.target.className === "ui-grid-icon-minus-squared" || evt.target.className === "ui-grid-icon-plus-squared") {
+                return;
+              }
+
               // if we get a click, then stop listening for touchend
               $elm.off('touchend', touchEnd);
 


### PR DESCRIPTION
When grouping and enableRowSelection is set to true clicking on plus/minus icons selects/deselects the row. This seems counter intuitive.

The problem was fixed by detecting where the click came from; in the case of an icon, it is ignored, otherwise a select/deselect action is triggered.
