### PR TITLE
fix(cellnav): when grid has only one focusable column, should navigat…

### DIFF
--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -128,7 +128,7 @@
         var nextColIndex = curColIndex === 0 ? focusableCols.length - 1 : curColIndex - 1;
 
         //get column to left
-        if (nextColIndex > curColIndex) {
+        if (nextColIndex >= curColIndex) {
           // On the first row
           // if (curRowIndex === 0 && curColIndex === 0) {
           //   return null;
@@ -160,7 +160,7 @@
         }
         var nextColIndex = curColIndex === focusableCols.length - 1 ? 0 : curColIndex + 1;
 
-        if (nextColIndex < curColIndex) {
+        if (nextColIndex <= curColIndex) {
           if (curRowIndex === focusableRows.length - 1) {
             return new GridRowColumn(curRow, focusableCols[nextColIndex]); //return same row
           }


### PR DESCRIPTION
When only one columns is focusable function 'getRowColRight' should return 'GridRowColumn' from next row and function 'getRowColLeft' should return 'GridRowColumn' from previous row. Similar behave occurred now(only when grid has more than one focusable columns) from first and last focusable columns in row.
