### PR TITLE
feat(cellnav): output aria text for cells that come from selection feature - works on IE with JAWS screen reader

### DIFF
--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -792,7 +792,7 @@
                                            'id="' + grid.id +'-aria-speakable" ' +
                                            'class="ui-grid-a11y-ariascreenreader-speakable ui-grid-offscreen" ' +
                                            'aria-live="assertive" ' +
-                                           'role="region" ' +
+                                           'role="alert" ' +
                                            'aria-atomic="true" ' +
                                            'aria-hidden="false" ' +
                                            'aria-relevant="additions" ' +


### PR DESCRIPTION
This is an extension PR to https://github.com/angular-ui/ui-grid/pull/6260 There is a need of another PR concerning this, because what I have already done worked in Chrome, but not on Internet Explorer with JAWS screen reader. Therefore I ask to merge this PR into master branch as well. The fix is very simple, but it changes the semantics of aria implementation a little bit. You have used the aria-live attribute which should already work as a live region regardless of the role of the element, but unfortunately the JAWS screen reader doesn't see those live messages on Internet Explorer. It does see it when the role is set to 'alert'. It's not very pretty, but it's the only way it works on IE.