### PR TITLE
Workaround to solve issue with enable___ (enableRowSelection, ...)

### DIFF
--- a/misc/tutorial/101_intro.ngdoc
+++ b/misc/tutorial/101_intro.ngdoc
@@ -34,7 +34,10 @@ Steps:
    </pre>
  </li>
  <li>
-   Add a css style to your app css so the grid knows it's dimensions
+   Add a css style to your app css so the grid knows it's dimensions. This is optional.
+   <br>
+   If the grid container does not have a height, the grid's height will be calculated using gridOptions.minsRowsToShow,
+   assuming gridOptions.enableMinHeightCheck = true (The default).
    <pre>
      .myGrid {
          width: 500px;

--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -283,58 +283,13 @@ function uiGridDirective($compile, $templateCache, $timeout, $window, gridUtil, 
 
             // If the grid isn't tall enough to fit a single row, it's kind of useless. Resize it to fit a minimum number of rows
             if (grid.gridHeight <= grid.options.rowHeight && grid.options.enableMinHeightCheck) {
-              autoAdjustHeight();
+              grid.autoAdjustHeight();
             }
 
             // Run initial canvas refresh
             grid.refreshCanvas(true);
           }
 
-          // Set the grid's height ourselves in the case that its height would be unusably small
-          function autoAdjustHeight() {
-            // Figure out the new height
-            var contentHeight = grid.options.minRowsToShow * grid.options.rowHeight;
-            var headerHeight = grid.options.showHeader ? grid.options.headerRowHeight : 0;
-            var footerHeight = grid.calcFooterHeight();
-
-            var scrollbarHeight = 0;
-            if (grid.options.enableHorizontalScrollbar === uiGridConstants.scrollbars.ALWAYS) {
-              scrollbarHeight = gridUtil.getScrollbarWidth();
-            }
-
-            var maxNumberOfFilters = 0;
-            // Calculates the maximum number of filters in the columns
-            angular.forEach(grid.options.columnDefs, function(col) {
-              if (col.hasOwnProperty('filter')) {
-                if (maxNumberOfFilters < 1) {
-                    maxNumberOfFilters = 1;
-                }
-              }
-              else if (col.hasOwnProperty('filters')) {
-                if (maxNumberOfFilters < col.filters.length) {
-                    maxNumberOfFilters = col.filters.length;
-                }
-              }
-            });
-
-            if (grid.options.enableFiltering  && !maxNumberOfFilters) {
-              var allColumnsHaveFilteringTurnedOff = grid.options.columnDefs.length && grid.options.columnDefs.every(function(col) {
-                return col.enableFiltering === false;
-              });
-
-              if (!allColumnsHaveFilteringTurnedOff) {
-                maxNumberOfFilters = 1;
-              }
-            }
-
-            var filterHeight = maxNumberOfFilters * headerHeight;
-
-            var newHeight = headerHeight + contentHeight + footerHeight + scrollbarHeight + filterHeight;
-
-            $elm.css('height', newHeight + 'px');
-
-            grid.gridHeight = $scope.gridHeight = gridUtil.elementHeight($elm);
-          }
 
           // Resize the grid on window resize events
           function gridResize($event) {

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2538,6 +2538,66 @@ angular.module('ui.grid')
     }
   };
 
+  /**
+  * @ngdoc function
+  * @name autoAdjustHeight
+  * @methodOf ui.grid.class:Grid
+  * @description Automatically adjusts the height of the grid by calculating a height
+  * necessary to display the gridOptions.minRowsToShow
+  */
+  Grid.prototype.autoAdjustHeight = function () {
+    var self = this;
+    // Set the grid's height ourselves in the case that its height would be unusably small
+    // Figure out the new height
+    var contentHeight = self.options.minRowsToShow * self.options.rowHeight;
+    var headerHeight = self.options.showHeader ? self.options.headerRowHeight : 0;
+    var footerHeight = self.calcFooterHeight();
+    var prevGridHeight = self.gridHeight;
+
+    var scrollbarHeight = 0;
+    if (self.options.enableHorizontalScrollbar === uiGridConstants.scrollbars.ALWAYS) {
+      scrollbarHeight = gridUtil.getScrollbarWidth();
+    }
+
+    var maxNumberOfFilters = 0;
+    // Calculates the maximum number of filters in the columns
+    angular.forEach(self.options.columnDefs, function (col) {
+      if (col.hasOwnProperty('filter')) {
+        if (maxNumberOfFilters < 1) {
+          maxNumberOfFilters = 1;
+        }
+      }
+      else if (col.hasOwnProperty('filters')) {
+        if (maxNumberOfFilters < col.filters.length) {
+          maxNumberOfFilters = col.filters.length;
+        }
+      }
+    });
+
+    if (self.options.enableFiltering) {
+      var allColumnsHaveFilteringTurnedOff = self.options.columnDefs.every(function (col) {
+        return col.enableFiltering === false;
+      });
+
+      if (!allColumnsHaveFilteringTurnedOff) {
+        maxNumberOfFilters++;
+      }
+    }
+
+    var filterHeight = maxNumberOfFilters * headerHeight;
+
+    var newHeight = headerHeight + contentHeight + footerHeight + scrollbarHeight + filterHeight;
+
+
+    self.element.css('height', newHeight + 'px');
+
+    self.gridHeight = gridUtil.elementHeight(self.element);
+
+    if (self.gridHeight !== prevGridHeight) {
+      self.api.core.raise.gridDimensionChanged(prevGridHeight, self.gridWidth, self.gridHeight, self.gridWidth);
+    }
+  };
+
 
 
   return Grid;

--- a/src/js/core/factories/GridApi.js
+++ b/src/js/core/factories/GridApi.js
@@ -152,6 +152,15 @@
            * arguments: oldGridHeight, oldGridWidth, newGridHeight, newGridWidth
            */
           this.registerEvent( 'core', 'gridDimensionChanged');
+
+          /**
+           * @ngdoc function
+           * @name autoAdjustHeight
+           * @methodOf  ui.grid.core.api:PublicApi
+           * @description Automatically adjusts the height of the grid by calculating a height
+           * necessary to display the gridOptions.minRowsToShow
+           */
+          this.registerMethod('core', 'autoAdjustHeight', this.grid.autoAdjustHeight);
         };
 
         /**


### PR DESCRIPTION
When trying to set enable(RowSelection) in gridOptions the row still remain selectable.

$scope.gridOptions = {
    enableRowSelection: **false**,
    enableSelectAll: true,
    selectionRowHeaderWidth: 35,
    rowHeight: 35,
    showGridFooter:true
  };

When setting ui-grid-selection here the parameter enableRowSelection have no effect to the grid whatever is value (true / false)

<div ui-grid="gridOptions" ui-grid-selection class="grid"></div>


I've made a workaround to solve this issue here:
https://github.com/neolanders/angular-ui-grid-dynamic-wrapper
