### PR TITLE
Drag and drop effect for entire column

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -488,12 +488,24 @@
 
                 onDownEvents();
 
-
                 var cloneElement = function () {
                   elmCloned = true;
 
+
                   //Cloning header cell and appending to current header cell.
                   movingElm = $elm.clone();
+
+                  //copy column children for full column move effect
+                  if ($scope.grid.options.enableMovableChildCells) {
+                    var idClass = _.find(movingElm[0].classList, function (c) {
+                      return c.indexOf('ui-grid-coluiGrid-') > -1;
+                    });
+                    var extraElms = angular.element(document.querySelectorAll('.ui-grid-cell.' + idClass)).clone();
+                    var _scroll = $scope.grid.renderContainers.body.prevScrollTop - ($scope.grid.renderContainers.body.currentTopRow * $scope.grid.renderContainers.body.renderedRows[0].$$height);
+                    movingElm.append(angular.element('<div class="extras-wrapper" style="top: ' + (0 - _scroll) + 'px;"></div>').append(extraElms));
+                    movingElm.addClass('move-child-cells');
+                  }
+
                   $elm.parent().append(movingElm);
 
                   //Left of cloned element should be aligned to original header cell.
@@ -508,6 +520,7 @@
                   }
                   movingElm.css(movingElementStyles);
                 };
+
 
                 var moveElement = function (changeValue) {
                   //Calculate total column width

--- a/src/features/move-columns/less/colMovable.less
+++ b/src/features/move-columns/less/colMovable.less
@@ -6,6 +6,60 @@
   border: 1px solid @borderColor;
   box-shadow: inset 0 0 14px rgba(0, 0, 0, 0.2);
 
+  &.move-child-cells {
+
+    position: fixed;
+    top: 0;
+    box-shadow: none;
+    z-index: 99;
+    background: transparent !important;
+    overflow-x: hidden;
+
+    cursor: grabbing;
+    cursor: -moz-grabbing;
+    cursor: -webkit-grabbing;
+    max-height: 100%;
+    overflow-y: hidden;
+    box-shadow: 0 1px 1px;
+
+    &.ui-grid-header-cell:last-child {
+      border-right: 1px solid @borderColor;
+    }
+
+    .extras-wrapper {
+      position: relative;
+
+    }
+
+    .ui-grid-cell-contents.ui-grid-header-cell-primary-focus {
+      padding: 0;
+      cursor: grabbing;
+      cursor: -moz-grabbing;
+      cursor: -webkit-grabbing;
+    }
+
+    div[role=columnheader] {
+
+      position: relative;
+      z-index: 99;
+      width: 100%;
+      padding: 5px;
+      cursor: grabbing;
+      cursor: -moz-grabbing;
+      cursor: -webkit-grabbing;
+      background: #EEE;
+      border-bottom: 1px solid #d4d4d4;
+    }
+    .ui-grid-cell {
+      display: block;
+      visibility: visible;
+      cursor: grabbing;
+      cursor: -moz-grabbing;
+      cursor: -webkit-grabbing;
+      font-weight: normal;
+
+    }
+  }
   .ui-grid-icon-angle-down {
     display: none;
   }


### PR DESCRIPTION
I added an optional drag and drop effect for the entire column (as opposed to just the header cell) for the movable columns feature. Set 'enableMovableChildCells' to true in gridOptions to use this feature. Screenshot provided below as a preview of the feature.

![screen shot 2016-10-26 at 3 17 26 pm](https://cloud.githubusercontent.com/assets/7968039/19741640/7d567a76-9b8f-11e6-992e-024f73006864.png)
