### PR TITLE
fix (expandable) expand all opens disableRowExpandable rows

### DIFF
--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -265,7 +265,7 @@
 
       expandAllRows: function(grid, $scope) {
         grid.renderContainers.body.visibleRowCache.forEach( function(row) {
-          if (!row.isExpanded && !row.entity.subGridOptions.disableRowExpandable) {
+          if (!row.isExpanded && !(row.entity.subGridOptions && row.entity.subGridOptions.disableRowExpandable)) {
             service.toggleRowExpansion(grid, row);
           }
         });

--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -265,7 +265,7 @@
 
       expandAllRows: function(grid, $scope) {
         grid.renderContainers.body.visibleRowCache.forEach( function(row) {
-          if (!row.isExpanded) {
+          if (!row.isExpanded && !row.entity.subGridOptions.disableRowExpandable) {
             service.toggleRowExpansion(grid, row);
           }
         });

--- a/src/features/expandable/test/expandable.spec.js
+++ b/src/features/expandable/test/expandable.spec.js
@@ -45,7 +45,7 @@ describe('ui.grid.expandable', function () {
   it('expandAll and collapseAll should set and unset row.isExpanded', function () {
     scope.gridApi.expandable.expandAllRows();
     scope.grid.rows.forEach(function(row) {
-      expect(row.isExpanded).toBe(true);
+      expect(row.isExpanded || (row.entity.subGridOptions && row.entity.subGridOptions.disableRowExpandable)).toBe(true);
     });
     scope.gridApi.expandable.collapseAllRows();
     scope.grid.rows.forEach(function(row) {
@@ -56,7 +56,7 @@ describe('ui.grid.expandable', function () {
   it('toggleAllRows should set and unset row.isExpanded', function(){
     scope.gridApi.expandable.toggleAllRows();
     scope.grid.rows.forEach(function(row){
-      expect(row.isExpanded).toBe(true);
+      expect(row.isExpanded || (row.entity.subGridOptions && row.entity.subGridOptions.disableRowExpandable)).toBe(true);
     });
     scope.gridApi.expandable.toggleAllRows();
     scope.grid.rows.forEach(function(row){


### PR DESCRIPTION
Resolved issue where clicking the "expand all" button opens sub grids that have disableRowExpandable set to true.
This leads to seeing ugly empty sub grid white space.  The fix simply includes a check for each row to see if expansion is disabled or not.