### PR TITLE
fix: update bower.json and package.json to include files for current npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="v3.2.4"></a>
+### v3.2.4 (2016-06-30)
+
+
+#### Bug Fixes
+
+* update bower.json and package.json to include files for current npm ([f7c6700d](http://github.com/angular-ui/ng-grid/commit/f7c6700dedacfa213eaa65838d127aab0bf24867))
+* **col-movable:** prevent hidden columns triggering unnecessary re-order event ([644b324b](http://github.com/angular-ui/ng-grid/commit/644b324b42e83cf8014ffcd05acc948084698aaa))
+
 <a name="v3.2.3"></a>
 ### v3.2.3 (2016-06-29)
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-grid",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "homepage": "http://ui-grid.info",
   "repository": {
     "type": "git",

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -302,14 +302,12 @@ module.exports = function(grunt) {
                             return !/\.min\./.test(f)
                               && !/^bower\.json$/.test(f)
                               && !/^package\.json$/.test(f);
-                         })
-                         // Preprend "./" to each file path
-                         .map(function (f) { return './' + f; });
+                         });
 
     // Copy a README file
     var readme = path.resolve(projectPath, 'misc/publish/README.md');
     shell.cp('-f', readme, taggedReleaseDir);
-
+    
     var bowerJsonFile = path.join(taggedReleaseDir, 'bower.json');
     var pkgJsonFile = path.join(taggedReleaseDir, 'package.json');
 
@@ -330,8 +328,10 @@ module.exports = function(grunt) {
 
     fs.writeFileSync(bowerJsonFile, JSON.stringify(json, null, 2));
 
-    // Add version for package.json
+    // For package.json
     json.version = currentTag;
+    json.main = "ui-grid.js";
+    json.files = releaseFiles;
 
     fs.writeFileSync(pkgJsonFile, JSON.stringify(json, null, 2));
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-grid",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "A data grid for Angular",
   "directories": {
     "test": "test"


### PR DESCRIPTION
package.json no longer accepts an array for it's main attribute, so releaseFiles is moved to files and main now receives a string "ui-grid.js". bower.json, however, will remain unchanged.

fixes: #4743