### PR TITLE
fix: 5075 & 5076 Menu close by ESC and cyclical tabbing

### DIFF
--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -48,7 +48,7 @@ function ( i18nService, uiGridConstants, gridUtil ) {
      *
      */
     setColMenuItemWatch: function ( $scope ){
-      var deregFunction = $scope.$watch('col.menuItems', function (n, o) {
+      var deregFunction = $scope.$watch('col.menuItems', function (n) {
         if (typeof(n) !== 'undefined' && n && angular.isArray(n)) {
           n.forEach(function (item) {
             if (typeof(item.context) === 'undefined' || !item.context) {
@@ -265,8 +265,6 @@ function ( i18nService, uiGridConstants, gridUtil ) {
      */
     repositionMenu: function( $scope, column, positionData, $elm, $columnElement ) {
       var menu = $elm[0].querySelectorAll('.ui-grid-menu');
-      var containerId = column.renderContainer ? column.renderContainer : 'body';
-      var renderContainer = column.grid.renderContainers[containerId];
 
       // It's possible that the render container of the column we're attaching to is
       // offset from the grid (i.e. pinned containers), we need to get the difference in the offsetLeft
@@ -509,7 +507,7 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
     controller: ['$scope', function ($scope) {
       var self = this;
 
-      $scope.$watch('menuItems', function (n, o) {
+      $scope.$watch('menuItems', function (n) {
         self.menuItems = n;
       });
     }]

--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -213,16 +213,6 @@ function ( i18nService, uiGridConstants, gridUtil ) {
             $event.stopPropagation();
             $scope.hideColumn();
           }
-        },
-        {
-          title: i18nService.getSafeText('columnMenu.close'),
-          screenReaderOnly: true,
-          shown: function(){
-            return true;
-          },
-          action: function($event){
-            $event.stopPropagation();
-          }
         }
       ];
     },
@@ -379,6 +369,7 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
           $scope.colElement = $columnElement;
           $scope.colElementPosition = colElementPosition;
           $scope.$broadcast('show-menu', { originalEvent: event });
+
         }
       };
 
@@ -421,6 +412,8 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
       $scope.$on('menu-shown', function() {
         $timeout( function() {
           uiGridColumnMenuService.repositionMenu( $scope, $scope.col, $scope.colElementPosition, $elm, $scope.colElement );
+          //Focus on the first item
+          gridUtil.focus.bySelector($document, '.ui-grid-menu-items .ui-grid-menu-item', true);
           delete $scope.colElementPosition;
           delete $scope.columnElement;
         }, 200);

--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -99,10 +99,15 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
 
         // Turn off an existing document click handler
         angular.element(document).off('click touchstart', applyHideMenu);
+        $elm.off('keyup', checkKeyUp);
+        $elm.off('keydown', checkKeyDown);
 
         // Turn on the document click handler, but in a timeout so it doesn't apply to THIS click if there is one
         $timeout(function() {
           angular.element(document).on(docEventType, applyHideMenu);
+          $elm.on('keyup', checkKeyUp);
+          $elm.on('keydown', checkKeyDown);
+
         });
         //automatically set the focus to the first button element in the now open menu.
         gridUtil.focus.bySelector($elm, 'button[type=button]', true);
@@ -129,6 +134,8 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
         }
 
         angular.element(document).off('click touchstart', applyHideMenu);
+        $elm.off('keyup', checkKeyUp);
+        $elm.off('keydown', checkKeyDown);
       };
 
       $scope.$on('hide-menu', function (event, args) {
@@ -146,6 +153,34 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
           $scope.$apply(function () {
             $scope.hideMenu();
           });
+        }
+      };
+
+      // close menu on ESC and keep tab cyclical
+      var checkKeyUp = function(event) {
+        if (event.keyCode === 27) {
+          $scope.hideMenu();
+        }
+      };
+
+      var checkKeyDown = function(event) {
+        var setFocus = function(elm) {
+          elm.focus();
+          event.preventDefault();
+          return false;
+        };
+        if (event.keyCode === 9) {
+          var firstMenuItem, lastMenuItem;
+          var menuItemButtons = $elm.find('button');
+          if (menuItemButtons.length > 0) {
+            firstMenuItem = menuItemButtons[0];
+            lastMenuItem = menuItemButtons[menuItemButtons.length - 1];
+            if (event.target === lastMenuItem && !event.shiftKey) {
+              setFocus(firstMenuItem);
+            } else if (event.target === firstMenuItem && event.shiftKey) {
+              setFocus(lastMenuItem);
+            }
+          }
         }
       };
 

--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -43,8 +43,6 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
     templateUrl: 'ui-grid/uiGridMenu',
     replace: false,
     link: function ($scope, $elm, $attrs, uiGridCtrl) {
-      var menuMid;
-      var $animate;
       var gridMenuMaxHeight;
 
       $scope.dynamicStyles = '';
@@ -107,14 +105,13 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
           angular.element(document).on(docEventType, applyHideMenu);
           $elm.on('keyup', checkKeyUp);
           $elm.on('keydown', checkKeyDown);
-
         });
         //automatically set the focus to the first button element in the now open menu.
         gridUtil.focus.bySelector($elm, 'button[type=button]', true);
       };
 
 
-      $scope.hideMenu = function(event, args) {
+      $scope.hideMenu = function(event) {
         if ( $scope.shown ){
           /*
            * In order to animate cleanly we animate the addition of ng-hide, then use a $timeout to
@@ -171,7 +168,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
         };
         if (event.keyCode === 9) {
           var firstMenuItem, lastMenuItem;
-          var menuItemButtons = $elm.find('button');
+          var menuItemButtons = $elm[0].querySelectorAll('button:not(.ng-hide)');
           if (menuItemButtons.length > 0) {
             firstMenuItem = menuItemButtons[0];
             lastMenuItem = menuItemButtons[menuItemButtons.length - 1];
@@ -206,12 +203,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
       }
 
       $scope.$on('$destroy', $scope.$on(uiGridConstants.events.ITEM_DRAGGING, applyHideMenu ));
-    },
-
-
-    controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
-      var self = this;
-    }]
+    }
   };
 
   return uiGridMenu;
@@ -231,15 +223,12 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
       leaveOpen: '=',
       screenReaderOnly: '='
     },
-    require: ['?^uiGrid', '^uiGridMenu'],
+    require: ['?^uiGrid'],
     templateUrl: 'ui-grid/uiGridMenuItem',
     replace: false,
-    compile: function($elm, $attrs) {
+    compile: function() {
       return {
-        pre: function ($scope, $elm, $attrs, controllers) {
-          var uiGridCtrl = controllers[0],
-              uiGridMenuCtrl = controllers[1];
-
+        pre: function ($scope, $elm) {
           if ($scope.templateUrl) {
             gridUtil.getTemplate($scope.templateUrl)
                 .then(function (contents) {
@@ -251,8 +240,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
           }
         },
         post: function ($scope, $elm, $attrs, controllers) {
-          var uiGridCtrl = controllers[0],
-              uiGridMenuCtrl = controllers[1];
+          var uiGridCtrl = controllers[0];
 
           // TODO(c0bra): validate that shown and active are functions if they're defined. An exception is already thrown above this though
           // if (typeof($scope.shown) !== 'undefined' && $scope.shown && typeof($scope.shown) !== 'function') {

--- a/src/templates/ui-grid/uiGridMenu.html
+++ b/src/templates/ui-grid/uiGridMenu.html
@@ -9,17 +9,6 @@
     ng-show="shownMid">
     <div
     class="ui-grid-menu-inner">
-      <button
-        type="button"
-        ng-focus="focus=true"
-        ng-blur="focus=false"
-        class="ui-grid-menu-close-button"
-        ng-class="{'ui-grid-sr-only': (!focus)}">
-        <i
-          class="ui-grid-icon-cancel"
-          ui-grid-one-bind-aria-label="i18n.close">
-        </i>
-      </button>
       <ul
         role="menu"
         class="ui-grid-menu-items">

--- a/test/unit/core/directives/ui-grid-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-menu.spec.js
@@ -231,4 +231,47 @@ describe('ui-grid-menu', function() {
       expect(item.hasClass('ng-hide')).toBe(false);
     });
   });
+
+  describe( 'menu should close when ESC key is pressed', function() {
+    var timeout;
+    beforeEach( function() {
+      spyOn($scope, 'hideMenu');
+      $scope.$broadcast('show-menu');
+      inject(function ($timeout) {
+        timeout = $timeout;
+      });
+    });
+
+    it('should call hideMenu if ESC is pressed', function() {
+      var e = $.Event("keyup");
+      e.which = 27;
+      $(menu).trigger(e);
+      timeout.flush();
+      expect($scope.hideMenu).toHaveBeenCalled();
+    });
+  });
+
+  ddescribe('focus should be retained within the menu', function() {
+    var timeout, menuItemButtons;
+    beforeEach( function() {
+      $scope.$broadcast('show-menu');
+      inject(function ($timeout) {
+        timeout = $timeout;
+      });
+      console.log(menu);
+      menuItemButtons = menu.find('button');
+    });
+
+    it('should call hideMenu if ESC is pressed', function() {
+      var e = $.Event("keydown");
+      e.which = 9;
+      $(menuItemButtons[menuItemButtons.length - 1]).trigger(e);
+
+      spyOn(menuItemButtons[0],'focus');
+      timeout.flush();
+      expect(menuItemButtons[0].focus).toHaveBeenCalled();
+    });
+
+  });
+
 });

--- a/test/unit/core/directives/ui-grid-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-menu.spec.js
@@ -232,46 +232,33 @@ describe('ui-grid-menu', function() {
     });
   });
 
-  describe( 'menu should close when ESC key is pressed', function() {
-    var timeout;
-    beforeEach( function() {
-      spyOn($scope, 'hideMenu');
-      $scope.$broadcast('show-menu');
-      inject(function ($timeout) {
-        timeout = $timeout;
-      });
-    });
 
-    it('should call hideMenu if ESC is pressed', function() {
-      var e = $.Event("keyup");
-      e.which = 27;
-      $(menu).trigger(e);
-      timeout.flush();
-      expect($scope.hideMenu).toHaveBeenCalled();
-    });
-  });
-
-  ddescribe('focus should be retained within the menu', function() {
+  describe('keyUp and keyDown actions', function() {
     var timeout, menuItemButtons;
     beforeEach( function() {
-      $scope.$broadcast('show-menu');
       inject(function ($timeout) {
         timeout = $timeout;
       });
-      console.log(menu);
-      menuItemButtons = menu.find('button');
+      $scope.$broadcast('show-menu');
+      $scope.$digest();
+      timeout.flush();
     });
 
-    it('should call hideMenu if ESC is pressed', function() {
+    it('should focus on the first menu item after tabbing from the last menu item', function() {
+      menuItemButtons = menu.find('button');
       var e = $.Event("keydown");
-      e.which = 9;
-      $(menuItemButtons[menuItemButtons.length - 1]).trigger(e);
-
+      e.keyCode = 9;
       spyOn(menuItemButtons[0],'focus');
-      timeout.flush();
+      $(menuItemButtons[menuItemButtons.length - 1]).trigger(e);
       expect(menuItemButtons[0].focus).toHaveBeenCalled();
     });
 
+    it('should call hideMenu if ESC is pressed', function() {
+      spyOn(isolateScope, 'hideMenu');
+      var e = $.Event("keyup");
+      e.keyCode = 27;
+      $(menu).trigger(e);
+      expect(isolateScope.hideMenu).toHaveBeenCalled();
+  	});
   });
-
 });


### PR DESCRIPTION
For ARIA, an X and Close menu option had been implemented into the column menus. This PR removes those and implements the ESC key to close the menu via a keyboard. It also makes sure tabbing is cyclical, so tabbing continuously will keep you contained within the menu.