### PR TITLE
fix:dropdown losing focus when using scrollToFocus from anoter editfield

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -1117,8 +1117,8 @@
    *
    */
   module.directive('uiGridEditDropdown',
-    ['uiGridConstants', 'uiGridEditConstants',
-      function (uiGridConstants, uiGridEditConstants) {
+    ['uiGridConstants', 'uiGridEditConstants', '$timeout',
+      function (uiGridConstants, uiGridEditConstants, $timeout) {
         return {
           require: ['?^uiGrid', '?^uiGridRenderContainer'],
           scope: true,
@@ -1133,7 +1133,10 @@
 
                 //set focus at start of edit
                 $scope.$on(uiGridEditConstants.events.BEGIN_CELL_EDIT, function () {
-                  $elm[0].focus();
+                  $timeout(function(){
+                    $elm[0].focus();      
+                  });
+                  
                   $elm[0].style.width = ($elm[0].parentElement.offsetWidth - 1) + 'px';
                   $elm.on('blur', function (evt) {
                     $scope.stopEdit(evt);


### PR DESCRIPTION
The simplest possible solution i found to fixing an issue where selects with the "ui-grid-edit-dropdown" attribute would loose focus directly after getting it when trying to focus it with scrollToFocus while editing another field.

Simplified scenario: i have a textbox in the grid, if i type 2 i scrollToFocus to column 2, if i type 3 i scrollToFocus to column 3. This works great for all columns that isnt using the ui-grid-edit-dropdown attribute in the editTemplate. I compared the code for ui-grid-editor and ui-grid-edit-dropdown and noticed that ui-grid-editor has its elm[0].focus() inside a timeout. When applied to my issue this solved it,and it did not seem to cause any form of regression. Since it is already approved for use on the grid-editor attribute, i thought it would be reasonable to add it here too.

Did not know if i should add only the focus or everything in the timeout, so i went with least amount possible.