### PR TITLE
Added simple clearExistingGridSortsOnColumnHeaderMenuSort option to c…

### DIFF
--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -422,7 +422,8 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
       $scope.sortColumn = function (event, dir) {
         event.stopPropagation();
 
-        $scope.grid.sortColumn($scope.col, dir, true)
+        var appendSort = $scope.col.colDef.clearExistingGridSortsOnColumnHeaderMenuSort ? false : true;
+        $scope.grid.sortColumn($scope.col, dir, appendSort)
           .then(function () {
             $scope.grid.refresh();
             $scope.hideMenu();

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -81,6 +81,23 @@ angular.module('ui.grid')
    */
 
   /**
+   * @ngdoc property
+   * @name clearExistingGridSortsOnColumnHeaderMenuSort
+   * @propertyOf ui.grid.class:GridOptions.columnDef
+   * @description Optional property whose value is true or false.  Defaults to false.  If this value is set to true any sorts currently applied to the grid will be cleared when a user activates a sort option through the grid header menu.
+   */
+
+  /**
+   * @ngdoc property
+   * @name clearExistingGridSortsOnColumnHeaderMenuSort
+   * @propertyOf ui.grid.class:GridColumn
+   * @description Optional property whose value is true or false.  Defaults to false.  If this value is set to true any sorts currently applied to the grid will be cleared when a user activates a sort option through the grid header menu.
+   * @example
+   * <pre>GridOptions.columnDef.clearExistingGridSortsOnColumnHeaderMenuSort=true</pre>
+   *
+   */
+
+   /**
    * @ngdoc object
    * @name ui.grid.class:GridColumn
    * @description Represents the viewModel for each column.  Any state or methods needed for a Grid Column

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -696,6 +696,15 @@ describe('Grid factory', function () {
       expect( column.sort.priority ).toEqual(0);
     });
 
+    it( 'if clearExistingGridSortsOnColumnHeaderMenuSort is set to true expect resetColumnSorting to be called', function() {
+      spyOn(grid, 'resetColumnSorting');
+      column.clearExistingGridSortsOnColumnHeaderMenuSort = true;
+      grid.sortColumn( column, false );
+      expect(grid.resetColumnSorting).toHaveBeenCalled();
+      delete column.clearExistingGridSortsOnColumnHeaderMenuSort;
+    });
+
+
     it( 'if sort is currently ASC, then should toggle to DESC, and reset priortiy', function() {
       column.sort = {direction: uiGridConstants.ASC, priority: 2};
       grid.sortColumn( column, false );


### PR DESCRIPTION
…olumn defs to allow for default column menu sorting to reset any active sort set before the new sort is applied.

Also added documentation and example.