### PR TITLE
$elm.focus is not a function when we click on checkbox

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -977,7 +977,7 @@
                     if ($elm[0].type === 'checkbox') {
                       $elm.off('blur', $scope.stopEdit);
                       $timeout(function() {
-                        $elm.focus();
+                        $elm[0].focus();
                         $elm.on('blur', $scope.stopEdit);
                       });
                     }


### PR DESCRIPTION
I am making changes based on the issue created by me as follows.
https://github.com/angular-ui/ui-grid/issues/6048

Please have a look at this and commit the changes if you find it feasible.