### PR TITLE
Corrected spelling for German description

### DIFF
--- a/src/js/i18n/de.js
+++ b/src/js/i18n/de.js
@@ -88,7 +88,7 @@
             pageToLast: 'Zum Ende'
           },
           sizes: 'Einträge pro Seite',
-          totalItems: 'Einträge',
+          totalItems: 'Einträgen',
           through: 'bis',
           of: 'von'
         },


### PR DESCRIPTION
So far it read "... von ... Einträge". However, von implies the noun to be of dative case. This again is "Einträgen" instead of "Einträge".

See:
https://en.wiktionary.org/wiki/von#Preposition
https://en.wiktionary.org/wiki/Einträgen#German