### PR TITLE
fix(getTemplate): Updated custom templates as promises condition

### DIFF
--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -351,7 +351,7 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
       }
 
       // See if the template is itself a promise
-      if (template.hasOwnProperty('then')) {
+      if (angular.isFunction(template.then)) {
         return template.then(s.postProcessTemplate);
       }
 


### PR DESCRIPTION
now custom promise templates will handled properly, e.g.:
`headerCellTemplate: $http.get('./template.html').then(function(res) {return res.data;})`

fixes issue https://github.com/angular-ui/ui-grid/issues/4514