### PR TITLE
fix: use grid headerHeight instead of random 30px value for menu heig…

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -47,10 +47,10 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
       $scope.dynamicStyles = '';
 
       var setupHeightStyle = function(gridHeight) {
-        // magic number of 30 because the grid menu displays somewhat below
-        // the top of the grid. It is approximately 30px.
-        var gridMenuMaxHeight = gridHeight - 30;
-		$scope.dynamicStyles = [
+        //menu appears under header row, so substract that height from it's total
+        // additional 20px for general padding
+        var gridMenuMaxHeight = gridHeight - uiGridCtrl.grid.headerHeight - 20;
+        $scope.dynamicStyles = [
           '.grid' + uiGridCtrl.grid.id + ' .ui-grid-menu-mid {',
           'max-height: ' + gridMenuMaxHeight + 'px;',
           '}'

--- a/test/unit/core/directives/ui-grid-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-menu.spec.js
@@ -80,7 +80,7 @@ describe('ui-grid-menu', function() {
       $scope.$broadcast('show-menu');
 
       expect(isolateScope.dynamicStyles).toBeDefined();
-      expect(isolateScope.dynamicStyles).toContain('.grid1234 .ui-grid-menu-mid { max-height: 370px; }');
+      expect(isolateScope.dynamicStyles).toContain('.grid1234 .ui-grid-menu-mid { max-height: 350px; }');
     });
 
     function compileWithGrid () {
@@ -88,6 +88,7 @@ describe('ui-grid-menu', function() {
       grid.data('$uiGridController', $controller(function ($scope) {
         this.grid = {
           gridHeight: 400,
+          headerHeight: 30,
           id: '1234',
           api: {
             core: {


### PR DESCRIPTION
Menu height is calculated with a random 30px.  This uses the actual header Height so a larger header does not force menu to display larger than the grid itself.