### PR TITLE
feat(core): expose GridMenuTemplate

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -40,11 +40,19 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
       autoHide: '=?'
     },
     require: '?^uiGrid',
-    templateUrl: 'ui-grid/uiGridMenu',
     replace: false,
     link: function ($scope, $elm, $attrs, uiGridCtrl) {
-
       $scope.dynamicStyles = '';
+
+      if (uiGridCtrl) {
+        $scope.grid = uiGridCtrl.grid;
+        var gridMenuTemplate = $scope.grid.options.gridMenuTemplate;
+        gridUtil.getTemplate(gridMenuTemplate).then(function (contents) {
+          var template = angular.element(contents);
+          var newElm = $compile(template)($scope);
+          $elm.append(newElm);
+        });
+      }
 
       var setupHeightStyle = function(gridHeight) {
         //menu appears under header row, so substract that height from it's total
@@ -61,7 +69,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
         setupHeightStyle(uiGridCtrl.grid.gridHeight);
         uiGridCtrl.grid.api.core.on.gridDimensionChanged($scope, function(oldGridHeight, oldGridWidth, newGridHeight, newGridWidth) {
           setupHeightStyle(newGridHeight);
-		});
+        });
       }
 
       $scope.i18n = {

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -488,6 +488,15 @@ angular.module('ui.grid')
       baseOptions.rowTemplate = baseOptions.rowTemplate || 'ui-grid/ui-grid-row';
 
       /**
+       * @ngdoc string
+       * @name gridMenuTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description (optional) 'ui-grid/uiGridMenu' by default. When provided, this setting uses a
+       * custom grid menu template.
+       */
+      baseOptions.gridMenuTemplate = baseOptions.gridMenuTemplate || 'ui-grid/uiGridMenu';
+
+      /**
        * @ngdoc object
        * @name appScopeProvider
        * @propertyOf ui.grid.class:GridOptions


### PR DESCRIPTION
Expose grid menu template from grid options so that users can customize. 

Example: sort columns alphabetically in the grid menu.
