### PR TITLE
Update getCellDisplayValue

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1886,11 +1886,11 @@ angular.module('ui.grid')
       } else if (this.options.flatEntityAccess && typeof(col.field) !== 'undefined') {
         col.cellDisplayGetterCache = $parse(row.entity[col.field] + custom_filter);
       } else {
-        col.cellDisplayGetterCache = $parse(row.getEntityQualifiedColField(col) + custom_filter);
+        col.cellDisplayGetterCache = $parse("row." + row.getEntityQualifiedColField(col) + custom_filter);
       }
     }
 
-    return col.cellDisplayGetterCache(row);
+    return col.cellDisplayGetterCache({ row: row, col: col });
   };
 
 


### PR DESCRIPTION
Currently any filter does not have any access to the coldef. Because of this filters that make use of editabledropdownarray can't use getCellDisplayValue method. this fix should allow ones to  build filters that has access to both row and column.