### PR TITLE
fix(col-movable): prevent hidden columns triggering unnecessary re-or…

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -168,11 +168,23 @@
         });
       },
       redrawColumnAtPosition: function (grid, originalPosition, newPosition) {
+        var columns = grid.columns;
+
         if (originalPosition === newPosition) {
           return;
         }
 
-        var columns = grid.columns;
+        //check columns in between move-range to make sure they are visible columns
+        var i0 = Math.min(originalPosition, newPosition);
+        for (i0; i0 < Math.max(originalPosition, newPosition);i0++) {
+          if (columns[i0].visible) {
+            break;
+          }
+        }
+        if (i0 === Math.max(originalPosition, newPosition)) {
+          //no visible column found, column did not visibly move
+          return;
+        }
 
         var originalColumn = columns[originalPosition];
         if (originalColumn.colDef.enableColumnMoving) {


### PR DESCRIPTION
This fix checks all the columns between the originalPosition and newPosition.  IF they are all hidden, then no re-order event is necessary.  If a visible column is found, column re-ordering will be triggered.

Fixes issue: #5254