### PR TITLE
fix(Grid): Add missing promise wait in refresh().

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2060,10 +2060,10 @@ angular.module('ui.grid')
       self.setVisibleColumns(renderableColumns);
     });
 
-    return $q.all([p1, p2]).then(function () {
-      self.redrawInPlace(rowsAltered);
+    var p3 = self.refreshCanvas(true);
 
-      self.refreshCanvas(true);
+    return $q.all([p1, p2, p3]).then(function () {
+      self.redrawInPlace(rowsAltered);
     });
   };
 


### PR DESCRIPTION
Fix issue with ui-grid-auto-resize where every tick (250ms) the grid increases by 0.2 pixel. Also fixes Firefox issue where grid rows would sometimes be endlessly redrawn if ui-grid-auto-resize was used.

Fixes #2901
