### PR TITLE
2.x - fix for pinned columns bug in Chrome and Opera

### DIFF
--- a/build/ng-grid.debug.js
+++ b/build/ng-grid.debug.js
@@ -2138,7 +2138,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 var w = col.width + colwidths;
                 if (col.pinned) {
                     addCol(col);
-                    var newLeft = i > 0 ? (scrollLeft + totalLeft) : scrollLeft;
+                    var newLeft = Math.round(i > 0 ? (scrollLeft + totalLeft) : scrollLeft);
                     domUtilityService.setColLeft(col, newLeft, self);
                     totalLeft += col.width;
                 } else {

--- a/build/ng-grid.js
+++ b/build/ng-grid.js
@@ -1868,7 +1868,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 var w = col.width + colwidths;
                 if (col.pinned) {
                     addCol(col);
-                    var newLeft = i > 0 ? (scrollLeft + totalLeft) : scrollLeft;
+                    var newLeft = Math.round(i > 0 ? (scrollLeft + totalLeft) : scrollLeft);
                     domUtilityService.setColLeft(col, newLeft, self);
                     totalLeft += col.width;
                 } else {

--- a/ng-grid-2.0.14.debug.js
+++ b/ng-grid-2.0.14.debug.js
@@ -2138,7 +2138,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 var w = col.width + colwidths;
                 if (col.pinned) {
                     addCol(col);
-                    var newLeft = i > 0 ? (scrollLeft + totalLeft) : scrollLeft;
+                    var newLeft = Math.round(i > 0 ? (scrollLeft + totalLeft) : scrollLeft);
                     domUtilityService.setColLeft(col, newLeft, self);
                     totalLeft += col.width;
                 } else {

--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -791,7 +791,7 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
                 var w = col.width + colwidths;
                 if (col.pinned) {
                     addCol(col);
-                    var newLeft = i > 0 ? (scrollLeft + totalLeft) : scrollLeft;
+                    var newLeft = Math.round(i > 0 ? (scrollLeft + totalLeft) : scrollLeft);
                     domUtilityService.setColLeft(col, newLeft, self);
                     totalLeft += col.width;
                 } else {


### PR DESCRIPTION
**Description**
We use ng-grid 2.0.14 in our project and faced a bug with pinned column in Chrome and Opera

**Steps to reproduce it:**
1. In ngViewport make a table with one or two pinned columns and number of not pinned columns that is enough to make ngViewport scrollable. 
2. Scale browser window with Ctrl-+ or with Ctrl-Mouse Scroll. The window scale should be other than 100%.
3. Try to scroll table columns - pinned columns will scroll as they were not pinned. 

**The bug root cause**
ng-grid uses regular expression to find in CSS Left position parameter for pinned columns  in order to update them when ngViewport scrolls. Scaling browser window Chrome leads to fractional Left position values, and regexp can't find them as it takes in account only digits, but not a fractional point. So it can't update these values for pinned columns.

**Browser versions**
We detected this bug in Chrome and Opera. 
In Firefox and Konqueror pinned columns seems to work normally.