### PR TITLE
fix(rowEdit): cancel rowEditSaveTimer on flushDirtyRows

### DIFF
--- a/src/features/row-edit/js/gridRowEdit.js
+++ b/src/features/row-edit/js/gridRowEdit.js
@@ -394,6 +394,7 @@
         flushDirtyRows: function(grid){
           var promises = [];
           grid.api.rowEdit.getDirtyRows().forEach( function( gridRow ){
+            service.cancelTimer( grid, gridRow );
             service.saveRow( grid, gridRow )();
             promises.push( gridRow.rowEditSavePromise );
           });


### PR DESCRIPTION
rowEdit.flushDirtyRows may cause double row save

http://plnkr.co/edit/F0lXg3JtKzTgdZh2CqsA?p=preview
How to reproduce the problem:
- modify any value in the grid, for example Age
- immediately press Flush button on top
Flush button calls flushDirtyRows and saves dirty rows. Console prints "saveRow resolved".
About two seconds later rowEditSaveTimer save already saved row again. Console prints "saveRow resolved" second time
