### PR TITLE
fix(Grid.js): wrong  use in getCellDisplayValue

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1906,7 +1906,8 @@ angular.module('ui.grid')
       }
     }
 
-    return col.cellDisplayGetterCache(row);
+    var rowWithCol = angular.extend({}, row, {col: col});
+    return col.cellDisplayGetterCache(rowWithCol);
   };
 
 


### PR DESCRIPTION
I fixed an issue in a method in Grid prototype: getCellDisplayValue. The method has used the angular $parse service to cache the result of parsing the expression that should be evaluated to get the displayed value for a single cell. As we know from the documentation the $parse service returns a JavaScript function that can be called to retrieve the result of the expression evaluation when the argument should be the context which the expression should be evaluated in. The context in angular means: the scope.
In the deleted line of code in my commit the argument to the cached method was the row object though. This is incorrect. This should be scope. I assume that the developer that wrote this just wanted to make use of the service to, let's say, cache the expression evaluation, but the actual argument passed was intended to be the row object. This is still incorrect though, because there is one case when this is not enough. Namely I had an angular filter with one param applied to the grid cell. While the expression (something like: "entity.someProperty | someFilter : col.colDef.someFilterParam") was evaluated, there was this problem that when the row object was passed to the function, it had no property named "col", which caused an error in the evaluated expression. Therefore what I changed is that I extended the object passed as an argument to have the col property which is in fact the whole column object. I made it so, that the original row object is not affected not to break the rest of the library. I made it so, because I can't see any other way of using a cell-filter with a custom param except of adding it to the colDef object. We have used this throughout the whole project and now we just fix the accessibility issues and just observed that this happens. It works in general, but not in the first call of the filter function (the call comes from the affected line of code in the commit). The error is thrown there and the whole expression is displayed as it is. Then angular evaluates this against the real scope, where the col object is present. This is the only reason it worked in our application, but not in live-region for aria.
Please give me a feedback to this solution. I know that this is maybe not completely intended behavior of the getCellDisplayValue method, but I think that this is also a rather common use case.