### PR TITLE
Maintain focus on selected ui-grid-menu item.

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -295,12 +295,8 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
               if ( !$scope.leaveOpen ){
                 $scope.$emit('hide-menu');
               } else {
-                /*
-                 * XXX: Fix after column refactor
-                 * Ideally the focus would remain on the item.
-                 * However, since there are two menu items that have their 'show' property toggled instead. This is a quick fix.
-                 */
-                gridUtil.focus.bySelector(angular.element(gridUtil.closestElm($elm, ".ui-grid-menu-items")), 'button[type=button]', true);
+                // Maintain focus on the selected item
+                gridUtil.focus.bySelector(angular.element($event.target.parentElement), 'button[type=button]', true);
               }
             }
           };


### PR DESCRIPTION
Currently, selecting a menu item in a ui-grid-menu cause focus to jump to the first item in the list.  This is a problem when the list of menu items is long.

Apply and test suggested fix from @tirithen in closed PR #4575

Demo Broken: http://take.ms/gSV7S
Demo Fixed: http://take.ms/UPEQk