### PR TITLE
fix(cellNav): notifyText incorrect if cellFilter had string literal parameter

### DIFF
--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -815,7 +815,7 @@
                   var values = [];
                   var currentSelection = grid.api.cellNav.getCurrentSelection();
                   for (var i = 0; i < currentSelection.length; i++) {
-                    values.push(currentSelection[i].getIntersectionValueFiltered());
+                    values.push(grid.getCellDisplayValue(currentSelection[i].row, currentSelection[i].col));
                   }
                   var cellText = values.toString();
                   setNotifyText(cellText);

--- a/src/js/core/factories/GridRowColumn.js
+++ b/src/js/core/factories/GridRowColumn.js
@@ -45,41 +45,6 @@
         var context = this.row;
         return getter(context);
       };
-      /**
-       * @ngdoc function
-       * @name getIntersectionValueFiltered
-       * @methodOf ui.grid.class:GridRowColumn
-       * @description Gets the intersection of where the row and column meet.
-       * @returns {String|Number|Object} The value from the grid data that this GridRowColumn points too.
-       *          If the column has a cellFilter this will also apply the filter to it and return the value that the filter displays.
-       */
-      GridRowColumn.prototype.getIntersectionValueFiltered = function(){
-        var value = this.getIntersectionValueRaw();
-        if (this.col.cellFilter && this.col.cellFilter !== ''){
-          var getFilterIfExists = function(filterName){
-            try {
-              return $filter(filterName);
-            } catch (e){
-              return null;
-            }
-          };
-          var filter = getFilterIfExists(this.col.cellFilter);
-          if (filter) { // Check if this is filter name or a filter string
-            value = filter(value);
-          } else { // We have the template version of a filter so we need to parse it apart
-            // Get the filter params out using a regex
-            // Test out this regex here https://regex101.com/r/rC5eR5/2
-            var re = /([^:]*):([^:]*):?([\s\S]+)?/;
-            var matches;
-            if ((matches = re.exec(this.col.cellFilter)) !== null) {
-                // View your result using the matches-variable.
-                // eg matches[0] etc.
-                value = $filter(matches[1])(value, matches[2], matches[3]);
-            }
-          }
-        }
-        return value;
-      };
       return GridRowColumn;
     }
   ]);


### PR DESCRIPTION
GridRowColumn had an alternate implementation for getting the filtered value of a cell, possibly brought forward from ng-grid, but in certain situations, particular when handling cellFilters with parameters that were string literals, it would not always produce the correct output.  Grid already has a getCellDisplayValue with works perfectly (by storing the actual value, not attempting to duplicate all of angular's filter processing), and the single call in cellNav was the only place getIntersectionValueFiltered was being used.  Maintaining two functions that do the same thing in different ways, particularly when one is an attempted re-implementation of internal angular logic seems dangerous, so I'm proposing it be removed altogether in favor of using getCellDisplayValue.