### PR TITLE
fix(core): check for undefined on sort priority

### DIFF
--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -33,8 +33,8 @@
             };
             $scope.isSortPriorityVisible = function() {
               //show sort priority if column is sorted and there is at least one other sorted column
-              return $scope.col.sort.priority && $scope.grid.columns.some(function(element, index){
-                  return element.sort.priority && element !== $scope.col;
+              return $scope.col.sort.priority !== undefined && $scope.grid.columns.some(function(element, index){
+                  return element.sort.priority !== undefined && element !== $scope.col;
                 });
             };
             $scope.getSortDirectionAriaLabel = function(){


### PR DESCRIPTION
in Issue #4876 isSortPriorityVisible() is introduced.  However it is testing the variable rather than for undefined, so when element.sort.priority == 0, it is returning as false, even though that should return true.

This update is adding the checks for undefined

@jbarrus @JLLeitschuh 