### PR TITLE
fix(6017) Fixes ui-grid-viewport scroll issue in chrome v56

### DIFF
--- a/src/less/body.less
+++ b/src/less/body.less
@@ -17,7 +17,10 @@
   position: relative;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
-
+  // overflow-anchor is a new feature/bug in chrome 56. See https://www.chromestatus.com/feature/5700102471548928
+  // It causes ui-grid-viewport to scroll indefinitely. See https://github.com/angular-ui/ui-grid/issues/6017
+  overflow-anchor: none;
+  
   &:focus {
     outline: none !important;
   }


### PR DESCRIPTION
Chrome v56 introduced a new feature called "scroll anchoring" which causes the scroll position to update if element content above the current scroll position has changed.
Since ui-grid-viewport updates the margin of the first line whenever a user is scrolling, scroll anchoring will cause it to get into a scroll loop and scroll indefinitely (i.e. scroll to the end of the grid)

This issue is outlined in detail on the ["Scroll Anchoring" feature explainer](https://github.com/WICG/ScrollAnchoring/blob/master/explainer.md#flow-change-suppression):

> If the DOM changes made by a scroll event handler alter the position of the anchor node, we may encounter feedback loops in which scroll anchoring and the scroll event handler trigger each other ad infinitum.

See issue #6017 for more details.