### PR TITLE
fix(exporter): pass column seperator options as param to downloadFile

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -914,10 +914,19 @@
           var a = D.createElement('a');
           var strMimeType = 'application/octet-stream;charset=utf-8';
           var rawFile;
-          var ieVersion;
+          var ieVersion = this.isIE();
 
-          ieVersion = this.isIE();
-          if (ieVersion && ieVersion < 10) {
+          // IE10+
+          if (navigator.msSaveBlob) {
+            return navigator.msSaveOrOpenBlob(
+              new Blob(
+                [exporterOlderExcelCompatibility ? "\uFEFF" : '', csvContent],
+                { type: strMimeType } ),
+              fileName
+            );
+          }
+
+          if (ieVersion) {
             var frame = D.createElement('iframe');
             document.body.appendChild(frame);
 
@@ -929,16 +938,6 @@
 
             document.body.removeChild(frame);
             return true;
-          }
-
-          // IE10+
-          if (navigator.msSaveBlob) {
-            return navigator.msSaveOrOpenBlob(
-              new Blob(
-                [exporterOlderExcelCompatibility ? "\uFEFF" : '', csvContent],
-                { type: strMimeType } ),
-              fileName
-            );
           }
 
           //html5 A[download]

--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -626,7 +626,7 @@
             var exportData = self.getData(grid, rowTypes, colTypes);
             var csvContent = self.formatAsCsv(exportColumnHeaders, exportData, grid.options.exporterCsvColumnSeparator);
 
-            self.downloadFile (grid.options.exporterCsvFilename, csvContent, grid.options.exporterOlderExcelCompatibility);
+            self.downloadFile (grid.options.exporterCsvFilename, csvContent, grid.options.exporterCsvColumnSeparator, grid.options.exporterOlderExcelCompatibility);
           });
         },
 
@@ -909,7 +909,7 @@
          * download as a file
          * @param {boolean} exporterOlderExcelCompatibility whether or not we put a utf-16 BOM on the from (\uFEFF)
          */
-        downloadFile: function (fileName, csvContent, exporterOlderExcelCompatibility) {
+        downloadFile: function (fileName, csvContent, columnSeparator, exporterOlderExcelCompatibility) {
           var D = document;
           var a = D.createElement('a');
           var strMimeType = 'application/octet-stream;charset=utf-8';
@@ -921,8 +921,8 @@
             var frame = D.createElement('iframe');
             document.body.appendChild(frame);
 
-            frame.contentWindow.document.open("text/html", "replace");
-            frame.contentWindow.document.write('sep=,\r\n' + csvContent);
+            frame.contentWindow.document.open('text/html', 'replace');
+            frame.contentWindow.document.write('sep=,' + columnSeparator + '\r\n' + csvContent);
             frame.contentWindow.document.close();
             frame.contentWindow.focus();
             frame.contentWindow.document.execCommand('SaveAs', true, fileName);


### PR DESCRIPTION
Write the correct csv header seperator. When `gridOptions.exporterCsvColumnSeparator` was set to something else than coma the header and the seperators are not equal and result in wrong behavior with excel.

In addition changed the ieVersion handling since it was broken due to #4640 for the csv part of the exporter.