### PR TITLE
Focus on selection mark of unselected rows was hardly visible.

### DIFF
--- a/src/features/selection/less/selection.less
+++ b/src/features/selection/less/selection.less
@@ -16,13 +16,11 @@
 
 .ui-grid-selection-row-header-buttons {
   cursor: pointer;
-  opacity: 0.1;
-
-  &.ui-grid-row-selected {
-    opacity: 1;
+  &::before {
+    opacity: 0.1;
   }
-
-  &.ui-grid-all-selected {
+  &.ui-grid-row-selected::before,
+  &.ui-grid-all-selected::before {
     opacity: 1;
   }
 }


### PR DESCRIPTION
Before the focus on the selection row header could hardly be seen:
![image](https://user-images.githubusercontent.com/23314365/28576245-b09410ca-7153-11e7-943e-032017689782.png)

I therefore moved the opacity-property marking non-selected rows to the ::before-element to get a proper focus:
![image](https://user-images.githubusercontent.com/23314365/28576340-032c4668-7154-11e7-9dd9-40ec7df770e5.png)
