### PR TITLE
fix(filter): Fix noTerm option for filtering

### DIFF
--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -124,10 +124,10 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
         }
     
         if ( !gridUtil.isNullOrUndefined(filter.term) ){
-          // it is possible to have noTerm.  We don't need to copy that across, it was just a flag to avoid
-          // getting the filter ignored if the filter was a function that didn't use a term
+          // it is possible to have noTerm.
           newFilter.term = rowSearcher.stripTerm(filter);
         }
+        newFilter.noTerm = filter.noTerm;
         
         if ( filter.condition ){
           newFilter.condition = filter.condition;


### PR DESCRIPTION
The noTerm option was not being copied down to the internal filter
representation and so was preventing the filter being applied in
rowSearcher.searchColumn. This change ensures that flag is now
propagated correctly.

Resolves #5550 and #5551