### PR TITLE
Update gridTestUtils.spec.js (selectRow)

### DIFF
--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -123,7 +123,7 @@ module.exports = {
   selectRow: function( gridId, rowNum ) {
     // NOTE: Can't do .click() as it doesn't work when webdriving Firefox
     var row = this.getRow( gridId, rowNum );
-    var btn = row.element(by.css('.ui-grid-selection-row-header-buttons'));
+    var btn = row.element( by.css('.ui-grid-selection-row-header-buttons') );
     return browser.actions().mouseMove(btn).mouseDown(btn).mouseUp().perform();
   },
 

--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -123,7 +123,8 @@ module.exports = {
   selectRow: function( gridId, rowNum ) {
     // NOTE: Can't do .click() as it doesn't work when webdriving Firefox
     var row = this.getRow( gridId, rowNum );
-    return browser.actions().mouseMove(row).mouseDown(row).mouseUp().perform();
+    var btn = row.element(by.css('.ui-grid-selection-row-header-buttons'));
+    return browser.actions().mouseMove(btn).mouseDown(btn).mouseUp().perform();
   },
 
   /**


### PR DESCRIPTION
selectRow doesn't work when ui-grid-selection is enabled together with ui-grid-tree-view.
getRow returns first div in the row which will be the node expand/collapse icon's div if tree view is enabled.