### PR TITLE
Fixed i18n typo in German language

### DIFF
--- a/src/js/i18n/de.js
+++ b/src/js/i18n/de.js
@@ -88,7 +88,7 @@
             pageToLast: 'Zum Ende'
           },
           sizes: 'Einträge pro Seite',
-          totalItems: 'Einträge',
+          totalItems: 'Einträgen',
           through: 'bis',
           of: 'von'
         },


### PR DESCRIPTION
The plural form of "items" (= "Einträge") in german is "Einträgen" of used like this in the pagination:
"1 of 30 items" => "1 von 20 Einträge**n**"