### PR TITLE
Toggle subGrid controll visibility

### DIFF
--- a/misc/tutorial/216_expandable_grid.ngdoc
+++ b/misc/tutorial/216_expandable_grid.ngdoc
@@ -147,6 +147,32 @@ appears when you quickly scroll through the grid.
               $scope.gridOptions.data = data;
             });
         }]);
+    app.controller('FourthCtrl', ['$scope', '$http', '$log', function ($scope, $http, $log) {
+          $scope.gridOptions = {
+            enableRowSelection: true,
+            expandableRowTemplate: 'expandableRowTemplate.html',
+            expandableRowHeight: 150
+          }
+
+          $scope.gridOptions.columnDefs = [
+            { name: 'id', pinnedLeft:true },
+            { name: 'name'},
+            { name: 'age'},
+            { name: 'address.city'}
+          ];
+
+          $http.get('/data/500_complex.json')
+            .success(function(data) {
+              for(i = 0; i < data.length; i++){
+                data[i].subGridOptions = {
+                  columnDefs: [ {name:"Id", field:"id"},{name:"Name", field:"name"} ],
+                  data: data[i].friends,
+                  disableRowExpandable : (i % 2 === 0)
+                }
+              }
+              $scope.gridOptions.data = data;
+            });
+        }]);
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl">
@@ -162,6 +188,10 @@ appears when you quickly scroll through the grid.
     </div>
     Retrieve data for subGrid when expanding
     <div ng-controller="ThirdCtrl">
+       <div ui-grid="gridOptions" ui-grid-expandable class="grid"></div>
+    </div>
+    Toggle expand subGrid control
+    <div ng-controller="FourthCtrl">
        <div ui-grid="gridOptions" ui-grid-expandable class="grid"></div>
     </div>
   </file>

--- a/src/features/expandable/templates/expandableRowHeader.html
+++ b/src/features/expandable/templates/expandableRowHeader.html
@@ -2,7 +2,7 @@
   class="ui-grid-row-header-cell ui-grid-expandable-buttons-cell">
   <div
     class="ui-grid-cell-contents">
-    <i ng-if="!row.groupHeader==true"
+    <i ng-if="!(row.groupHeader==true || row.entity.subGridOptions.disableRowExpandable)"
       ng-class="{ 'ui-grid-icon-plus-squared' : !row.isExpanded, 'ui-grid-icon-minus-squared' : row.isExpanded }"
       ng-click="grid.api.expandable.toggleRowExpansion(row.entity)">
     </i>


### PR DESCRIPTION
Set a 'disableRowExpandable' property on the subGridOptions object to
control the visibility of the + icon for toggling the subGridVisiblity.

Solves the problem discussed @ http://stackoverflow.com/questions/33082810/angular-ui-grid-conditional-row-expand/33583355#33583355