### PR TITLE
fix(3901): Raise rowsVisibleChanged on setVisibleRows.

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1391,6 +1391,7 @@ angular.module('ui.grid')
         self.renderContainers[targetContainer].visibleRowCache.push(row);
       }
     }
+    self.api.core.raise.rowsVisibleChanged(this.api);
     self.api.core.raise.rowsRendered(this.api);
   };
 


### PR DESCRIPTION
Several issues and Stackoverflow threads indicate that one would expect the rowsVisibleChanged event to be emitted when a filter is applied. It seems pretty rational that rowsVisibleChanged ought to be raised by setVisibleRows(), which is what this small PR implements.

A related issue not addressed by this PR is that many of the SO threads and issues also seem to believe that a filtersChanged event should be raised after the visible rows are changed via filters. This is a common misunderstanding of how ui-grid operates in that changing filters are a different operation from changing visible rows. Since there seems to be a timing/ordering issue between when filtersChanged is raised and setVisibleRows is called this probably merits discussion before/if a change is made. Perhaps a tutorial page on events could alleviate this confusion?

https://github.com/angular-ui/ui-grid/issues/3901
https://github.com/angular-ui/ui-grid/issues/4138
http://stackoverflow.com/questions/27301690/angular-ui-grid-ng-grid-filterchanged-firing-too-frequently
http://stackoverflow.com/questions/33764946/how-to-get-filtered-data-from-paged-ui-grid
