### PR TITLE
Fix for Issue: #5101 - enableColumnResizing accumulates watchers with each table $digest cycle

### DIFF
--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -199,7 +199,9 @@
       compile: function() {
         return {
           post: function ($scope, $elm, $attrs, uiGridCtrl) {
-            var grid = uiGridCtrl.grid;
+            var grid = uiGridCtrl.grid,
+              resizerScopes = [],
+              resizers = [];
 
             if (grid.options.enableColumnResizing) {
               var columnResizerElm = $templateCache.get('ui-grid/columnResizer');

--- a/src/features/resize-columns/test/resizeColumns.spec.js
+++ b/src/features/resize-columns/test/resizeColumns.spec.js
@@ -93,6 +93,16 @@ describe('ui.grid.resizeColumns', function () {
     });
   });
 
+  describe('destroying header cell',function(){
+    it('should have 0 watchers after destroy',function(){
+      var secondCol = $(grid).find('[ui-grid-header-cell]:nth-child(1)');
+      secondCol.parent().scope().$destroy();
+      var numWatchers = secondCol.scope().$$watchers.length;
+
+      expect(numWatchers).toEqual(0);
+    });
+  });
+
   describe('setting enableColumnResizing to false', function () {
     it('should result in no resizer elements being attached to the column', function () {
       $scope.gridOpts.enableColumnResizing = false;


### PR DESCRIPTION
Fixes Issue: enableColumnResizing accumulates watchers with each table $digest cycle #5101.

https://github.com/angular-ui/ui-grid/issues/5101
 
Creates a new scope for each resizer, stores them into an array so that the scopes can be destroyed before resetting the resizers.