### PR TITLE
Fix intermittent bug where dropdowns are not properly removed after editing.

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -660,7 +660,7 @@
              *  [ {id: xxx, value: xxx} ], which will be used to populate
              *  the edit dropdown.  This can be used when the dropdown values are dependent on
              *  the backing row entity with some kind of algorithm.
-             *  If this property is set then both editDropdownOptionsArray and 
+             *  If this property is set then both editDropdownOptionsArray and
              *  editDropdownRowEntityOptionsArrayPath will be ignored.
              *  @param {object} rowEntity the options.data element that the returned array refers to
              *  @param {object} colDef the column that implements this dropdown
@@ -856,7 +856,10 @@
               var gridCellContentsEl = angular.element($elm.children()[0]);
               //remove edit element
               editCellScope.$destroy();
-              angular.element($elm.children()[1]).remove();
+              var children = $elm.children();
+              for (var i = 1; i < children.length; i++) {
+                angular.element(children[i]).remove();
+              }
               gridCellContentsEl.removeClass('ui-grid-cell-contents-hidden');
               inEdit = false;
               registerBeginEditEvents();


### PR DESCRIPTION
One of my users discovered that if you hammer on an editable grid with dropdowns enough, you will occasionally end up with a dropdown left behind that should have been removed from the DOM. This fix makes sure that orphan dropdowns get cleaned up too.

After a quick look at your test suite, I could not come up with a good way to test for this bug, and they're not going to let me spend more time on this. I figured that the fix was still valuable though.