### PR TITLE
Issue: Cannot hide many columns at the same time

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -177,7 +177,9 @@ angular.module('ui.grid')
      */
     self.flagScrollingHorizontally = function(scrollEvent) {
       if (!self.isScrollingVertically && !self.isScrollingHorizontally) {
-        self.api.core.raise.scrollBegin(scrollEvent);
+        if (scrollEvent.x && scrollEvent.x.percentage !== 1) {
+          self.api.core.raise.scrollBegin(scrollEvent);
+        }
       }
       self.isScrollingHorizontally = true;
       if (self.options.scrollDebounce === 0 || !scrollEvent.withDelay) {


### PR DESCRIPTION
Hi All,
I am working in an project that use Angular ui-grid.
It's very nice at all.
But I have found a small issue related to scroll feature as:
When scroll is at right
Open grid menu
=> Hide first column
=> Grid menu auto hide, so we cannot hide another column

I have try to fix it with a small changes in Grid factory.
I'm not sure it correctly at all, so please help to review my changes bellow.
If you are happy with this, please help to merge. Or please make the fix for this issue.

Many thanks & Regards,
Duong Trinh