### PR TITLE
Apply column visibility properly

### DIFF
--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -55,7 +55,7 @@
             return rows;
           });
 
-          grid.registerColumnsProcessor(function allColumnsVisible(columns) {
+          grid.registerColumnsProcessor(function applyColumnVisibility(columns) {
             columns.forEach(function (column) {
               column.visible = angular.isDefined(column.colDef.visible) ? column.colDef.visible : true;
             });

--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -57,22 +57,11 @@
 
           grid.registerColumnsProcessor(function allColumnsVisible(columns) {
             columns.forEach(function (column) {
-              column.visible = true;
+              column.visible = angular.isDefined(column.colDef.visible) ? column.colDef.visible : true;
             });
 
             return columns;
           }, 50);
-
-          grid.registerColumnsProcessor(function(renderableColumns) {
-              renderableColumns.forEach(function (column) {
-                  if (column.colDef.visible === false) {
-                      column.visible = false;
-                  }
-              });
-
-              return renderableColumns;
-          }, 50);
-
 
           grid.registerRowsProcessor(grid.searchRows, 100);
 


### PR DESCRIPTION
This fix removes an unneeded additional function when setting
column visibility. Since both functions were of the same
priority level, it was possible that the visibility that
was passed in would be overwritten with the default value of
true under certain circumstances. There was really no need
for two functions, as this default behavior can be accomplished
in one. This fixes the following issue: https://github.com/angular-ui/ui-grid/issues/5303