### PR TITLE
Missing test for whether value is a number

### DIFF
--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -1356,7 +1356,7 @@
             parent.treeNode.aggregations.forEach( function( aggregation ){
               var fieldValue = grid.getCellValue(row, aggregation.col);
               var numValue = Number(fieldValue);
-              if (!isNaN(numValue)) 
+              if (!isNaN(numValue)) {
                 aggregation.col.treeAggregationFn(aggregation, fieldValue, numValue, row);
               }
 

--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -1356,7 +1356,9 @@
             parent.treeNode.aggregations.forEach( function( aggregation ){
               var fieldValue = grid.getCellValue(row, aggregation.col);
               var numValue = Number(fieldValue);
-              aggregation.col.treeAggregationFn(aggregation, fieldValue, numValue, row);
+              if (!isNaN(numValue)) 
+                aggregation.col.treeAggregationFn(aggregation, fieldValue, numValue, row);
+              }
 
               if ( index === 0 && typeof(aggregation.col.treeFooterAggregation) !== 'undefined' ){
                 aggregation.col.treeAggregationFn(aggregation.col.treeFooterAggregation, fieldValue, numValue, row);


### PR DESCRIPTION
This operation is performed in GridColumn.js, line 133, but not here in tree-base.js.

The result of not performing this check in tree-base is that "avg" aggregate counts `undefined` values as `0`, throwing off (miscalculating) averages.