### PR TITLE
Force columns with width set by % be integer pixels

### DIFF
--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -634,7 +634,8 @@ angular.module('ui.grid')
 
       } else if (gridUtil.endsWith(column.width, "%")) {
         // percentage width, set to percentage of the viewport
-        width = parseFloat(parseInt(column.width.replace(/%/g, ''), 10) / 100 * availableWidth);
+        // round down to int - some browsers don't play nice with float maxWidth
+        width = parseInt(parseInt(column.width.replace(/%/g, ''), 10) / 100 * availableWidth);
 
         if ( width > column.maxWidth ){
           width = column.maxWidth;


### PR DESCRIPTION
Browsers affected: Firefox v51 for Windows

This is actually a firefox bug but I think ui-grid should support it. When a div has maxWidth and minWidth that are floats, sometimes the computed width of the div (for reasons I don't yet understand) gets rounded. Most notably, sometimes the width gets rounded up by up to 0.01 pixels so that the computed width is greater than the maxWidth. In a ui-grid, this can cause the divs to sum to larger than the parent row width which causes the last cell to spill to the next row (blurred for confidentiality): 
![image](https://cloud.githubusercontent.com/assets/2466482/22583303/866498b4-e9a0-11e6-8c2f-9c909afa5629.png)

 This Firefox bug is evident in the following plunker which was created based on the HTML/CSS output of our ui-grid: https://plnkr.co/edit/d85iZpOtJNmBl1YmRPCp - works fine on Chome and Firefox on Mac, but the computed div widths are slightly greater than maxWidth on Firefox running on Windows. This causes the last cell to spill to the next line. I think the best workaround is to have all pixel values by integers.