### PR TITLE
feature(treeGrid): fix #3646 - allow to disable expand all button

### DIFF
--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -525,6 +525,16 @@
          *  <br/>Defaults to {}
          */
         gridOptions.treeCustomAggregations = gridOptions.treeCustomAggregations || {};
+
+        /**
+         *  @ngdoc object
+         *  @name enableExpandAll
+         *  @propertyOf  ui.grid.treeBase.api:GridOptions
+         *  @description Enable the expand all button at the top of the row header
+         *
+         *  <br/>Defaults to true
+         */
+        gridOptions.enableExpandAll = gridOptions.enableExpandAll !== false;
       },
 
 

--- a/src/features/tree-base/templates/treeBaseHeaderCell.html
+++ b/src/features/tree-base/templates/treeBaseHeaderCell.html
@@ -2,7 +2,8 @@
   <div
     class="ui-grid-cell-contents"
     col-index="renderIndex">
-    <ui-grid-tree-base-expand-all-buttons>
+    <ui-grid-tree-base-expand-all-buttons
+            ng-if="grid.options.enableExpandAll">
     </ui-grid-tree-base-expand-all-buttons>
   </div>
 </div>

--- a/src/features/tree-base/test/tree-base.spec.js
+++ b/src/features/tree-base/test/tree-base.spec.js
@@ -86,7 +86,8 @@ describe('ui.grid.treeBase uiGridTreeBaseService', function () {
         showTreeRowHeader: true,
         showTreeExpandNoChildren: true,
         treeRowHeaderAlwaysVisible: true,
-        treeCustomAggregations: {}
+        treeCustomAggregations: {},
+        enableExpandAll: true
       });
     });
   });


### PR DESCRIPTION
Please consider pulling this commit.
Closes the mentioned issue.

Usage:
new supported gridOption
enableExpandAll
default value: true
Setting this value as false will hide the expand all button