### PR TITLE
feat(pagination): Add custom pagination with variable page sizes

### DIFF
--- a/misc/tutorial/406_custom_pagination.ngdoc
+++ b/misc/tutorial/406_custom_pagination.ngdoc
@@ -1,0 +1,120 @@
+@ngdoc overview
+@name Tutorial: 406 Custom Pagination
+@description
+
+When pagination is enabled, the data is displayed in pages that can be browsed using the built in
+pagination selector. However, you don't always have pages with the same number of rows.
+
+For custom pagination, set the `pageSizes` option and the `useCustomPagination`.
+~~ and implement the `gridApi.pagination.on.paginationChanged` callback function. The callback
+may contain code to update any pagination state variables your application may utilize, e.g. variables containing
+the `pageNumber`, `pageSize`, and `pageSizeList`. The REST call used to fetch the data from the server should be
+called from within this callback. The URL of the call should contain query parameters that will allow the server-side
+code to have sufficient information to be able to retrieve the specific subset of data that the client requires from
+the entire set.~~
+
+It should also update the `$scope.gridOptions.totalItems` variable with the total count of rows that exist (but
+were not all fetched in the REST call mentioned above since they exist in other pages of data).
+
+This will allow ui-grid to calculate the correct number of pages on the client-side.
+
+@example
+This shows custom pagination.
+<example module="app">
+  <file name="app.js">
+    var app = angular.module('app', ['ngTouch', 'ui.grid', 'ui.grid.pagination']);
+
+    app.controller('MainCtrl', [
+    '$scope', '$http', 'uiGridConstants', function($scope, $http, uiGridConstants) {
+
+      $scope.gridOptions1 = {
+        paginationPageSizes: null,
+        useCustomPagination: true,
+        columnDefs: [
+          { name: 'name', enableSorting: false },
+          { name: 'gender', enableSorting: false },
+          { name: 'company', enableSorting: false }
+        ]
+      };
+
+      $scope.gridOptions2 = {
+        paginationPageSizes: null,
+        useCustomPagination: true,
+        useExternalPagination : true,
+        columnDefs: [
+          { name: 'name', enableSorting: false },
+          { name: 'gender', enableSorting: false },
+          { name: 'company', enableSorting: false }
+        ],
+        onRegisterApi: function(gridApi) {
+          gridApi.pagination.on.paginationChanged($scope, function (pageNumber, pageSize) {
+            $scope.gridOptions2.data = getPage($scope.grid2data, pageNumber);
+          });
+        }
+      };
+
+      $http.get('/data/100_ASC.json')
+      .success(function (data) {
+        $scope.gridOptions1.data = data;
+        $scope.gridOptions1.paginationPageSizes = calculatePageSizes(data);
+      });
+
+      $http.get('/data/100.json')
+      .success(function (data) {
+        $scope.grid2data = data;
+        $scope.gridOptions2.totalItems = 0;//data.length;
+        $scope.gridOptions2.paginationPageSizes = calculatePageSizes(data);
+        $scope.gridOptions2.data = getPage($scope.grid2data, 1);
+      });
+
+
+      function calculatePageSizes(data) {
+        var initials = [];
+        return data.reduce(function(pageSizes, row) {
+          var initial = row.name.charAt(0);
+          var index = initials.indexOf(initial);
+          if(index < 0)
+          {
+            index = initials.length;
+            initials.push(initial);
+          }
+          pageSizes[index] = (pageSizes[index] || 0) + 1;
+          return pageSizes;
+        }, []);
+      }
+
+      function getPage(data, pageNumber)
+      {
+        var initials = [];
+        return data.reduce(function(pages, row) {
+          var initial = row.name.charAt(0);
+
+          if(!pages[initial]) pages[initial] = [];
+          pages[initial].push(row);
+
+          if(initials.indexOf(initial) < 0)
+          {
+            initials.push(initial);
+            initials.sort();
+          }
+
+          return pages;
+
+        }, {})[initials[pageNumber - 1]] || [];
+      }
+
+    }
+    ]);
+  </file>
+  <file name="index.html">
+    <div ng-controller="MainCtrl">
+      <div ui-grid="gridOptions1" ui-grid-pagination class="grid"></div>
+      <div ui-grid="gridOptions2" ui-grid-pagination class="grid"></div>
+    </div>
+  </file>
+  <file name="main.css">
+    .grid {
+      width: 600px;
+    }
+  </file>
+</example>

--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -77,7 +77,7 @@
                       return index < grid.options.paginationCurrentPage - 1 ? result + size : result;
                     }, 0);
                   }
