### PR TITLE
ISSUE: 3782 (https://github.com/angular-ui/ui-grid/issues/3782)

### DIFF
--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -910,7 +910,7 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
         e = elem[0];
       }
 
-      if (e) {
+      if (e && e !== null) {
         var styles = getStyles(e);
         return e.offsetWidth === 0 && rdisplayswap.test(styles.display) ?
                   s.swap(e, cssShow, function() {


### PR DESCRIPTION
e can be null in Firefox. This gives the styles is null error.

Add this extra !== null check and the error is gone.
