### PR TITLE
feat(tree-view): Supports recursive expanding

### DIFF
--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -330,9 +330,10 @@
                * @methodOf  ui.grid.treeBase.api:PublicApi
                * @description expand the immediate children of the specified row
                * @param {gridRow} row the row you wish to expand
+               * @param {boolean} recursive true if you wish to expand the row's ancients
                */
-              expandRow: function (row) {
-                service.expandRow(grid, row);
+              expandRow: function (row, recursive) {
+                service.expandRow(grid, row, recursive);
               },
 
               /**
@@ -804,7 +805,7 @@
         if (row.treeNode.state === uiGridTreeBaseConstants.EXPANDED){
           service.collapseRow(grid, row);
         } else {
-          service.expandRow(grid, row);
+          service.expandRow(grid, row, false);
         }
 
         grid.queueGridRefresh();
@@ -819,17 +820,38 @@
        *
        * @param {Grid} grid grid object
        * @param {GridRow} row the row we want to expand
+       * @param {boolean} recursive true if you wish to expand the row's ancients
        */
-      expandRow: function ( grid, row ){
-        if ( typeof(row.treeLevel) === 'undefined' || row.treeLevel === null || row.treeLevel < 0 ){
-          return;
-        }
+      expandRow: function ( grid, row, recursive ){
+        if ( recursive ){
+          var parents = [];
+          while ( row && typeof(row.treeLevel) !== 'undefined' && row.treeLevel !== null && row.treeLevel >= 0 && row.treeNode.state !== uiGridTreeBaseConstants.EXPANDED ){
+            parents.push(row);
+            row = row.treeNode.parentRow;
+          }
 
-        if ( row.treeNode.state !== uiGridTreeBaseConstants.EXPANDED ){
-          row.treeNode.state = uiGridTreeBaseConstants.EXPANDED;
-          grid.api.treeBase.raise.rowExpanded(row);
-          grid.treeBase.expandAll = service.allExpanded(grid.treeBase.tree);
-          grid.queueGridRefresh();
+          if ( parents.length > 0 ){
+            row = parents.pop();
+            while ( row ){
+                row.treeNode.state = uiGridTreeBaseConstants.EXPANDED;
+                grid.api.treeBase.raise.rowExpanded(row);
+                row = parents.pop();
+            }
+
+            grid.treeBase.expandAll = service.allExpanded(grid.treeBase.tree);
+            grid.queueGridRefresh();
+          }
+        } else {
+          if ( typeof(row.treeLevel) === 'undefined' || row.treeLevel === null || row.treeLevel < 0 ){
+            return;
+          }
+
+          if ( row.treeNode.state !== uiGridTreeBaseConstants.EXPANDED ){
+            row.treeNode.state = uiGridTreeBaseConstants.EXPANDED;
+            grid.api.treeBase.raise.rowExpanded(row);
+            grid.treeBase.expandAll = service.allExpanded(grid.treeBase.tree);
+            grid.queueGridRefresh();
+          }
         }
       },
 

--- a/src/features/tree-base/test/tree-base.spec.js
+++ b/src/features/tree-base/test/tree-base.spec.js
@@ -125,6 +125,15 @@ describe('ui.grid.treeBase uiGridTreeBaseService', function () {
       expect( expandCount ).toEqual(1);
     });
 
+    it( 'expandRow recursively', function() {
+      expect( treeRows.length ).toEqual( 2, 'only the level 0 rows are visible' );
+
+      grid.api.treeBase.expandRow(grid.rows[4], true);
+      treeRows = uiGridTreeBaseService.treeRows.call( grid, grid.rows.slice(0) );
+      expect( treeRows.length ).toEqual( 7, 'children of row 0, row 3 and row 4 are also visible' );
+      expect( expandCount ).toEqual(3);
+    });
+
     it( 'expandRowChildren', function() {
       expect( treeRows.length ).toEqual( 2, 'only the level 0 rows are visible' );
 


### PR DESCRIPTION
Currently it's hard to expand a child under collapsed tree node(s).
This PR enable it without any change on existing behaviors.