### PR TITLE
fix(saveState): Fixes #4146 - Allow saving of pagination state

### DIFF
--- a/src/features/saveState/js/saveState.js
+++ b/src/features/saveState/js/saveState.js
@@ -287,6 +287,7 @@
           savedState.selection = service.saveSelection( grid );
           savedState.grouping = service.saveGrouping( grid );
           savedState.treeView = service.saveTreeView( grid );
+          savedState.pagination = service.savePagination( grid );
 
           return savedState;
         },
@@ -321,6 +322,10 @@
 
           if ( state.treeView ){
             service.restoreTreeView( grid, state.treeView );
+          }
+
+          if ( state.pagination ){
+            service.restorePagination( grid, state.pagination );
           }
 
           grid.refresh();
@@ -471,6 +476,26 @@
           }
 
           return grid.api.grouping.getGrouping( grid.options.saveGroupingExpandedStates );
+        },
+
+
+        /**
+         * @ngdoc function
+         * @name savePagination
+         * @methodOf  ui.grid.saveState.service:uiGridSaveStateService
+         * @description Saves the pagination state, if the pagination feature is enabled
+         * @param {Grid} grid the grid whose state we'd like to save
+         * @returns {object} the pagination state ready to be saved
+         */
+        savePagination: function( grid ) {
+          if ( !grid.api.pagination || !grid.options.paginationPageSize ){
+            return {};
+          }
+
+          return {
+            paginationCurrentPage: grid.options.paginationCurrentPage,
+            paginationPageSize: grid.options.paginationPageSize
+          };
         },
 
 
@@ -696,6 +721,25 @@
           }
 
           grid.api.treeView.setTreeView( treeViewState );
+        },
+
+        /**
+         * @ngdoc function
+         * @name restorePagination
+         * @methodOf  ui.grid.saveState.service:uiGridSaveStateService
+         * @description Restores the pagination information, if pagination is enabled.
+         * @param {Grid} grid the grid whose state we'd like to restore
+         * @param {object} pagination the pagination object to be restored
+         * @param {number} pagination.paginationCurrentPage the page number to restore
+         * @param {number} pagination.paginationPageSize the number of items displayed per page
+         */
+        restorePagination: function( grid, pagination ){
+          if ( !grid.api.pagination || !grid.options.paginationPageSize ){
+            return;
+          }
+
+          grid.options.paginationCurrentPage = pagination.paginationCurrentPage;
+          grid.options.paginationPageSize = pagination.paginationPageSize;
         },
 
         /**

--- a/src/features/saveState/test/saveState.spec.js
+++ b/src/features/saveState/test/saveState.spec.js
@@ -189,6 +189,22 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
     });
   });
 
+  describe('savePagination', function() {
+    beforeEach(function() {
+      grid.options.paginationPageSize = 25;
+      grid.options.paginationCurrentPage = 2;
+      grid.api.pagination = true;
+    });
+
+    it('saves paginationCurrentPage', function() {
+      expect(uiGridSaveStateService.savePagination( grid ) ).toEqual({
+        paginationCurrentPage: 2,
+        paginationPageSize: 25
+      });
+    });
+
+  });
+
 
   describe('saveScrollFocus', function() {
     it('does nothing when no cellNav module initialized', function() {
@@ -479,6 +495,46 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
       expect( colVisChangeCount ).toEqual( 0, '0 columns changed visibility');
       expect( colFilterChangeCount ).toEqual( 0, '0 columns changed filter');
       expect( colSortChangeCount ).toEqual( 0, '0 columns changed sort');
+    });
+  });
+
+  describe('restorePagination', function() {
+    var pagination = {
+      paginationCurrentPage: 2,
+      paginationPageSize: 25
+    };
+
+    describe('when pagination is on', function() {
+      beforeEach(function() {
+        grid.options.paginationPageSize = 1;
+        grid.api.pagination = true;
+        uiGridSaveStateService.restorePagination( grid, pagination );
+      });
+
+      it('sets the paginationPageSize', function() {
+        expect(grid.options.paginationPageSize).toEqual(25);
+      });
+
+      it('sets the paginationCurrentPage', function() {
+        expect(grid.options.paginationCurrentPage).toEqual(2);
+      });
+    });
+
+    describe('when pagination is off', function() {
+      beforeEach(function() {
+        grid.api.pagination = false;
+        uiGridSaveStateService.restorePagination( grid, pagination );
+      });
+
+      it('does not modify paginationPageSize', function() {
+        expect(grid.options.paginationPageSize).toBeUndefined();
+      });
+
+      it('does not modify paginationCurrentPage', function() {
+        expect(grid.options.paginationCurrentPage).toBeUndefined();
+      });
+
+
     });
   });
 


### PR DESCRIPTION
Saves the page save and current page position when saveState is called, as long as pagination is enabled. Fixes #4146