### PR TITLE
use $watch instead of setTimeout call every 250 ms in auto-resize directive

### DIFF
--- a/src/features/auto-resize-grid/js/auto-resize.js
+++ b/src/features/auto-resize-grid/js/auto-resize.js
@@ -15,54 +15,24 @@
   var module = angular.module('ui.grid.autoResize', ['ui.grid']);
 
 
-  module.directive('uiGridAutoResize', ['$timeout', 'gridUtil', function ($timeout, gridUtil) {
+  module.directive('uiGridAutoResize', ['gridUtil', function (gridUtil) {
     return {
       require: 'uiGrid',
       scope: false,
       link: function ($scope, $elm, $attrs, uiGridCtrl) {
-        var prevGridWidth, prevGridHeight;
-
-        function getDimensions() {
-          prevGridHeight = gridUtil.elementHeight($elm);
-          prevGridWidth = gridUtil.elementWidth($elm);
-        }
-
-        // Initialize the dimensions
-        getDimensions();
-
-        var resizeTimeoutId;
-        function startTimeout() {
-          clearTimeout(resizeTimeoutId);
-
-          resizeTimeoutId = setTimeout(function () {
-            var newGridHeight = gridUtil.elementHeight($elm);
-            var newGridWidth = gridUtil.elementWidth($elm);
-
-            if (newGridHeight !== prevGridHeight || newGridWidth !== prevGridWidth) {
-              uiGridCtrl.grid.gridHeight = newGridHeight;
-              uiGridCtrl.grid.gridWidth = newGridWidth;
-              uiGridCtrl.grid.api.core.raise.gridDimensionChanged(prevGridHeight, prevGridWidth, newGridHeight, newGridWidth);
-
-              $scope.$apply(function () {
-                uiGridCtrl.grid.refresh()
-                  .then(function () {
-                    getDimensions();
-
-                    startTimeout();
-                  });
-              });
-            }
-            else {
-              startTimeout();
-            }
-          }, 250);
-        }
-
-        startTimeout();
-
-        $scope.$on('$destroy', function() {
-          clearTimeout(resizeTimeoutId);
-        });
+        $scope.$watch(function () {
+          return {
+            height: gridUtil.elementHeight($elm),
+            width: gridUtil.elementWidth($elm)
+          }
+        }, function (newDimensions, oldDimensions) {
+          if (newDimensions.height !== oldDimensions.height || newDimensions.width !== oldDimensions.width) {
+            uiGridCtrl.grid.gridHeight = newDimensions.height;
+            uiGridCtrl.grid.gridWidth = newDimensions.width;
+            uiGridCtrl.grid.api.core.raise.gridDimensionChanged(oldDimensions.height, oldDimensions.width, newDimensions.height, newDimensions.width);
+            uiGridCtrl.grid.refresh();
+          }
+        }, true);
       }
     };
   }]);

--- a/src/features/auto-resize-grid/js/auto-resize.js
+++ b/src/features/auto-resize-grid/js/auto-resize.js
@@ -24,7 +24,7 @@
           return {
             height: gridUtil.elementHeight($elm),
             width: gridUtil.elementWidth($elm)
-          }
+          };
         }, function (newDimensions, oldDimensions) {
           if (newDimensions.height !== oldDimensions.height || newDimensions.width !== oldDimensions.width) {
             uiGridCtrl.grid.gridHeight = newDimensions.height;


### PR DESCRIPTION
Now ui-grid resize occurs a 250 ms after container resize. Because of that, for exampple, I have scroll bar flick when I resize ui-grid container
![screenshot 74](https://cloud.githubusercontent.com/assets/6369252/23972810/1f6f22d0-09f5-11e7-9adc-0bead7490f21.png)
If you will use $watch, there will be no delay between container resize and ui-grid resize.