### PR TITLE
fix: prevent hidden columns triggering unnecessary re-order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="v3.2.5"></a>
+### v3.2.5 (2016-07-01)
+
+* update for package.json creation for npm
+
 <a name="v3.2.4"></a>
 ### v3.2.4 (2016-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="v3.2.4"></a>
+### v3.2.4 (2016-06-30)
+
+
+#### Bug Fixes
+
+* update bower.json and package.json to include files for current npm ([f7c6700d](http://github.com/angular-ui/ng-grid/commit/f7c6700dedacfa213eaa65838d127aab0bf24867))
+* **col-movable:** prevent hidden columns triggering unnecessary re-order event ([644b324b](http://github.com/angular-ui/ng-grid/commit/644b324b42e83cf8014ffcd05acc948084698aaa))
+
 <a name="v3.2.3"></a>
 ### v3.2.3 (2016-06-29)
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-grid",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "homepage": "http://ui-grid.info",
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-grid",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "homepage": "http://ui-grid.info",
   "repository": {
     "type": "git",

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -297,17 +297,16 @@ module.exports = function(grunt) {
 
     // Get the list of files from the release directory
     var releaseFiles = fs.readdirSync(taggedReleaseDir)
-                         // Filter out minified files and the bower.json file, if it's there already
-                         .filter(function (f) {
-                            return !/\.min\./.test(f)
-                              && !/^bower\.json$/.test(f)
-                              && !/^package\.json$/.test(f);
-                         });
+      // Filter out the bower.json and package.json file, if it's there already
+      .filter(function (f) {
+      	return !/^bower\.json$/.test(f)
+          && !/^package\.json$/.test(f);
+			});
 
     // Copy a README file
     var readme = path.resolve(projectPath, 'misc/publish/README.md');
     shell.cp('-f', readme, taggedReleaseDir);
-    
+
     var bowerJsonFile = path.join(taggedReleaseDir, 'bower.json');
     var pkgJsonFile = path.join(taggedReleaseDir, 'package.json');
 

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -302,14 +302,12 @@ module.exports = function(grunt) {
                             return !/\.min\./.test(f)
                               && !/^bower\.json$/.test(f)
                               && !/^package\.json$/.test(f);
-                         })
-                         // Preprend "./" to each file path
-                         .map(function (f) { return './' + f; });
+                         });
 
     // Copy a README file
     var readme = path.resolve(projectPath, 'misc/publish/README.md');
     shell.cp('-f', readme, taggedReleaseDir);
-
+    
     var bowerJsonFile = path.join(taggedReleaseDir, 'bower.json');
     var pkgJsonFile = path.join(taggedReleaseDir, 'package.json');
 
@@ -330,8 +328,10 @@ module.exports = function(grunt) {
 
     fs.writeFileSync(bowerJsonFile, JSON.stringify(json, null, 2));
 
-    // Add version for package.json
+    // For package.json
     json.version = currentTag;
+    json.main = "ui-grid.js";
+    json.files = releaseFiles;
 
     fs.writeFileSync(pkgJsonFile, JSON.stringify(json, null, 2));
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-grid",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "A data grid for Angular",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-grid",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "A data grid for Angular",
   "directories": {
     "test": "test"

--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -175,13 +175,14 @@
         }
 
         //check columns in between move-range to make sure they are visible columns
-        var i0 = Math.min(originalPosition, newPosition);
-        for (i0; i0 < Math.max(originalPosition, newPosition);i0++) {
+        var pos = (originalPosition < newPosition) ? originalPosition + 1 : originalPosition - 1;
+        var i0 = Math.min(pos, newPosition);
+        for (i0; i0 <= Math.max(pos, newPosition);i0++) {
           if (columns[i0].visible) {
             break;
           }
         }
-        if (i0 === Math.max(originalPosition, newPosition)) {
+        if (i0 > Math.max(pos, newPosition)) {
           //no visible column found, column did not visibly move
           return;
         }

--- a/src/features/move-columns/test/column-movable.spec.js
+++ b/src/features/move-columns/test/column-movable.spec.js
@@ -183,5 +183,16 @@ describe('ui.grid.moveColumns', function () {
     expect(scope.grid.columns[3].name).toBe('company');
     expect(scope.grid.columns[4].name).toBe('phone');
   });
+  
+  it('expect column move not to happen if moving across hidden columns', function() {
+    scope.gridOptions.columnDefs[1].visible = false;
+    scope.gridApi.colMovable.moveColumn(0, 3);
+    expect(scope.grid.columns[0].name).toBe('name');
+    expect(scope.grid.columns[1].name).toBe('gender');
+    expect(scope.grid.columns[2].name).toBe('age');
+    expect(scope.grid.columns[3].name).toBe('company');
+    expect(scope.grid.columns[4].name).toBe('phone');
+
+  });
 
 });


### PR DESCRIPTION
This fix checks all the columns between the originalPosition and newPosition. IF they are all hidden, then no re-order event is necessary. If a visible column is found, column re-ordering will be triggered.  This is an adjustment of #5255 as originalPosition is always a visible column.

Fixes issue: #5254