### PR TITLE
fix(build): Cope with tags not conforming to semver format when building.

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -360,7 +360,7 @@ var util = module.exports = {
 
       var v = semver.clean(tag);
 
-      if (!v.match(/-.+?$/)) {
+      if (v && !v.match(/-.+?$/)) {
         return v;
       }
     }


### PR DESCRIPTION
If a developer had defined a git tag which did not conform to the semver format "vx.y.z", the build
process would take this tag and assume it to be the current version but fail when it does not. The
script now skips these tags. It might also make sense to warn about these tags, as the developer may
have had a typo. But this still enforces the pattern to only have tags in that format.

Before this fix, if such a tag had been defined the following error message appeared:
```
$ grunt
Loading "Gruntfile.js" tasks...ERROR
>> TypeError: Cannot read property 'match' of null
```