-                  return ((grid.options.paginationCurrentPage - 1) * grid.options.paginationPageSize) + 1;
+                  return ((grid.options.paginationCurrentPage - 1) * grid.options.paginationPageSize);
                 },
                 /**
                  * @ngdoc method

--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -87,9 +87,7 @@
                  */
                 getLastRowIndex: function () {
                   if (grid.options.useCustomPagination) {
-                    return grid.options.paginationPageSizes.reduce(function(result, size, index) {
-                      return index <= grid.options.paginationCurrentPage - 1 ? result + size : result;
-                    }, 0);
+                    return publicApi.methods.pagination.getFirstRowIndex() + grid.options.paginationPageSizes[grid.options.paginationCurrentPage - 1];
                   }
                   return Math.min(grid.options.paginationCurrentPage * grid.options.paginationPageSize, grid.options.totalItems);
                 },

--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -67,6 +67,34 @@
                 },
                 /**
                  * @ngdoc method
+                 * @name getFirstRowIndex
+                 * @methodOf ui.grid.pagination.api:PublicAPI
+                 * @description Returns the index of the first row of the current page.
+                 */
+                getFirstRowIndex: function () {
+                  if (grid.options.useCustomPagination) {
+                    return grid.options.paginationPageSizes.reduce(function(result, size, index) {
+                      return index < grid.options.paginationCurrentPage - 1 ? result + size : result;
+                    }, 0);
+                  }
+                  return ((grid.options.paginationCurrentPage - 1) * grid.options.paginationPageSize) + 1;
+                },
+                /**
+                 * @ngdoc method
+                 * @name getLastRowIndex
+                 * @methodOf ui.grid.pagination.api:PublicAPI
+                 * @description Returns the index of the last row of the current page.
+                 */
+                getLastRowIndex: function () {
+                  if (grid.options.useCustomPagination) {
+                    return grid.options.paginationPageSizes.reduce(function(result, size, index) {
+                      return index <= grid.options.paginationCurrentPage - 1 ? result + size : result;
+                    }, 0);
+                  }
+                  return Math.min(grid.options.paginationCurrentPage * grid.options.paginationPageSize, grid.options.totalItems);
+                },
+                /**
+                 * @ngdoc method
                  * @name getTotalPages
                  * @methodOf ui.grid.pagination.api:PublicAPI
                  * @description Returns the total number of pages
@@ -74,6 +102,10 @@
                 getTotalPages: function () {
                   if (!grid.options.enablePagination) {
                     return null;
+                  }
+
+                  if (grid.options.useCustomPagination) {
+                    return grid.options.paginationPageSizes.length;
                   }
 
                   return (grid.options.totalItems === 0) ? 1 : Math.ceil(grid.options.totalItems / grid.options.paginationPageSize);
@@ -146,12 +178,14 @@
             var visibleRows = renderableRows.filter(function (row) { return row.visible; });
             grid.options.totalItems = visibleRows.length;
 
-            var firstRow = (currentPage - 1) * pageSize;
+            var firstRow = publicApi.methods.pagination.getFirstRowIndex();
+            var lastRow  = publicApi.methods.pagination.getLastRowIndex();
+
             if (firstRow > visibleRows.length) {
               currentPage = grid.options.paginationCurrentPage = 1;
               firstRow = (currentPage - 1) * pageSize;
             }
-            return visibleRows.slice(firstRow, firstRow + pageSize);
+            return visibleRows.slice(firstRow, lastRow);
           };
 
           grid.registerRowsProcessor(processPagination, 900 );
@@ -189,6 +223,16 @@
            *              and totalItems.  Defaults to `false`
            */
           gridOptions.useExternalPagination = gridOptions.useExternalPagination === true;
