### PR TITLE
fix(edit): fix boolean edit issue on Firefox and Safari on macOS

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -966,9 +966,20 @@
                     });
                   }
 
-                  $elm.on('blur', function (evt) {
-                    $scope.stopEdit(evt);
+                  // macOS will blur the checkbox when clicked in Safari and Firefox,
+                  // to get around this, we disable the blur handler on mousedown,
+                  // and then focus the checkbox and re-enable the blur handler after $timeout
+                  $elm.on('mousedown', function(evt) {
+                    if ($elm[0].type === 'checkbox') {
+                      $elm.off('blur', $scope.stopEdit);
+                      $timeout(function() {
+                        $elm.focus();
+                        $elm.on('blur', $scope.stopEdit);
+                      });
+                    }
                   });
+
+                  $elm.on('blur', $scope.stopEdit);
                 });
 
 
@@ -1132,9 +1143,9 @@
                 //set focus at start of edit
                 $scope.$on(uiGridEditConstants.events.BEGIN_CELL_EDIT, function () {
                   $timeout(function(){
-                    $elm[0].focus();      
+                    $elm[0].focus();
                   });
-                  
+
                   $elm[0].style.width = ($elm[0].parentElement.offsetWidth - 1) + 'px';
                   $elm.on('blur', function (evt) {
                     $scope.stopEdit(evt);


### PR DESCRIPTION
Add mousedown listener to ui.grid.edit.directive:uiGridEditor to disable
blur handler if the element is a checkbox, and then re-focus the
checkbox and enable the blur handler after a $timeout. This change is to
deal with Safari and Firefox behavior in macOS where clicking the
checkbox causes a blur event, and the value is not updated.

GitHub issues: #1785, #4778, #4782
