### PR TITLE
docs(core): fix javascript file reference format error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Need Some Inspiration? Have a look at our open [PRs Plz!](https://github.com/ang
 
 ```html
     <link rel="stylesheet" type="text/css" href="bower_components/angular-ui-grid/ui-grid.min.css">
-    <script src="bower_components/angular-ui-grid/ui-grid.min.js">
+    <script src="bower_components/angular-ui-grid/ui-grid.min.js"></script>
 ```
 
 ## NPM
@@ -37,7 +37,7 @@ Need Some Inspiration? Have a look at our open [PRs Plz!](https://github.com/ang
 
 ```html
     <link rel="stylesheet" type="text/css" href="node_modules/angular-ui-grid/ui.grid.min.css">
-    <script src="node_modules/angular-ui-grid/ui.grid.min.js">
+    <script src="node_modules/angular-ui-grid/ui.grid.min.js"></script>
 ```
 
 ## CDN


### PR DESCRIPTION
fixed a error of missing the end part of javascript reference tag in README.md, which is not allowed in html standard syntax