### PR TITLE
fix(#5691): Updating title link URL in documentation page

### DIFF
--- a/grunt/ngdocs.js
+++ b/grunt/ngdocs.js
@@ -43,7 +43,7 @@ module.exports = {
       // '<%= dist %>/release/<%= pkg.name %>.css'
     ],
     title: 'UI Grid',
-    titleLink: 'http://<%= site %>',
+    titleLink: '/',
     html5Mode: false,
     analytics: {
       account: 'UA-46391685-1',


### PR DESCRIPTION
Fixing title link in documentation page.

Issue #5691