### PR TITLE
fix(selection): remove a logic bug in setSelected(..)

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -66,12 +66,9 @@
          * @param {bool} selected value to set
          */
         $delegate.prototype.setSelected = function(selected) {
-          this.isSelected = selected;
-          if (selected) {
-            this.grid.selection.selectedCount++;
-          }
-          else {
-            this.grid.selection.selectedCount--;
+          if (selected !== this.isSelected) {
+            this.isSelected = selected;
+            this.grid.selection.selectedCount += selected ? 1 : -1;
           }
         };
 

--- a/src/features/selection/test/uiGridSelectionService.spec.js
+++ b/src/features/selection/test/uiGridSelectionService.spec.js
@@ -173,6 +173,26 @@ describe('ui.grid.selection uiGridSelectionService', function () {
       expect(grid.rows[4].isSelected).toBe(false);
     });
   });
+  
+  describe('setSelected function', function() {
+    it('select row and check the selected count is correct', function() {
+      
+      expect(grid.selection.selectedCount).toBe(0);
+      
+      grid.rows[0].setSelected(true);
+      expect(grid.rows[0].isSelected).toBe(true);
+      expect(grid.selection.selectedCount).toBe(1);
+    
+      // the second setSelected(true) should have no effect
+      grid.rows[0].setSelected(true);
+      expect(grid.rows[0].isSelected).toBe(true);
+      expect(grid.selection.selectedCount).toBe(1);
+      
+      grid.rows[0].setSelected(false);
+      expect(grid.rows[0].isSelected).toBe(false);
+      expect(grid.selection.selectedCount).toBe(0);
+    });
+  });
 
   describe('selectAllRows and clearSelectedRows functions', function() {
     it('should select all rows, and select all rows when already all selected, then unselect again', function () {


### PR DESCRIPTION
The bug was that selectedCount would become incorrect if setSelected(x)
was called twice in sequence for the same row with the same x.