### PR TITLE
feat(importer): add excel functionality to importer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "jquery": "~1.8.0",
     "lodash": "~2.4.1",
     "pdfmake": "~0.1.8",
-    "csv-js": "https://github.com/c0bra/CSV-JS.git#~1.0.2"
+    "csv-js": "https://github.com/c0bra/CSV-JS.git#~1.0.2",
+    "js-xlsx": "~0.8.0"
   }
 }

--- a/grunt/ngdocs.js
+++ b/grunt/ngdocs.js
@@ -22,6 +22,8 @@ module.exports = {
       '//ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular-touch.js',
       '//ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular-animate.js',
       'bower_components/csv-js/csv.js',
+      'bower_components/js-xlsx/dist/jszip.js',
+      'bower_components/js-xlsx/dist/xlsx.js',
       'bower_components/pdfmake/build/pdfmake.js',
       'bower_components/pdfmake/build/vfs_fonts.js'
     ],


### PR DESCRIPTION
add Excel file (xlsx, xls, etc) functionality to importer feature with optional inclusion of JS-XLSX (https://github.com/SheetJS/js-xlsx) library, similar to how CSV import is currently implemented.

closes #3420