### PR TITLE
fix #5760: only show ui-grid-scrollbar-placeholder if there's a horizontal scrollbar in another container

### DIFF
--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -743,7 +743,11 @@ angular.module('ui.grid')
   };
 
   GridRenderContainer.prototype.needsHScrollbarPlaceholder = function () {
-    return this.grid.options.enableHorizontalScrollbar && !this.hasHScrollbar && !this.grid.disableScrolling;
+    var bodyRenderContainerWidth = this.grid.renderContainers.body ? this.grid.renderContainers.body.canvasWidth : 0;
+    var leftRenderContainerWidth = this.grid.renderContainers.left ? this.grid.renderContainers.left.canvasWidth : 0;
+    var rightRenderContainerWidth = this.grid.renderContainers.right ? this.grid.renderContainers.right.canvasWidth : 0;
+    var fullGridWidth = bodyRenderContainerWidth + leftRenderContainerWidth + rightRenderContainerWidth;
+    return this.grid.options.enableHorizontalScrollbar && !this.hasHScrollbar && !this.grid.disableScrolling && (fullGridWidth > this.grid.gridWidth);
   };
 
   GridRenderContainer.prototype.getViewportStyle = function () {

--- a/test/unit/core/factories/GridRenderContainer.spec.js
+++ b/test/unit/core/factories/GridRenderContainer.spec.js
@@ -232,6 +232,7 @@ describe('GridRenderContainer factory', function () {
       left.canvasWidth = 100;
       body.canvasWidth = 200;
       grid.gridWidth = 200;
+      grid.options.enableHorizontalScrollbar = true;
     });
 	
     it('should return false if the container does not have the horizontal scrollbar enabled', function(){

--- a/test/unit/core/factories/GridRenderContainer.spec.js
+++ b/test/unit/core/factories/GridRenderContainer.spec.js
@@ -229,6 +229,9 @@ describe('GridRenderContainer factory', function () {
       body.name = 'body';
       left = new GridRenderContainer('leftContainer', grid);
       left.name = 'left';
+      left.canvasWidth = 100;
+      body.canvasWidth = 200;
+      grid.gridWidth = 200;
     });
 	
     it('should return false if the container does not have the horizontal scrollbar enabled', function(){
@@ -237,15 +240,10 @@ describe('GridRenderContainer factory', function () {
     });
 	
     it('should return true if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is greater than the grid width', function(){
-      left.canvasWidth = 100;
-      body.canvasWidth = 200;
-      grid.gridWidth = 200;
       expect(left.needsHScrollbarPlaceholder()).toBe(true);
     });
 	
-    it('should return true if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is less than the grid width', function(){
-      left.canvasWidth = 100;
-      body.canvasWidth = 200;
+    it('should return false if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is less than the grid width', function(){
       grid.gridWidth = 400;
       expect(left.needsHScrollbarPlaceholder()).toBe(false);
     });

--- a/test/unit/core/factories/GridRenderContainer.spec.js
+++ b/test/unit/core/factories/GridRenderContainer.spec.js
@@ -226,29 +226,29 @@ describe('GridRenderContainer factory', function () {
 
     beforeEach(function () {
       body = new GridRenderContainer('bodyContainer', grid);
-	  body.name = 'body';
+      body.name = 'body';
       left = new GridRenderContainer('leftContainer', grid);
-	  left.name = 'left'
+      left.name = 'left'
     });
 	
-	it('should return false if the container does not have the horizontal scrollbar enabled', function(){
+    it('should return false if the container does not have the horizontal scrollbar enabled', function(){
       grid.options.enableHorizontalScrollbar = uiGridConstants.scrollbars.NEVER;
       expect(body.needsHScrollbarPlaceholder()).toBe(false);
-	});
+    });
 	
-	it('should return true if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is greater than the grid width', function(){
+    it('should return true if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is greater than the grid width', function(){
       left.canvasWidth = 100;
-	  body.canvasWidth = 200;
-	  grid.gridWidth = 200;
-	  expect(left.needsHScrollbarPlaceholder()).toBe(true);
-	});
+      body.canvasWidth = 200;
+      grid.gridWidth = 200;
+      expect(left.needsHScrollbarPlaceholder()).toBe(true);
+    });
 	
-	it('should return true if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is less than the grid width', function(){
+    it('should return true if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is less than the grid width', function(){
       left.canvasWidth = 100;
-	  body.canvasWidth = 200;
-	  grid.gridWidth = 400;
-	  expect(left.needsHScrollbarPlaceholder()).toBe(false);
-	});
+      body.canvasWidth = 200;
+      grid.gridWidth = 400;
+      expect(left.needsHScrollbarPlaceholder()).toBe(false);
+    });
 	
   });
   

--- a/test/unit/core/factories/GridRenderContainer.spec.js
+++ b/test/unit/core/factories/GridRenderContainer.spec.js
@@ -228,7 +228,7 @@ describe('GridRenderContainer factory', function () {
       body = new GridRenderContainer('bodyContainer', grid);
       body.name = 'body';
       left = new GridRenderContainer('leftContainer', grid);
-      left.name = 'left'
+      left.name = 'left';
     });
 	
     it('should return false if the container does not have the horizontal scrollbar enabled', function(){

--- a/test/unit/core/factories/GridRenderContainer.spec.js
+++ b/test/unit/core/factories/GridRenderContainer.spec.js
@@ -233,6 +233,8 @@ describe('GridRenderContainer factory', function () {
       body.canvasWidth = 200;
       grid.gridWidth = 200;
       grid.options.enableHorizontalScrollbar = true;
+      body.hasHScrollbar = true;
+      left.hasHScrollbar = false;
     });
 	
     it('should return false if the container does not have the horizontal scrollbar enabled', function(){

--- a/test/unit/core/factories/GridRenderContainer.spec.js
+++ b/test/unit/core/factories/GridRenderContainer.spec.js
@@ -221,4 +221,35 @@ describe('GridRenderContainer factory', function () {
     });
   });
 
+  describe('needsHScrollbarPlaceholder ', function() {
+   var body, left;
+
+    beforeEach(function () {
+      body = new GridRenderContainer('bodyContainer', grid);
+	  body.name = 'body';
+      left = new GridRenderContainer('leftContainer', grid);
+	  left.name = 'left'
+    });
+	
+	it('should return false if the container does not have the horizontal scrollbar enabled', function(){
+      grid.options.enableHorizontalScrollbar = uiGridConstants.scrollbars.NEVER;
+      expect(body.needsHScrollbarPlaceholder()).toBe(false);
+	});
+	
+	it('should return true if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is greater than the grid width', function(){
+      left.canvasWidth = 100;
+	  body.canvasWidth = 200;
+	  grid.gridWidth = 200;
+	  expect(left.needsHScrollbarPlaceholder()).toBe(true);
+	});
+	
+	it('should return true if another container does have a horizontal scrollbar and the current container does not have the horizontal scrollbar enabled AND the total canvas width is less than the grid width', function(){
+      left.canvasWidth = 100;
+	  body.canvasWidth = 200;
+	  grid.gridWidth = 400;
+	  expect(left.needsHScrollbarPlaceholder()).toBe(false);
+	});
+	
+  });
+  
 });


### PR DESCRIPTION
Basically adding a check to see if the sum of all of the widths containers in the grid exceeds the viewport size. If true and if horizontal scrolling is not disabled, then show the ui-grid-scrollbar-placeholder div.