### PR TITLE
fix(columnMoving): handle touch events properly when jQuery is used

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -324,7 +324,7 @@
                     gridLeft += $scope.grid.renderContainers.left.header[0].getBoundingClientRect().width;
                   }
 
-                  previousMouseX = event.pageX;
+                  previousMouseX = event.pageX || event.originalEvent.pageX;
                   totalMouseMovement = 0;
                   rightMoveLimit = gridLeft + $scope.grid.getViewportWidth();
 
@@ -338,7 +338,8 @@
                 };
 
                 var moveFn = function( event ) {
-                  var changeValue = event.pageX - previousMouseX;
+                  var pageX = event.pageX || event.originalEvent.pageX;
+                  var changeValue = pageX - previousMouseX;
                   if ( changeValue === 0 ){ return; }
                   //Disable text selection in Chrome during column move
                   document.onselectstart = function() { return false; };
@@ -350,7 +351,7 @@
                   }
                   else if (elmCloned) {
                     moveElement(changeValue);
-                    previousMouseX = event.pageX;
+                    previousMouseX = pageX;
                   }
                 };
 

--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -324,7 +324,7 @@
                     gridLeft += $scope.grid.renderContainers.left.header[0].getBoundingClientRect().width;
                   }
 
-                  previousMouseX = event.pageX || event.originalEvent.pageX;
+                  previousMouseX = event.pageX || (event.originalEvent ? event.originalEvent.pageX : 0);
                   totalMouseMovement = 0;
                   rightMoveLimit = gridLeft + $scope.grid.getViewportWidth();
 
@@ -338,7 +338,7 @@
                 };
 
                 var moveFn = function( event ) {
-                  var pageX = event.pageX || event.originalEvent.pageX;
+                  var pageX = event.pageX || (event.originalEvent ? event.originalEvent.pageX : 0);
                   var changeValue = pageX - previousMouseX;
                   if ( changeValue === 0 ){ return; }
                   //Disable text selection in Chrome during column move


### PR DESCRIPTION
When using jQuery, touch events are wrapped in new object (`event`) that removes the `event.pageX` property, causing column moving to break when used on mobile devices. However, jQuery stores the original native object in `event.originalEvent` ([docs](https://api.jquery.com/category/events/event-object/)).

If `event.pageX` is not set, this logic will instead use `event.originalEvent.pageX`, allowing column moving to work in conjunction with jQuery on mobile devices.