### PR TITLE
removed log debug statement

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -271,7 +271,6 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
           };
 
           $scope.itemAction = function($event,title) {
-            gridUtil.logDebug('itemAction');
             $event.stopPropagation();
 
             if (typeof($scope.action) === 'function') {


### PR DESCRIPTION
There was a debug log statement in ui-grid-menu.js that was causing a log in the browser console any time the method itemAction was called. This has been removed.