### PR TITLE
chore(build): change contents saved to package.json

### DIFF
--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -331,9 +331,9 @@ module.exports = function(grunt) {
     fs.writeFileSync(bowerJsonFile, JSON.stringify(json, null, 2));
 
     // Add version for package.json
-    json.version = currentTag;
+    pkg.version = currentTag;
 
-    fs.writeFileSync(pkgJsonFile, JSON.stringify(json, null, 2));
+    fs.writeFileSync(pkgJsonFile, JSON.stringify(pkg, null, 2));
   });
 
   // Publish release to NPM


### PR DESCRIPTION
The same contents saved to bower.json were being saved to package.json, generating an invalid package.json since the main attribute was an array instead of a string. Now this has been changed, and the package.json generated for distribution contains the same contents of the package.json file in the source code.

Fixes #4743