### PR TITLE
feat(headerKeyDown): add options to specify SPACE/RETURN key down fun…

### DIFF
--- a/src/js/core/constants.js
+++ b/src/js/core/constants.js
@@ -233,6 +233,26 @@
       NEVER: 0,
       ALWAYS: 1
       //WHEN_NEEDED: 2
+    },
+
+    /**
+     * @ngdoc object
+     * @name keyboardActions
+     * @propertyOf ui.grid.service:uiGridConstants
+     * @description Used with {@link ui.grid.class:GridOptions#properties_columnHeaderKeyDownAction GridOptions.columnHeaderKeyDownAction},
+     * {@link ui.grid.class:GridOptions#properties_columnHeaderSpaceAction GridOptions.columnHeaderSpaceAction} and
+     * {@link ui.grid.class:GridOptions#properties_columnHeaderReturnAction GridOptions.columnHeaderReturnAction}
+     * to specify  the action to be performed, when the space bar or the return key is pressed on a column header.
+     *
+     * Available options are:
+     * - `uiGridConstants.keyboardActions.NO_ACTION` - does nothing
+     * - `uiGridConstants.keyboardActions.SHOW_MENU` - shows the column menu
+     * - `uiGridConstants.keyboardActions.DO_SORT` - fires the click event on the column header
+     */
+    keyboardActions: {
+      NO_ACTION: 0,
+      SHOW_MENU: 1,
+      DO_SORT: 2
     }
   });
 

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -163,9 +163,42 @@
               }
             };
 
+            $scope.spaceAction =  typeof($scope.col.grid.options.columnHeaderSpaceAction) !== "undefined" ? 
+              $scope.col.grid.options.columnHeaderSpaceAction : $scope.col.grid.options.columnHeaderKeyDownAction;
+            $scope.returnAction =  typeof($scope.col.grid.options.columnHeaderReturnAction) !== "undefined" ? 
+              $scope.col.grid.options.columnHeaderReturnAction : $scope.col.grid.options.columnHeaderKeyDownAction;
+
+            if ($scope.returnAction === uiGridConstants.keyboardActions.SHOW_MENU || 
+              $scope.spaceAction === uiGridConstants.keyboardActions.SHOW_MENU) {
+              $elm.find('.ui-grid-cell-contents').attr('aria-haspopup', 'true');
+            }
+
             $scope.handleKeyDown = function(event) {
-              if (event.keyCode === 32) {
+              
+              var performeKeyDownAction = function(action) {
+
                 event.preventDefault();
+
+                switch (action) {
+                  case uiGridConstants.keyboardActions.DO_SORT:
+                    if ($scope.sortable) {
+                      $scope.handleClick(event);
+                    }
+                    break;
+                  case uiGridConstants.keyboardActions.SHOW_MENU:
+                    if ($scope.col.grid.options.enableColumnMenus && $scope.col.colDef.enableColumnMenu !== false) {
+                      $scope.toggleMenu(event);
+                    }
+                    break;
+                  default:
+                    break;
+                }
+              };
+
+              if (event.keyCode === uiGridConstants.keymap.ENTER) {
+                performeKeyDownAction($scope.returnAction);
+              } else if (event.keyCode === uiGridConstants.keymap.SPACE) {
+                performeKeyDownAction($scope.spaceAction);
               }
             };
 

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -512,6 +512,30 @@ angular.module('ui.grid')
        */
       baseOptions.appScopeProvider = baseOptions.appScopeProvider || null;
 
+      /**
+       * @ngdoc object
+       * @name columnHeaderKeyDownAction
+       * @propertyOf ui.grid.class:GridOptions
+       * @description this option specifies the action to be performed, when the space bar or the return key is 
+       * pressed on a column header. This option takes a value of the enum uiGridConstants.keyboardActions.
+       * This option can be overwritten by the options columnHeaderSpaceAction and columnHeaderReturnAction
+       */
+      baseOptions.columnHeaderKeyDownAction = typeof(baseOptions.columnHeaderKeyDownAction) !== "undefined" ? baseOptions.columnHeaderKeyDownAction : uiGridConstants.keyboardActions.DO_SORT;
+
+      /**
+       * @ngdoc object
+       * @name columnHeaderSpaceAction
+       * @propertyOf ui.grid.class:GridOptions
+       * @description this options overwrites the columnHeaderKeyDownAction option for the space bar.
+       */
+
+      /**
+       * @ngdoc object
+       * @name columnHeaderReturnAction
+       * @propertyOf ui.grid.class:GridOptions
+       * @description this options overwrites the columnHeaderKeyDownAction option for the return key.
+       */
+
       return baseOptions;
     }
   };

