### PR TITLE
Removed the X and Close on menu, and implemented-ESC and cyclical tabs

### DIFF
--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -48,7 +48,7 @@ function ( i18nService, uiGridConstants, gridUtil ) {
      *
      */
     setColMenuItemWatch: function ( $scope ){
-      var deregFunction = $scope.$watch('col.menuItems', function (n, o) {
+      var deregFunction = $scope.$watch('col.menuItems', function (n) {
         if (typeof(n) !== 'undefined' && n && angular.isArray(n)) {
           n.forEach(function (item) {
             if (typeof(item.context) === 'undefined' || !item.context) {
@@ -213,16 +213,6 @@ function ( i18nService, uiGridConstants, gridUtil ) {
             $event.stopPropagation();
             $scope.hideColumn();
           }
-        },
-        {
-          title: i18nService.getSafeText('columnMenu.close'),
-          screenReaderOnly: true,
-          shown: function(){
-            return true;
-          },
-          action: function($event){
-            $event.stopPropagation();
-          }
         }
       ];
     },
@@ -275,8 +265,6 @@ function ( i18nService, uiGridConstants, gridUtil ) {
      */
     repositionMenu: function( $scope, column, positionData, $elm, $columnElement ) {
       var menu = $elm[0].querySelectorAll('.ui-grid-menu');
-      var containerId = column.renderContainer ? column.renderContainer : 'body';
-      var renderContainer = column.grid.renderContainers[containerId];
 
       // It's possible that the render container of the column we're attaching to is
       // offset from the grid (i.e. pinned containers), we need to get the difference in the offsetLeft
@@ -379,6 +367,7 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
           $scope.colElement = $columnElement;
           $scope.colElementPosition = colElementPosition;
           $scope.$broadcast('show-menu', { originalEvent: event });
+
         }
       };
 
@@ -421,6 +410,8 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
       $scope.$on('menu-shown', function() {
         $timeout( function() {
           uiGridColumnMenuService.repositionMenu( $scope, $scope.col, $scope.colElementPosition, $elm, $scope.colElement );
+          //Focus on the first item
+          gridUtil.focus.bySelector($document, '.ui-grid-menu-items .ui-grid-menu-item', true);
           delete $scope.colElementPosition;
           delete $scope.columnElement;
         }, 200);
@@ -516,7 +507,7 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
     controller: ['$scope', function ($scope) {
       var self = this;
 
-      $scope.$watch('menuItems', function (n, o) {
+      $scope.$watch('menuItems', function (n) {
         self.menuItems = n;
       });
     }]

--- a/src/templates/ui-grid/uiGridMenu.html
+++ b/src/templates/ui-grid/uiGridMenu.html
@@ -9,17 +9,6 @@
     ng-show="shownMid">
     <div
     class="ui-grid-menu-inner">
-      <button
-        type="button"
-        ng-focus="focus=true"
-        ng-blur="focus=false"
-        class="ui-grid-menu-close-button"
-        ng-class="{'ui-grid-sr-only': (!focus)}">
-        <i
-          class="ui-grid-icon-cancel"
-          ui-grid-one-bind-aria-label="i18n.close">
-        </i>
-      </button>
       <ul
         role="menu"
         class="ui-grid-menu-items">

--- a/test/unit/core/directives/ui-grid-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-menu.spec.js
@@ -231,4 +231,35 @@ describe('ui-grid-menu', function() {
       expect(item.hasClass('ng-hide')).toBe(false);
     });
   });
+
+
+  describe('keyUp and keyDown actions', function() {
+    var timeout, menuItemButtons;
+    beforeEach( function() {
+      inject(function ($timeout) {
+        timeout = $timeout;
+      });
+      $scope.$broadcast('show-menu');
+      $scope.$digest();
+      timeout.flush();
+    });
+
+    it('should focus on the first menu item after tabbing from the last menu item', function() {
+      menuItemButtons = menu.find('button');
+      var e = $.Event("keydown");
+      e.keyCode = 9;
+      spyOn(menuItemButtons[0],'focus');
+      //mock has 4 items, last one his hidden
+      $(menuItemButtons[2]).trigger(e);
+      expect(menuItemButtons[0].focus).toHaveBeenCalled();
+    });
+
+    it('should call hideMenu if ESC is pressed', function() {
+      spyOn(isolateScope, 'hideMenu');
+      var e = $.Event("keyup");
+      e.keyCode = 27;
+      $(menu).trigger(e);
+      expect(isolateScope.hideMenu).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
For ARIA, an X and Close menu option had been implemented into the column menus.  This PR removes those and implements the ESC key to close the menu via a keyboard.  It also makes sure tabbing is cyclical, so tabbing continuously will keep you contained within the menu.