### PR TITLE
fix(batch): Prevent batch event from firing for single row

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -600,7 +600,7 @@
          * if we're doing batch events
          */
         decideRaiseSelectionBatchEvent: function( grid, changedRows, evt ){
-          if ( changedRows.length > 0 ){
+          if ( changedRows.length > 1 ){
             grid.api.selection.raise.rowSelectionChangedBatch(changedRows, evt);
           }
         }


### PR DESCRIPTION
Prevent `rowSelectionChangedBatch` from firing when a single row is changing. As seen in this [plunkr](http://plnkr.co/edit/Dtdm88XJtXg9QA8dBkyq?p=preview), when changing from one row to another we get an unnecessary batch log in the Developer tools. Batch event(s) should only fire when `changedRows.length > 1`.