### PR TITLE
Update ui-grid-util.js

### DIFF
--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -1375,8 +1375,6 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
     deltaX = Math[ deltaX >= 1 ? 'floor' : 'ceil' ](deltaX / lowestDelta);
     deltaY = Math[ deltaY >= 1 ? 'floor' : 'ceil' ](deltaY / lowestDelta);
 
-    event.deltaMode = 0;
-
     // Normalise offsetX and offsetY properties
     // if ($elm[0].getBoundingClientRect ) {
     //   var boundingRect = $(elm)[0].getBoundingClientRect();


### PR DESCRIPTION
WheelEvent.deltaMode is a READONLY property, as explained https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaMode and by the error message my browser throws.  This should not be reset to zero.