### PR TITLE
Fix compile sequence to allow custom directives with required controllers to work

### DIFF
--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -441,8 +441,9 @@
                       }
                     }
                   }
-                  var expandedRowElement = $compile(template)($scope);
+                  var expandedRowElement = angular.element(template);
                   $elm.append(expandedRowElement);
+                  expandedRowElement = $compile(expandedRowElement)($scope);
                   $scope.row.expandedRendered = true;
               });
             },


### PR DESCRIPTION
I was not able to use a directive that requires a parent controller. A ctreq error is thrown.
Turns out that the sequence of appending and compiling was not correct. Maybe there are more situations like in that in the project... I haven't checked.

2 stackoverflow links that describes the problem:
http://stackoverflow.com/questions/21854814/angular-compile-with-required-controller
http://stackoverflow.com/questions/27644985/angularjs-dynamically-created-directives-require-not-working