### PR TITLE
make getLastRowIndex return 0-based index

### DIFF
--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -87,9 +87,9 @@
                  */
                 getLastRowIndex: function () {
                   if (grid.options.useCustomPagination) {
-                    return publicApi.methods.pagination.getFirstRowIndex() + grid.options.paginationPageSizes[grid.options.paginationCurrentPage - 1];
+                    return publicApi.methods.pagination.getFirstRowIndex() + grid.options.paginationPageSizes[grid.options.paginationCurrentPage - 1] - 1;
                   }
-                  return Math.min(grid.options.paginationCurrentPage * grid.options.paginationPageSize, grid.options.totalItems);
+                  return Math.min(grid.options.paginationCurrentPage * grid.options.paginationPageSize, grid.options.totalItems) - 1;
                 },
                 /**
                  * @ngdoc method
@@ -183,7 +183,7 @@
               currentPage = grid.options.paginationCurrentPage = 1;
               firstRow = (currentPage - 1) * pageSize;
             }
-            return visibleRows.slice(firstRow, lastRow);
+            return visibleRows.slice(firstRow, lastRow + 1);
           };
 
           grid.registerRowsProcessor(processPagination, 900 );


### PR DESCRIPTION
Currently getLastRowIndex returns 1-based index and spoils, for example, rows range appearance in the pagination footer block. 

Related issue: #5944 