### PR TITLE
Prevent scrollEvent when scroll percentage is greater then 1.

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2394,7 +2394,9 @@ angular.module('ui.grid')
 
           // Turn the scroll position into a percentage and make it an argument for a scroll event
           percentage = scrollPixels / scrollLength;
-          scrollEvent.y = { percentage: percentage  };
+          if (percentage <= 1) {
+            scrollEvent.y = { percentage: percentage  };
+          }
         }
         // Otherwise if the scroll position we need to see the row is MORE than the bottom boundary, i.e. obscured below the bottom of the self...
         else if (pixelsToSeeRow > bottomBound) {
@@ -2404,7 +2406,9 @@ angular.module('ui.grid')
 
           // Turn the scroll position into a percentage and make it an argument for a scroll event
           percentage = scrollPixels / scrollLength;
-          scrollEvent.y = { percentage: percentage  };
+          if (percentage <= 1) {
+            scrollEvent.y = { percentage: percentage  };
+          }
         }
       }
 

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -63,12 +63,12 @@ describe('Grid factory', function () {
 
     it('should not scroll.y when scrollpercentage > 100% when row is less then top boundry', function() {
       // row is less then the top boundary
-      prevScrollTop = 100;
       var rowCache = [];
       for ( var i = 0; i < 9; i++ ){
         rowCache.push(i);
       }
       rowCache.push(rows[1]);
+      renderContainers.body.prevScrollTop = 100;
       renderContainers.body.visibleRowCache = rowCache;
       renderContainers.body.visibleColumnCache = [column];
       grid.renderContainers = renderContainers;
@@ -83,12 +83,12 @@ describe('Grid factory', function () {
 
     it('should not scroll.y when scrollpercentage > 100% when row is more then top boundry', function() {
       // row is more then the top boundary
-      prevScrollTop = 300;
       var rowCache = [];
       for ( var i = 0; i < 9; i++ ){
         rowCache.push(i);
       }
       rowCache.push(rows[1]);
+      renderContainers.body.prevScrollTop = 300;
       renderContainers.body.visibleRowCache = rowCache;
       renderContainers.body.visibleColumnCache = [column];
       grid.renderContainers = renderContainers;

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -38,6 +38,70 @@ describe('Grid factory', function () {
     $scope.$digest();
   }
 
+  describe('scrollToIfNecessary', function() {
+    var renderContainers;
+    var prevScrollTop = 100;
+    var viewportWidth = 100;
+    var viewportHeight = 100;
+    var canvasHeight = 360;
+    var canvasWidth = 100;
+
+    beforeEach(function() {
+      renderContainers = { 
+        body: { 
+          visibleRowCache: null, 
+          visibleColumnCache: null,
+          prevScrollTop: prevScrollTop,
+          headerHeight: 30,
+          getViewportWidth: jasmine.createSpy('getViewportWidth').and.callFake(function() { return viewportWidth;}),
+          getViewportHeight: jasmine.createSpy('getViewportWidth').and.callFake(function() { return viewportHeight;}),
+          getCanvasHeight: jasmine.createSpy('getCanvasHeight').and.callFake(function() { return canvasHeight; }),
+          getCanvasWidth: jasmine.createSpy('getCanvasHeight').and.callFake(function() { return canvasWidth; })
+        }
+      };
+    });
+
+    it('should not scroll.y when scrollpercentage > 100% when row is less then top boundry', function() {
+      // row is less then the top boundary
+      prevScrollTop = 100;
+      var rowCache = [];
+      for ( var i = 0; i < 9; i++ ){
+        rowCache.push(i);
+      }
+      rowCache.push(rows[1]);
+      renderContainers.body.visibleRowCache = rowCache;
+      renderContainers.body.visibleColumnCache = [column];
+      grid.renderContainers = renderContainers;
+
+      // try to scroll to row 10
+      grid.scrollToIfNecessary(rowCache[9], column).then(function(scrollEvent){
+        expect(scrollEvent).toBeUndefined();
+      });
+
+      $scope.$apply();
+    });
+
+    it('should not scroll.y when scrollpercentage > 100% when row is more then top boundry', function() {
+      // row is more then the top boundary
+      prevScrollTop = 300;
+      var rowCache = [];
+      for ( var i = 0; i < 9; i++ ){
+        rowCache.push(i);
+      }
+      rowCache.push(rows[1]);
+      renderContainers.body.visibleRowCache = rowCache;
+      renderContainers.body.visibleColumnCache = [column];
+      grid.renderContainers = renderContainers;
+
+      // try to scroll to row 10
+      grid.scrollToIfNecessary(rowCache[9], column).then(function(scrollEvent){
+        expect(scrollEvent).toBeUndefined();
+      });
+
+      $scope.$apply();
+    });    
+  });
+
   describe('constructor', function() {
     it('should throw an exception if no id is provided', function() {
       expect(function() {


### PR DESCRIPTION
In the scenario where cell edit and cell navigation is enabled the scrollPercentage will be greater then 1. But this only happens in the bottom row. The check prevents scrolling when this happens.