### PR TITLE
feat(sorting): add option to specify the keys to add/remove sort columns

### DIFF
--- a/src/js/core/constants.js
+++ b/src/js/core/constants.js
@@ -72,6 +72,10 @@
       F11: 122,
       F12: 123
     },
+    keyCombination: { 
+      SHIFT: 1, 
+      CTRL: 2
+    }, 
      /**
      * @ngdoc object
      * @name ASC

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -339,9 +339,12 @@
             $scope.$on( '$destroy', dataChangeDereg );
 
             $scope.handleClick = function(event) {
-              // If the shift key is being held down, add this column to the sort
+              // If the a specific key is being held down, add this column to the sort
               var add = false;
-              if (event.shiftKey) {
+              var useShift = uiGridCtrl.grid.options.keyToAddSortColumns & uiGridConstants.keyCombination.SHIFT;
+              var useCtrl = uiGridCtrl.grid.options.keyToAddSortColumns & uiGridConstants.keyCombination.CTRL;
+
+              if ((event.shiftKey && useShift) || (event.ctrlKey && useCtrl)) {
                 add = true;
               }
 

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -512,6 +512,15 @@ angular.module('ui.grid')
        */
       baseOptions.appScopeProvider = baseOptions.appScopeProvider || null;
 
+       /** 
+       * @ngdoc object 
+       * @name keyToAddSortColumns 
+       * @propertyOf ui.grid.class:GridOptions 
+       * @description this option specifies whether the adding of columns to the collection of sorted columns is enabled by pressing 
+       * the shift key, the control key or either. This option takes any binary OR combination of SHIFT and CTRL from uiGridConstants.keyCombination. 
+       */ 
+      baseOptions.keyToAddSortColumns = baseOptions.keyToAddSortColumns || uiGridConstants.keyCombination.SHIFT; 
+
       return baseOptions;
     }
   };

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -52,7 +52,8 @@ describe('GridOptions factory', function () {
         gridFooterTemplate: 'ui-grid/ui-grid-grid-footer',
         rowTemplate: 'ui-grid/ui-grid-row',
         gridMenuTemplate: 'ui-grid/uiGridMenu',
-        appScopeProvider: null
+        appScopeProvider: null,
+        keyToAddSortColumns: 1 
       });
     });
 
@@ -99,7 +100,8 @@ describe('GridOptions factory', function () {
         rowTemplate: 'testRow',
         gridMenuTemplate: 'testGridMenu',
         extraOption: 'testExtraOption',
-        appScopeProvider : 'anotherRef'
+        appScopeProvider : 'anotherRef',
+        keyToAddSortColumns: 3
       };
       expect( GridOptions.initialize(options) ).toEqual({
         onRegisterApi: testFunction,
@@ -143,7 +145,8 @@ describe('GridOptions factory', function () {
         rowTemplate: 'testRow',
         gridMenuTemplate: 'testGridMenu',
         extraOption: 'testExtraOption',
-        appScopeProvider : 'anotherRef'
+        appScopeProvider : 'anotherRef',
+        keyToAddSortColumns: 3
       });
     });
 
@@ -189,7 +192,8 @@ describe('GridOptions factory', function () {
         gridFooterTemplate: 'testGridFooter',
         rowTemplate: 'testRow',
         gridMenuTemplate: 'testGridMenu',
-        extraOption: 'testExtraOption'
+        extraOption: 'testExtraOption',
+        keyToAddSortColumns: 1
       };
       expect( GridOptions.initialize(options) ).toEqual({
         onRegisterApi: testFunction,
@@ -233,7 +237,8 @@ describe('GridOptions factory', function () {
         rowTemplate: 'testRow',
         gridMenuTemplate: 'testGridMenu',
         extraOption: 'testExtraOption',
-        appScopeProvider : null
+        appScopeProvider : null,
+        keyToAddSortColumns: 1
       });
     });
   });


### PR DESCRIPTION
With the option keyToAddSortColumns, we can enable adding/removing columns to/from the collection of sorted columns not only using the shift key, because the shift key has selection side effects in IE, but also the CTRL key, if this option enables that.