### PR TITLE
Fix getCellDisplayValue with flatEntityAccess

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1891,7 +1891,7 @@ angular.module('ui.grid')
       if (typeof(row.entity['$$' + col.uid]) !== 'undefined') {
         col.cellDisplayGetterCache = $parse(row.entity['$$' + col.uid].rendered + custom_filter);
       } else if (this.options.flatEntityAccess && typeof(col.field) !== 'undefined') {
-        col.cellDisplayGetterCache = $parse(row.entity[col.field] + custom_filter);
+        col.cellDisplayGetterCache = $parse('entity.' + col.field + custom_filter);
       } else {
         col.cellDisplayGetterCache = $parse(row.getEntityQualifiedColField(col) + custom_filter);
       }

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -591,6 +591,36 @@ describe('Grid factory', function () {
 
     });
 
+    it('should set cache correctly with flatEntityAccess', function() {
+
+      var colDefs = [
+        {name:'simpleProp'}
+      ];
+      var entity2 = {
+        simpleProp: 'simplePropValue.2'
+      };
+
+      var grid = new Grid({ id: 1, columnDefs:colDefs, flatEntityAccess:true });
+      var rows = [
+        new GridRow(entity,1,grid),
+        new GridRow(entity2,2,grid)
+      ];
+
+
+      grid.buildColumns();
+      grid.modifyRows([entity, entity2]);
+
+      var simpleCol = grid.getColumn('simpleProp');
+
+      var row = grid.rows[0];
+      expect(grid.getCellValue(row,simpleCol)).toBe('simplePropValue');
+      expect(grid.getCellDisplayValue(row,simpleCol)).toBe('simplePropValue');
+      
+      var row2 = grid.rows[1];
+      expect(grid.getCellValue(row2,simpleCol)).toBe('simplePropValue.2');
+      expect(grid.getCellDisplayValue(row2,simpleCol)).toBe('simplePropValue.2');
+    });
+
     it('should bind correctly to $$this', function() {
       var colDefs = [
         {name: 'thisProp', field: '$$this'}
@@ -621,6 +651,23 @@ describe('Grid factory', function () {
         {displayName:'weekday', field:'dateProp', cellFilter: 'date:"EEEE" | uppercase'}
       ];
       var grid = new Grid({ id: 1, columnDefs:colDefs });
+      var rows = [
+        new GridRow(entity,1,grid)
+      ];
+      grid.buildColumns();
+      grid.modifyRows([entity]);
+
+      var row = grid.rows[0];
+      expect(grid.getCellDisplayValue(row,grid.columns[0])).toEqual("2015-07-01");
+      expect(grid.getCellDisplayValue(row,grid.columns[1])).toEqual("WEDNESDAY");
+    });
+
+    it('should apply angularjs filters with flatEntityAccess', function(){
+      var colDefs = [
+        {displayName:'date', field:'dateProp', cellFilter: 'date:"yyyy-MM-dd"'},
+        {displayName:'weekday', field:'dateProp', cellFilter: 'date:"EEEE" | uppercase'}
+      ];
+      var grid = new Grid({ id: 1, columnDefs:colDefs, flatEntityAccess:true });
       var rows = [
         new GridRow(entity,1,grid)
       ];


### PR DESCRIPTION
For flatEntityDataAcess the `col.cellDisplayGetterCache` was always returning the first cached item for the column, and effectively ignoring the row parameter after the `col.cellDisplayGetterCache` had been set.

Closes #5773 