### PR TITLE
fix #5770: verify that the keyCode is greater than zero

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -963,10 +963,10 @@
                   if (uiGridCtrl && uiGridCtrl.grid.api.cellNav) {
                     var viewPortKeyDownUnregister = uiGridCtrl.grid.api.cellNav.on.viewPortKeyPress($scope, function (evt, rowCol) {
                       if (uiGridEditService.isStartEditKey(evt)) {
-                          var code = typeof evt.which === 'number' ? evt.which : evt.keyCode;
+                        var code = typeof evt.which === 'number' ? evt.which : evt.keyCode;
                         if(code > 0) {
-                            ngModel.$setViewValue(String.fromCharCode(code), evt);
-                            ngModel.$render();
+                          ngModel.$setViewValue(String.fromCharCode(code), evt);
+                          ngModel.$render();
                         }
                       }
                       viewPortKeyDownUnregister();

--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -963,10 +963,10 @@
                   if (uiGridCtrl && uiGridCtrl.grid.api.cellNav) {
                     var viewPortKeyDownUnregister = uiGridCtrl.grid.api.cellNav.on.viewPortKeyPress($scope, function (evt, rowCol) {
                       if (uiGridEditService.isStartEditKey(evt)) {
-	                      var code = typeof evt.which === 'number' ? evt.which : evt.keyCode;
+                          var code = typeof evt.which === 'number' ? evt.which : evt.keyCode;
                         if(code > 0) {
-	                        ngModel.$setViewValue(String.fromCharCode(code), evt);
-	                        ngModel.$render();
+                            ngModel.$setViewValue(String.fromCharCode(code), evt);
+                            ngModel.$render();
                         }
                       }
                       viewPortKeyDownUnregister();

--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -964,7 +964,7 @@
                     var viewPortKeyDownUnregister = uiGridCtrl.grid.api.cellNav.on.viewPortKeyPress($scope, function (evt, rowCol) {
                       if (uiGridEditService.isStartEditKey(evt)) {
                         var code = typeof evt.which === 'number' ? evt.which : evt.keyCode;
-                        if(code > 0) {
+                        if (code > 0) {
                           ngModel.$setViewValue(String.fromCharCode(code), evt);
                           ngModel.$render();
                         }

--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -963,8 +963,11 @@
                   if (uiGridCtrl && uiGridCtrl.grid.api.cellNav) {
                     var viewPortKeyDownUnregister = uiGridCtrl.grid.api.cellNav.on.viewPortKeyPress($scope, function (evt, rowCol) {
                       if (uiGridEditService.isStartEditKey(evt)) {
-                        ngModel.$setViewValue(String.fromCharCode( typeof evt.which === 'number' ? evt.which : evt.keyCode), evt);
-                        ngModel.$render();
+	                      var code = typeof evt.which === 'number' ? evt.which : evt.keyCode;
+                        if(code > 0) {
+	                        ngModel.$setViewValue(String.fromCharCode(code), evt);
+	                        ngModel.$render();
+                        }
                       }
                       viewPortKeyDownUnregister();
                     });


### PR DESCRIPTION
Firefox handling keypress event for function key. Then uiGridCellnav rise 'viewPortKeyPress' event with property which=0.
In uiGridEditor directive:
ngModel.$setViewValue(String.fromCharCode( typeof evt.which === 'number' ? evt.which : evt.keyCode), evt);
which = 0 and "String.fromCharCode(0)" returns this strange character.

fix #5770 