### PR TITLE
adding showTopFooter option

### DIFF
--- a/src/templates/ui-grid/ui-grid-header.html
+++ b/src/templates/ui-grid/ui-grid-header.html
@@ -25,4 +25,18 @@
       </div>
     </div>
   </div>
+  <div ng-if="typeof(grid.options.showTopFooter) != 'undefined' && grid.options.showTopFooter"
+     class="ui-grid-footer-panel ui-grid-footer-aggregates-row"><!-- tfooter -->
+    <div class="ui-grid-footer ui-grid-footer-viewport">
+        <div class="ui-grid-footer-canvas">
+            <div class="ui-grid-footer-cell-wrapper" ng-style="colContainer.headerCellWrapperStyle()">
+                <div role="row" class="ui-grid-footer-cell-row">
+                    <div ui-grid-footer-cell role="gridcell"
+                         ng-repeat="col in colContainer.renderedColumns track by col.uid" col="col"
+                         render-index="$index" class="ui-grid-footer-cell ui-grid-clearfix"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 </div>

--- a/src/templates/ui-grid/ui-grid-header.html
+++ b/src/templates/ui-grid/ui-grid-header.html
@@ -25,7 +25,7 @@
       </div>
     </div>
   </div>
-  <div ng-if="typeof(grid.options.showTopFooter) != 'undefined' && grid.options.showTopFooter"
+  <div ng-if="grid.options.showTopFooter"
      class="ui-grid-footer-panel ui-grid-footer-aggregates-row"><!-- tfooter -->
     <div class="ui-grid-footer ui-grid-footer-viewport">
         <div class="ui-grid-footer-canvas">


### PR DESCRIPTION
Ok, first off I apologize if this breaks standards on this plugin or anything else, but here was my problem. I needed to add a top totals row along with a bottom totals row for some of the tables in my project.

I dug into bower_components/angular-ui-grid/ui-grid.js and was able to copy the ui-grid/ui-grid-footer template and append it in the ui-grid/ui-grid-header template and add an ng-if statement to only do it if grid.options.showTopFooter is defined and true.

When I forked the repo I saw that the project is laid out differently than my bower install. (No duh). I browsed through the src/templates folder and found ui-grid-header and copied my code there as I imagine this is the file that gets pulled into the template cache in the final ui-grid.js used in bower.

This solved a problem for me. I'm not sure if there is another request for this type of feature on the Issues board but I'll look for one. Again, I am new to angular so I apologize if I needed to make this change somewhere else or if there is a more elegant way to handle it. I figured I can't be the only one that wanted a duplicate of the footer underneath the header and I thought it would be a good idea to contribute to a project that has helped me so much.

Thanks!

Mike
