### PR TITLE
feat(filter): Add rawTerm option to columnDef filter options

### DIFF
--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -740,6 +740,8 @@ angular.module('ui.grid')
      * - ariaLabel: String that will be set to the `<input>.ariaLabel` attribute. This is what is read as a label to screen reader users.
      * - noTerm: set this to true if you have defined a custom function in condition, and
      * your custom function doesn't require a term (so it can run even when the term is null)
+     * - rawTerm: set this to true if you have defined a custom function in condition, and
+     * your custom function requires access to the raw unmodified search term that was entered
      * - flags: only flag currently available is `caseSensitive`, set to false if you don't want
      * case sensitive matching
      * - type: defaults to {@link ui.grid.service:uiGridConstants#properties_filter uiGridConstants.filter.INPUT},

--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -125,7 +125,11 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     
         if ( !gridUtil.isNullOrUndefined(filter.term) ){
           // it is possible to have noTerm.
-          newFilter.term = rowSearcher.stripTerm(filter);
+          if ( filter.rawTerm ){
+            newFilter.term = filter.term;
+          } else {
+            newFilter.term = rowSearcher.stripTerm(filter);
+          }
         }
         newFilter.noTerm = filter.noTerm;
         


### PR DESCRIPTION
Adds the rawTerm option to the columnDef filter options, when enabled
it causes the rowSearcher to skip trimming and escaping the search term,
providing the raw value to the specified filter condition. This is
intended for use with custom search condition functions where pre-escaping
all regular expression characters or trimming whitespace is not desired.

Relates to #2475