### PR TITLE
Update ui-grid-row.html (remove extra >)

### DIFF
--- a/src/templates/ui-grid/ui-grid-row.html
+++ b/src/templates/ui-grid/ui-grid-row.html
@@ -4,5 +4,5 @@
   class="ui-grid-cell"
   ng-class="{ 'ui-grid-row-header-cell': col.isRowHeader }"
   role="{{col.isRowHeader ? 'rowheader' : 'gridcell'}}"
-  ui-grid-cell>
+  ui-grid-cell
 </div>


### PR DESCRIPTION
Not a big thing, but I've noticed that there was an extra closing `>` in the template.