### PR TITLE
chore(grunt): Added a build flag to disable fontello

### DIFF
--- a/grunt/aliases.js
+++ b/grunt/aliases.js
@@ -36,6 +36,11 @@ module.exports = function (grunt, options) {
     baseTasks['dev'].splice(baseTasks['dev'].indexOf('autotest:unit'), 1);
   }
 
+  if (grunt.option('fontello') === false) {
+    grunt.log.writeln("Skipping fontello...");
+    baseTasks['build'].splice(baseTasks['build'].indexOf('fontello'), 1);
+  }
+
   if (process.env.TRAVIS){
     baseTasks['test:single'] = ['karma:travis'];
   }


### PR DESCRIPTION
Updated aliases.js so that it reads in a grunt option for fontello and removes it from the build

task if fontello is set to false. This will fix issue #2304.