### PR TITLE
feat(core): Reduce digest triggers when using $timeout

### DIFF
--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -241,7 +241,7 @@ function uiGridDirective($compile, $templateCache, $timeout, $window, gridUtil, 
               sizeChecks++;
             }
             else {
-              $timeout(init);
+              $timeout(init, 0, false);
             }
           }
 

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2244,13 +2244,13 @@ angular.module('ui.grid')
         }
 
         p.resolve();
-      });
+      }, 0, false);
     }
     else {
       // Timeout still needs to be here to trigger digest after styles have been rebuilt
       $timeout(function() {
         p.resolve();
-      });
+      }, 0, false);
     }
 
     return p.promise;

--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -831,7 +831,7 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
         } else {
           s.logWarn('[focus.byId] Element id ' + elementID + ' was not found.');
         }
-      });
+      }, 0, false);
       this.queue.push(promise);
       return promise;
     },
@@ -856,7 +856,7 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
         if (element){
           element[0].focus();
         }
-      });
+      }, 0, false);
       this.queue.push(promise);
       return promise;
     },
@@ -886,8 +886,8 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
       };
       this._purgeQueue();
       if (aSync){ //Do this asynchronysly
-        var promise = $timeout(focusBySelector);
-        this.queue.push($timeout(focusBySelector));
+        var promise = $timeout(focusBySelector, 0, false);
+        this.queue.push($timeout(focusBySelector), 0, false);
         return promise;
       } else {
         return focusBySelector();


### PR DESCRIPTION
Angular's $timeout takes a boolean 3rd parameter which, if `false`, causes the wrapped function to not run inside $apply. Since $timeout is used extensively in core, this parameter has been passed where possible in order to improve performance. Previously, the grid would trigger a large number of digests even when working normally, see issue: https://github.com/angular-ui/ui-grid/issues/5007.

This is very low-hanging fruit. It is possible the same investigation can be applied across the plugins as well.