### PR TITLE
fix(edit): Error on opening custom cell editor who's first element has no select method

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -935,7 +935,7 @@
                   $timeout(function () {
                     $elm[0].focus();
                     //only select text if it is not being replaced below in the cellNav viewPortKeyPress
-                    if ($scope.col.colDef.enableCellEditOnFocus || !(uiGridCtrl && uiGridCtrl.grid.api.cellNav)) {
+                    if ($elm[0].select && $scope.col.colDef.enableCellEditOnFocus || !(uiGridCtrl && uiGridCtrl.grid.api.cellNav)) {
                       $elm[0].select();
                     }
                     else {


### PR DESCRIPTION
This solves the problem angular-ui#4193 https://github.com/angular-ui/ui-grid/issues/4193
Only run elem.select() if it is available. Some custom renderers are not input of type text.