### PR TITLE
fix(core): Do not clear condition when clearing all filters

### DIFF
--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -193,7 +193,7 @@ angular.module('ui.grid')
       var clearFilters = [{
         title: i18nService.getSafeText('gridMenu.clearAllFilters'),
         action: function ($event) {
-          $scope.grid.clearAllFilters(undefined, true, undefined);
+          $scope.grid.clearAllFilters();
         },
         shown: function() {
           return $scope.grid.options.enableFiltering;


### PR DESCRIPTION
**Current Behavior**: Grid menu option _Clear all filters_ removes all filter `condition`s as well as search `term`s.

**Problem**: Users expect _Clear all filters_ to only remove search `term`s, but leave `condition`s as is so that filters can still be used to search the table. Essentially, we expect _Clear all fitlers_ to be the same as going through each filter and clicking the small _x_ next to it.

**Fix**: _Clear all filters_ only removes search `term`s and leaves `condition`s as is.

Fixes #4657
