### PR TITLE
Permit to disable watchers on filters

### DIFF
--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -257,7 +257,7 @@
                 }
 
                 // if column is filterable add a filter watcher
-                if ($scope.filterable) {
+                if ($scope.filterable && !uiGridCtrl.grid.options.disableFilteringWatchers) {
                   $scope.col.filters.forEach( function(filter, i) {
                     filterDeregisters.push($scope.$watch('col.filters[' + i + '].term', function(n, o) {
                       if (n !== o) {


### PR DESCRIPTION
Add an option (disableFilteringWatchers) to permit to disable watchers on filters which can slow behaviour and not necessarly needed (external filtering and/or custom filter templates)
