### PR TITLE
fix(Grid.js): add column header to text read by aria when user moves through grid with keyboard

### DIFF
--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -833,6 +833,10 @@
                     }
                   }
 
+                  function getAppendedColumnHeaderText(col) {
+                    return ', ' + i18nService.getSafeText('headerCell.aria.column') + ' ' + col.displayName;
+                  }
+
                   function getCellDisplayValue(currentRowColumn) {
                     if (currentRowColumn.col.field === 'selectionRowHeaderCol') {
                       // This is the case when the 'selection' feature is used in the grid and the user has moved
@@ -841,14 +845,15 @@
                       // is or is not currently selected.
                         return currentRowColumn.row.isSelected ? i18nService.getSafeText('search.aria.selected') : i18nService.getSafeText('search.aria.notSelected');
                       } else {
-                        return grid.getCellDisplayValue(currentRowColumn.row, currentSelection[i].col);
+                        return grid.getCellDisplayValue(currentRowColumn.row, currentRowColumn.col);
                       }
                     }
 
                   var values = [];
                   var currentSelection = grid.api.cellNav.getCurrentSelection();
                   for (var i = 0; i < currentSelection.length; i++) {
-                    values.push(getCellDisplayValue(currentSelection[i]));
+                    var cellDisplayValue = getCellDisplayValue(currentSelection[i]) + getAppendedColumnHeaderText(currentSelection[i].col);
+                    values.push(cellDisplayValue);
                   }
                   var cellText = values.toString();
                   setNotifyText(cellText);

--- a/src/js/i18n/de.js
+++ b/src/js/i18n/de.js
@@ -9,7 +9,8 @@
           aria: {
             defaultFilterLabel: 'Filter für Spalte',
             removeFilter: 'Filter löschen',
-            columnMenuButtonLabel: 'Spaltenmenü'
+            columnMenuButtonLabel: 'Spaltenmenü',
+            column: 'Spalte'
           },
           priority: 'Priorität:',
           filterLabel: "Filter für Spalte: "

--- a/src/js/i18n/en.js
+++ b/src/js/i18n/en.js
@@ -9,7 +9,8 @@
           aria: {
             defaultFilterLabel: 'Filter for column',
             removeFilter: 'Remove Filter',
-            columnMenuButtonLabel: 'Column Menu'
+            columnMenuButtonLabel: 'Column Menu',
+            column: 'Column'
           },
           priority: 'Priority:',
           filterLabel: "Filter for column: "

--- a/src/js/i18n/pl.js
+++ b/src/js/i18n/pl.js
@@ -9,7 +9,8 @@
           aria: {
             defaultFilterLabel: 'Filtr dla kolumny',
             removeFilter: 'Usuń filtr',
-            columnMenuButtonLabel: 'Menu kolumny'
+            columnMenuButtonLabel: 'Menu kolumny',
+            column: 'Kolumna'
           },
           priority: 'Prioritet:',
           filterLabel: "Filtr dla kolumny: "


### PR DESCRIPTION
Added functionality for ARIA. Now when user moves into a grid cell not only the content of the cell is read by the screen reader, but also the grid header for that cell. This is very helpful for a person who uses a screen reader, because he/she can not always easily find out under which column he/she is.