### PR TITLE
fix(pagination): remove unneeded height adjustment

### DIFF
--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -396,8 +396,11 @@
 
           var options = uiGridCtrl.grid.options;
 
+          
           uiGridCtrl.grid.renderContainers.body.registerViewportAdjuster(function (adjustment) {
-            adjustment.height = adjustment.height - gridUtil.elementHeight($elm, "padding");
+            if (options.enablePaginationControls) {
+              adjustment.height = adjustment.height - gridUtil.elementHeight($elm, "padding");
+            }
             return adjustment;
           });
 


### PR DESCRIPTION
If pagination is activated, the height of the ui-grid viewport has always been adjusted according to the height of the pagination control panel including its padding. This padding calculation resulted in unneeded margins under the horizontal scrollbar if the pagination is enabled but not needed. Now the height adjustment occurs only in case of shown pagination control panel.