+
+          /**
+           * @ngdoc property
+           * @name useCustomPagination
+           * @propertyOf ui.grid.pagination.api:GridOptions
+           * @description Disables client-side pagination. When true, handle the `paginationChanged` event and set `data`,
+           *              `firstRowIndex`, `lastRowIndex`, and `totalItems`.  Defaults to `false`.
+           */
+          gridOptions.useCustomPagination = gridOptions.useCustomPagination === true;
+
           /**
            * @ngdoc property
            * @name totalItems
@@ -368,8 +412,6 @@
           $scope.$on('$destroy', dataChangeDereg);
 
           var setShowing = function () {
-            $scope.showingLow = ((options.paginationCurrentPage - 1) * options.paginationPageSize) + 1;
-            $scope.showingHigh = Math.min(options.paginationCurrentPage * options.paginationPageSize, options.totalItems);
           };
 
           var deregT = $scope.$watch('grid.options.totalItems + grid.options.paginationPageSize', setShowing);
@@ -400,19 +442,16 @@
           });
 
           $scope.cantPageForward = function () {
-            if (options.totalItems > 0) {
-              return options.paginationCurrentPage >= $scope.paginationApi.getTotalPages();
+            if ($scope.paginationApi.getTotalPages()) {
+              return $scope.cantPageToLast();
             } else {
               return options.data.length < 1;
             }
           };
 
           $scope.cantPageToLast = function () {
-            if (options.totalItems > 0) {
-              return $scope.cantPageForward();
-            } else {
-              return true;
-            }
+            var totalPages = $scope.paginationApi.getTotalPages();
+            return !totalPages || options.paginationCurrentPage >= totalPages;
           };
 
           $scope.cantPageBackward = function () {

--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -409,11 +409,6 @@
 
           $scope.$on('$destroy', dataChangeDereg);
 
-          var setShowing = function () {
-          };
-
-          var deregT = $scope.$watch('grid.options.totalItems + grid.options.paginationPageSize', setShowing);
-
           var deregP = $scope.$watch('grid.options.paginationCurrentPage + grid.options.paginationPageSize', function (newValues, oldValues) {
               if (newValues === oldValues || oldValues === undefined) {
                 return;
@@ -429,13 +424,11 @@
                 return;
               }
 
-              setShowing();
               uiGridPaginationService.onPaginationChanged($scope.grid, options.paginationCurrentPage, options.paginationPageSize);
             }
           );
 
           $scope.$on('$destroy', function() {
-            deregT();
             deregP();
           });
 

--- a/src/features/pagination/templates/pagination.html
+++ b/src/features/pagination/templates/pagination.html
@@ -78,7 +78,7 @@
     </div>
     <div
       class="ui-grid-pager-row-count-picker"
-      ng-if="grid.options.paginationPageSizes.length > 1">
+      ng-if="grid.options.paginationPageSizes.length > 1 && !grid.options.useCustomPagination">
       <select
         ui-grid-one-bind-aria-labelledby-grid="'items-per-page-label'"
         ng-model="grid.options.paginationPageSize"
@@ -101,12 +101,12 @@
       class="ui-grid-pager-count">
       <span
         ng-show="grid.options.totalItems > 0">
-        {{showingLow}}
+        {{ 1 + paginationApi.getFirstRowIndex() }}
         <abbr
           ui-grid-one-bind-title="paginationThrough">
           -
         </abbr>
-        {{showingHigh}} {{paginationOf}} {{grid.options.totalItems}} {{totalItemsLabel}}
+        {{ paginationApi.getLastRowIndex() }} {{paginationOf}} {{grid.options.totalItems}} {{totalItemsLabel}}
       </span>
     </div>
   </div>

--- a/src/features/pagination/templates/pagination.html
+++ b/src/features/pagination/templates/pagination.html
@@ -106,7 +106,7 @@
           ui-grid-one-bind-title="paginationThrough">
           -
         </abbr>
-        {{ paginationApi.getLastRowIndex() }} {{paginationOf}} {{grid.options.totalItems}} {{totalItemsLabel}}
+        {{ 1 + paginationApi.getLastRowIndex() }} {{paginationOf}} {{grid.options.totalItems}} {{totalItemsLabel}}
       </span>
     </div>
   </div>

--- a/src/features/pagination/test/pagination.spec.js
+++ b/src/features/pagination/test/pagination.spec.js
@@ -64,6 +64,8 @@ describe('ui.grid.pagination uiGridPaginationService', function () {
   describe('initialisation', function () {
     it('registers the API and methods', function () {
       expect(gridApi.pagination.getPage).toEqual(jasmine.any(Function));
+      expect(gridApi.pagination.getFirstRowIndex).toEqual(jasmine.any(Function));
+      expect(gridApi.pagination.getLastRowIndex).toEqual(jasmine.any(Function));
       expect(gridApi.pagination.getTotalPages).toEqual(jasmine.any(Function));
       expect(gridApi.pagination.nextPage).toEqual(jasmine.any(Function));
       expect(gridApi.pagination.previousPage).toEqual(jasmine.any(Function));

--- a/src/features/pagination/test/pagination.spec.js
+++ b/src/features/pagination/test/pagination.spec.js
@@ -176,4 +176,111 @@ describe('ui.grid.pagination uiGridPaginationService', function () {
       });
     });
   });
+
+  describe('custom pagination', function () {
+
+    var pages = ['COSU', 'DJLPQTVX', 'ABFGHIKNRY', 'EMWZ'];
+
+    function getPage(data, pageNumber) {
+      return data.filter(function(datum) {
+        return pages[pageNumber-1].indexOf(datum.col2) >= 0;
+      });
+    }
+
+    beforeEach(inject(function (_$rootScope_, _$timeout_, $compile) {
+      $rootScope = _$rootScope_;
+      $timeout = _$timeout_;
+
+      $rootScope.gridOptions.useCustomPagination = true;
+      $rootScope.gridOptions.useExternalPagination = true;
+      $rootScope.gridOptions.paginationPageSizes = [4,8,10,4];
+
+      var data = $rootScope.gridOptions.data;
+      $rootScope.gridOptions.data = getPage(data, 1);
+      gridApi.pagination.on.paginationChanged($rootScope, function (pageNumber) {
+        $rootScope.gridOptions.data = getPage(data, pageNumber);
+      });
+
+      $rootScope.$digest();
+    }));
+
+    it('starts at page 1 with 4 records', function () {
+      var gridRows = gridElement.find('div.ui-grid-row');
+
+      expect(gridApi.pagination.getPage()).toBe(1);
+      expect(gridRows.length).toBe(4);
+
+      var firstCell = gridRows.eq(0).find('div.ui-grid-cell:first-child');
+      expect(firstCell.text()).toBe('6_1');
+
+      var lastCell = gridRows.eq(3).find('div.ui-grid-cell:last-child');
+      expect(lastCell.text()).toBe('25_4');
+    });
+
+    it('calculates the total number of pages correctly', function () {
+      expect(gridApi.pagination.getTotalPages()).toBe(4);
+    });
+
+    it('displays page 2 if I call nextPage()', function () {
+      gridApi.pagination.nextPage();
+      $rootScope.$digest();
+      $timeout.flush();
+
+      var gridRows = gridElement.find('div.ui-grid-row');
+
+      expect(gridApi.pagination.getPage()).toBe(2);
+      expect(gridRows.length).toBe(8);
+
+      var firstCell = gridRows.eq(0).find('div.ui-grid-cell:first-child');
+      expect(firstCell.text()).toBe('4_1');
+
+      var lastCell = gridRows.eq(7).find('div.ui-grid-cell:last-child');
+      expect(lastCell.text()).toBe('21_4');
+    });
+
+    it('displays 10 rows on page 3', function () {
+      gridApi.pagination.seek(3);
+      $rootScope.$digest();
+      $timeout.flush();
+
+      var gridRows = gridElement.find('div.ui-grid-row');
+
+      expect(gridApi.pagination.getPage()).toBe(3);
+      expect(gridRows.length).toBe(10);
+
+      var firstCell = gridRows.eq(0).find('div.ui-grid-cell:first-child');
+      expect(firstCell.text()).toBe('1_1');
+
+      var lastCell = gridRows.eq(9).find('div.ui-grid-cell:last-child');
+      expect(lastCell.text()).toBe('26_4');
+    });
+
+    it('paginates correctly on a sorted grid', function() {
+      gridApi.grid.sortColumn(gridApi.grid.columns[1]).then(function () {
+        gridApi.pagination.seek(3);
+        $rootScope.$digest();
+        $timeout.flush();
+
+        var gridRows = gridElement.find('div.ui-grid-row');
+        expect(gridApi.pagination.getPage()).toBe(1);
+        expect(gridRows.eq(0).find('div.ui-grid-cell').eq(1).text()).toBe('A');
+        expect(gridRows.eq(1).find('div.ui-grid-cell').eq(1).text()).toBe('B');
+        expect(gridRows.eq(2).find('div.ui-grid-cell').eq(1).text()).toBe('F');
+        expect(gridRows.eq(3).find('div.ui-grid-cell').eq(1).text()).toBe('G');
+        expect(gridRows.eq(4).find('div.ui-grid-cell').eq(1).text()).toBe('H');
+        expect(gridRows.eq(5).find('div.ui-grid-cell').eq(1).text()).toBe('I');
+        expect(gridRows.eq(6).find('div.ui-grid-cell').eq(1).text()).toBe('K');
+        expect(gridRows.eq(7).find('div.ui-grid-cell').eq(1).text()).toBe('N');
+        expect(gridRows.eq(8).find('div.ui-grid-cell').eq(1).text()).toBe('R');
+        expect(gridRows.eq(9).find('div.ui-grid-cell').eq(1).text()).toBe('Y');
+
+        gridApi.pagination.nextPage();
+        $rootScope.$digest();
+
+        gridRows = gridElement.find('div.ui-grid-row');
+        expect(gridApi.pagination.getPage()).toBe(2);
+        expect(gridRows.eq(0).find('div.ui-grid-cell').eq(1).text()).toBe('E');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Use Case:
 Client requests page breaks by (e.g.) Date column. This can currently be
accomplished by external pagination, but the 'page size' dropdown
becomes irrelevant, and the page-count on the right can no longer
correctly determine the correct row range.

The pagination template has been modified to hide the page-size dropdown
when custom pagination is enabled, and to use new API methods for the
row range.

A new tutorial page has been added as lesson 406-Custom-Pagination
which demonstrates two usages: pre-sorted data, with pre-calculated pages
sizes; and unsorted data, with external pagination.