--- a/src/templates/ui-grid/uiGridMenuItem.html
+++ b/src/templates/ui-grid/uiGridMenuItem.html
@@ -4,7 +4,6 @@
   ng-click="itemAction($event, title)"
   ng-show="itemShown()"
   ng-class="{ 'ui-grid-menu-item-active': active(), 'ui-grid-sr-only': (!focus && screenReaderOnly) }"
-  aria-pressed="{{active()}}"
   tabindex="0"
   ng-focus="focus=true"
   ng-blur="focus=false">

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -52,7 +52,8 @@ describe('GridOptions factory', function () {
         gridFooterTemplate: 'ui-grid/ui-grid-grid-footer',
         rowTemplate: 'ui-grid/ui-grid-row',
         gridMenuTemplate: 'ui-grid/uiGridMenu',
-        appScopeProvider: null
+        appScopeProvider: null,
+        columnHeaderKeyDownAction: 2
       });
     });
 
@@ -99,7 +100,10 @@ describe('GridOptions factory', function () {
         rowTemplate: 'testRow',
         gridMenuTemplate: 'testGridMenu',
         extraOption: 'testExtraOption',
-        appScopeProvider : 'anotherRef'
+        appScopeProvider : 'anotherRef',
+        columnHeaderKeyDownAction: 0,
+        columnHeaderSpaceAction: 1,
+        columnHeaderReturnAction: 2 
       };
       expect( GridOptions.initialize(options) ).toEqual({
         onRegisterApi: testFunction,
@@ -143,7 +147,10 @@ describe('GridOptions factory', function () {
         rowTemplate: 'testRow',
         gridMenuTemplate: 'testGridMenu',
         extraOption: 'testExtraOption',
-        appScopeProvider : 'anotherRef'
+        appScopeProvider : 'anotherRef',
+        columnHeaderKeyDownAction: 0,
+        columnHeaderSpaceAction: 1,
+        columnHeaderReturnAction: 2
       });
     });
 
@@ -189,7 +196,10 @@ describe('GridOptions factory', function () {
         gridFooterTemplate: 'testGridFooter',
         rowTemplate: 'testRow',
         gridMenuTemplate: 'testGridMenu',
-        extraOption: 'testExtraOption'
+        extraOption: 'testExtraOption',
+        columnHeaderKeyDownAction: 1,
+        columnHeaderSpaceAction: 2,
+        columnHeaderReturnAction: 0
       };
       expect( GridOptions.initialize(options) ).toEqual({
         onRegisterApi: testFunction,
@@ -233,7 +243,10 @@ describe('GridOptions factory', function () {
         rowTemplate: 'testRow',
         gridMenuTemplate: 'testGridMenu',
         extraOption: 'testExtraOption',
-        appScopeProvider : null
+        appScopeProvider : null,
+        columnHeaderKeyDownAction: 1,
+        columnHeaderSpaceAction: 2,
+        columnHeaderReturnAction: 0
       });
     });
   });


### PR DESCRIPTION
…ction on a column header.

columnHeaderKeyDownAction: This option specifies the action to be performed when the space bar or the return key is pressed on a column header. This option takes a value of the enum uiGridConstants.keyboardActions. This option can be overwritten by the options columnHeaderSpaceAction and columnHeaderReturnAction.

Available options are:
     * - `uiGridConstants.keyboardActions.NO_ACTION` - does nothing
     * - `uiGridConstants.keyboardActions.SHOW_MENU` - shows the column menu
     * - `uiGridConstants.keyboardActions.DO_SORT` - fires the click event on the column header