### PR TITLE
fix #6270: Update getCellDisplayValue to manage special case with flatEntityAccess

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1899,7 +1899,7 @@ angular.module('ui.grid')
       if (typeof(row.entity['$$' + col.uid]) !== 'undefined') {
         col.cellDisplayGetterCache = $parse(row.entity['$$' + col.uid].rendered + custom_filter);
       } else if (this.options.flatEntityAccess && typeof(col.field) !== 'undefined') {
-        col.cellDisplayGetterCache = $parse('entity.' + col.field + custom_filter);
+        col.cellDisplayGetterCache = $parse('entity[\'' + col.field + '\']' + custom_filter);
       } else {
         col.cellDisplayGetterCache = $parse(row.getEntityQualifiedColField(col) + custom_filter);
       }

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1899,7 +1899,8 @@ angular.module('ui.grid')
       if (typeof(row.entity['$$' + col.uid]) !== 'undefined') {
         col.cellDisplayGetterCache = $parse(row.entity['$$' + col.uid].rendered + custom_filter);
       } else if (this.options.flatEntityAccess && typeof(col.field) !== 'undefined') {
-        col.cellDisplayGetterCache = $parse('entity[\'' + col.field + '\']' + custom_filter);
+        var colField = col.field.replace(/(')|(\\)/g, "\\$&");
+        col.cellDisplayGetterCache = $parse('entity[\'' + colField + '\']' + custom_filter);
       } else {
         col.cellDisplayGetterCache = $parse(row.getEntityQualifiedColField(col) + custom_filter);
       }

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -635,7 +635,7 @@ describe('Grid factory', function () {
       var row = grid.rows[0];
       expect(grid.getCellValue(row,simpleCol)).toBe('simplePropValue');
       expect(grid.getCellDisplayValue(row,simpleCol)).toBe('simplePropValue');
-      
+
       var row2 = grid.rows[1];
       expect(grid.getCellValue(row2,simpleCol)).toBe('simplePropValue.2');
       expect(grid.getCellDisplayValue(row2,simpleCol)).toBe('simplePropValue.2');
@@ -697,6 +697,49 @@ describe('Grid factory', function () {
       var row = grid.rows[0];
       expect(grid.getCellDisplayValue(row,grid.columns[0])).toEqual("2015-07-01");
       expect(grid.getCellDisplayValue(row,grid.columns[1])).toEqual("WEDNESDAY");
+    });
+
+    it('should get cell display value with special chars column name and flatEntityAccess', function() {
+      var colDefs = [
+        {name: 'Column 1', field: 'column.1'},
+        {name: 'Column 2', field: 'column \'2\'', cellFilter: 'number:2'},
+        {name: 'Column 3', field: 'column   3'},
+        {name: 'Column 4', field: '\\\\////&é"(-è_çà)=+{}:/\\_!<>*|\',?;.§$ê£µ%'}
+      ];
+      var grid = new Grid({ id: 1, columnDefs:colDefs, flatEntityAccess:true });
+      var data = [
+        {
+          'column.1': 'test',
+          'column \'2\'': 2,
+          'column   3': '3',
+          '\\\\////&é"(-è_çà)=+{}:/\\_!<>*|\',?;.§$ê£µ%': '&é"(-è_çà)=+{}'
+        },
+        {
+          'column.1': 'test1',
+          'column \'2\'': 3,
+          'column   3': '4',
+          '\\\\////&é"(-è_çà)=+{}:/\\_!<>*|\',?;.§$ê£µ%': ''
+        }
+      ];
+      var rows = [
+        new GridRow(data[0], 1, grid),
+        new GridRow(data[1], 2, grid)
+      ];
+
+      grid.buildColumns();
+      grid.modifyRows(data);
+
+      expect(grid.getCellDisplayValue(rows[0], grid.getColumn('Column 1'))).toBe('test');
+      expect(grid.getCellDisplayValue(rows[1], grid.getColumn('Column 1'))).toBe('test1');
+
+      expect(grid.getCellDisplayValue(rows[0], grid.getColumn('Column 2'))).toBe('2.00');
+      expect(grid.getCellDisplayValue(rows[1], grid.getColumn('Column 2'))).toBe('3.00');
+
+      expect(grid.getCellDisplayValue(rows[0], grid.getColumn('Column 3'))).toBe('3');
+      expect(grid.getCellDisplayValue(rows[1], grid.getColumn('Column 3'))).toBe('4');
+
+      expect(grid.getCellDisplayValue(rows[0], grid.getColumn('Column 4'))).toBe('&é"(-è_çà)=+{}');
+      expect(grid.getCellDisplayValue(rows[1], grid.getColumn('Column 4'))).toBe('');
     });
 
     it('not overwrite column types specified in options', function() {


### PR DESCRIPTION
Context
- When using columnName with special chars and grid has option flatEntityAccess: true, the function getCellDisplayValue is broken.

What changed
- Replace the string handed to $parse to use square brackets notation instead of dot

Related to https://github.com/angular-ui/ui-grid/issues/6270
