### PR TITLE
fix(6017): Fixes ui-grid-viewport scroll issue in chrome v56

### DIFF
--- a/src/less/body.less
+++ b/src/less/body.less
@@ -18,6 +18,10 @@
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 
+  // overflow-anchor is a new feature/bug in chrome 56. See https://www.chromestatus.com/feature/5700102471548928
+  // It causes ui-grid-viewport to scroll indefinitely. See https://github.com/angular-ui/ui-grid/issues/6017
+  overflow-anchor: none;
+
   &:focus {
     outline: none !important;
   }


### PR DESCRIPTION
Chrome v56 introduced a new feature called "scroll anchoring" which causes the scroll position to

update if element content above the current scroll position has changed. Since ui-grid-viewport updates the margin of the first line whenever a user is scrolling, scroll

anchoring will cause it to get into a scroll loop and scroll indefinitely (i.e. scroll to the end of

the grid). Credit to @Joel-Kornbluh