### PR TITLE
fix(core): getCellDisplayValue fix for when flatEntityAccess enabled

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1875,8 +1875,6 @@ angular.module('ui.grid')
 
       if (typeof(row.entity['$$' + col.uid]) !== 'undefined') {
         col.cellDisplayGetterCache = $parse(row.entity['$$' + col.uid].rendered + custom_filter);
-      } else if (this.options.flatEntityAccess && typeof(col.field) !== 'undefined') {
-        col.cellDisplayGetterCache = $parse(row.entity[col.field] + custom_filter);
       } else {
         col.cellDisplayGetterCache = $parse(row.getEntityQualifiedColField(col) + custom_filter);
       }

--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -94,7 +94,7 @@ angular.module('ui.grid')
      * @returns {string} resulting name that can be evaluated against a row
      */
   GridRow.prototype.getEntityQualifiedColField = function(col) {
-    return gridUtil.preEval('entity.' + col.field);
+    return this.grid.options.flatEntityAccess ? 'entity[\'' + col.field + '\']' : gridUtil.preEval('entity.' + col.field);
   };
   
   

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -585,6 +585,23 @@ describe('Grid factory', function () {
       expect(grid.getCellDisplayValue(row,grid.columns[1])).toEqual("WEDNESDAY");
     });
 
+    it('should apply angularjs filters with flatEntityAccess', function(){
+      var colDefs = [
+        {displayName:'date', field:'dateProp', cellFilter: 'date:"yyyy-MM-dd"'},
+        {displayName:'weekday', field:'dateProp', cellFilter: 'date:"EEEE" | uppercase'}
+      ];
+      var grid = new Grid({ id: 1, columnDefs: colDefs, flatEntityAccess: true });
+      var rows = [
+        new GridRow(entity,1,grid)
+      ];
+      grid.buildColumns();
+      grid.modifyRows([entity]);
+
+      var row = grid.rows[0];
+      expect(grid.getCellDisplayValue(row,grid.columns[0])).toEqual("2015-07-01");
+      expect(grid.getCellDisplayValue(row,grid.columns[1])).toEqual("WEDNESDAY");
+    });
+
     it('not overwrite column types specified in options', function() {
 
       var grid1 = new Grid({ id: 3 });


### PR DESCRIPTION
Calls to `getCellDisplayValue` would throw when `flatEntityAccess` was enabled. Fixes [#5326](https://github.com/angular-ui/ui-grid/issues/5326).

I took the liberty of moving the check for the `flatEntityAccess` option into `GridRow`'s `getEntityQualifiedColField`, which looks to be a general entry point for getting the row entities "accessor". It makes more sense to me to check in here rather than to branch functionality elsewhere (which also places the burden on the caller and could lead to accidental bugs).

Also, just a note that `getCellDisplayValue` may still be broken for the case of using `$$col.uid` accessors...I'm not too familiar with how that all works (and it's outside the scope of the bug I was trying to fix), so I'm not able to verify that at this time. This is just a heads up given that it looks like it suffers from the same root issue (calling `$parse` with a value rather than a value "accessor"). Maybe someone can confirm and create an issue?
