### PR TITLE
Allows setting $$treeLevel to -1 on a row's entity

### DIFF
--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -1495,7 +1495,7 @@
        * @param {gridRow} row the parent we're finalising
        */
       finaliseAggregations: function( row ){
-        if ( typeof(row.treeNode.aggregations) === 'undefined' ){
+        if ( row == null || typeof(row.treeNode.aggregations) === 'undefined' ){
           return;
         }
 


### PR DESCRIPTION
finaliseAggregations would bomb because the parent row is passed to it but does not exist when you set a row's entity $$treeLevel to -1 so that you can keep it non-parent row.

[See issue 5147 ](https://github.com/angular-ui/ui-grid/issues/5147)