### PR TITLE
fix: update bower.json and package.json creation process to not pass …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="v3.2.2"></a>
+### v3.2.2 (2016-06-29)
+
+
+#### Bug Fixes
+
+* update bower.json and package.json creation process to not pass an array in to m ([f18c3511](http://github.com/angular-ui/ng-grid/commit/f18c3511446c27cc25ca80fbda588c1a3686c53b))
+* **col-movable:** prevent hidden columns triggering unnecessary re-order event ([644b324b](http://github.com/angular-ui/ng-grid/commit/644b324b42e83cf8014ffcd05acc948084698aaa))
+
 <a name="v3.2.1"></a>
 ### v3.2.1 (2016-06-24)
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-grid",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "homepage": "http://ui-grid.info",
   "repository": {
     "type": "git",

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -304,16 +304,12 @@ module.exports = function(grunt) {
                               && !/^package\.json$/.test(f);
                          })
                          // Preprend "./" to each file path
-                         .map(function (f) { return './' + f; });
+                         .map(function (f) { return f; });
 
     // Copy a README file
     var readme = path.resolve(projectPath, 'misc/publish/README.md');
     shell.cp('-f', readme, taggedReleaseDir);
-
-    // Copy a CHANGELOG file
-    var changelog = path.resolve(projectPath, 'misc/publish/CHANGELOG.md');
-    shell.cp('-f', changelog, taggedReleaseDir);
-
+    
     var bowerJsonFile = path.join(taggedReleaseDir, 'bower.json');
     var pkgJsonFile = path.join(taggedReleaseDir, 'package.json');
 

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -310,6 +310,10 @@ module.exports = function(grunt) {
     var readme = path.resolve(projectPath, 'misc/publish/README.md');
     shell.cp('-f', readme, taggedReleaseDir);
 
+    // Copy a CHANGELOG file
+    var changelog = path.resolve(projectPath, 'misc/publish/CHANGELOG.md');
+    shell.cp('-f', changelog, taggedReleaseDir);
+
     var bowerJsonFile = path.join(taggedReleaseDir, 'bower.json');
     var pkgJsonFile = path.join(taggedReleaseDir, 'package.json');
 

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -330,8 +330,10 @@ module.exports = function(grunt) {
 
     fs.writeFileSync(bowerJsonFile, JSON.stringify(json, null, 2));
 
-    // Add version for package.json
+    // For package.json
     json.version = currentTag;
+    json.main = "ui-grid.js";
+    json.files = releaseFiles;
 
     fs.writeFileSync(pkgJsonFile, JSON.stringify(json, null, 2));
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-grid",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A data grid for Angular",
   "directories": {
     "test": "test"


### PR DESCRIPTION
package.json no longer accepts an array for it's main attribute, so releaseFiles is moved to files and main now receives a string "ui-grid.js".  bower.json, however, will remain unchanged.

fixes: #4743