### PR TITLE
Fixed pt-br translation of 'through'.

### DIFF
--- a/src/js/i18n/pt-br.js
+++ b/src/js/i18n/pt-br.js
@@ -89,7 +89,7 @@
           },
           sizes: 'itens por página',
           totalItems: 'itens',
-          through: 'através dos',
+          through: 'a',
           of: 'de'
         },
         grouping: {


### PR DESCRIPTION
Correction of translation in brazilian portuguese of the term "through". The literal translation was ok, but in the context of a grid it is not correct.