### PR TITLE
feat(columnHeader): the sort arrow and priority do not disappear

### DIFF
--- a/src/features/selection/templates/selectionRowHeaderButtons.html
+++ b/src/features/selection/templates/selectionRowHeaderButtons.html
@@ -2,7 +2,7 @@
   class="ui-grid-selection-row-header-buttons ui-grid-icon-ok"
   ng-class="{'ui-grid-row-selected': row.isSelected}"
   ng-click="selectButtonClick(row, $event)"
-  ng-keydown="selectButtonKeyDown(row, $event)">
+  ng-keydown="selectButtonKeyDown(row, $event)"
   role="checkbox"
   ng-model="row.isSelected">
   &nbsp;

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -37,6 +37,7 @@
             var uiGridCtrl = controllers[0];
             var renderContainerCtrl = controllers[1];
 
+
             $scope.i18n = {
               headerCell: i18nService.getSafeText('headerCell'),
               sort: i18nService.getSafeText('sort')
@@ -61,6 +62,8 @@
             };
 
             $scope.grid = uiGridCtrl.grid;
+
+            $scope.showColMenuButton = $scope.grid.options.enableColumnMenus && !$scope.col.isRowHeader  && $scope.col.colDef.enableColumnMenu !== false;
 
             $scope.renderContainer = uiGridCtrl.grid.renderContainers[renderContainerCtrl.containerId];
 

--- a/src/less/header.less
+++ b/src/less/header.less
@@ -56,6 +56,40 @@
   position: relative
 }
 
+.ui-grid-header-cell-label {
+  max-width: 100%;
+  position: relative;
+  display: inline-block;
+
+  &.with-button-with-sort {
+    max-width: calc(~"100% - 30px") !important; 
+  }
+  
+  &.with-button-without-sort {
+    max-width: calc(~"100% - 22px") !important; 
+  }
+  
+  &.without-button-with-sort {
+    max-width: calc(~"100% - 19px") !important; 
+  }
+
+}
+
+.ui-grid-header-cell-label-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ui-grid-header-cell-sort-info {
+  position: absolute;
+  top: 0px;
+  right: -19px;
+}
+
+.ui-grid-header-cell-primary-focus {
+  text-overflow: unset !important;
+}
+
 .ui-grid-header-cell {
   position: relative;
   box-sizing: border-box;

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -10,27 +10,33 @@
     class="ui-grid-cell-contents ui-grid-header-cell-primary-focus"
     col-index="renderIndex"
     title="TOOLTIP">
-    <span
+    <div
       class="ui-grid-header-cell-label"
+      ng-class= "{'with-button-with-sort': showColMenuButton && col.sort.direction, 'with-button-without-sort': showColMenuButton && !col.sort.direction, 'without-button-with-sort': !showColMenuButton && col.sort.direction}"
       ui-grid-one-bind-id-grid="col.uid + '-header-text'">
-      {{ col.displayName CUSTOM_FILTERS }}
-    </span>
+      <div class="ui-grid-header-cell-label-text" >
+        {{ col.displayName CUSTOM_FILTERS }}
+      </div>
 
-    <span
+      <span
+      class="ui-grid-header-cell-sort-info"
       ui-grid-one-bind-id-grid="col.uid + '-sortdir-text'"
       ui-grid-visible="col.sort.direction"
       aria-label="{{getSortDirectionAriaLabel()}}">
-      <i
-       ng-class="{ 'ui-grid-icon-up-dir': col.sort.direction == asc, 'ui-grid-icon-down-dir': col.sort.direction == desc, 'ui-grid-icon-blank': !col.sort.direction }"
-       title="{{isSortPriorityVisible() ? i18n.headerCell.priority + ' ' + ( col.sort.priority + 1 )  : null}}"
-       aria-hidden="true">
-     </i>
-     <sub
-       ui-grid-visible="isSortPriorityVisible()"
-       class="ui-grid-sort-priority-number">
-       {{col.sort.priority + 1}}
-     </sub>
-    </span>
+        <i
+          ng-class="{ 'ui-grid-icon-up-dir': col.sort.direction == asc, 'ui-grid-icon-down-dir': col.sort.direction == desc, 'ui-grid-icon-blank': !col.sort.direction }"
+          title="{{isSortPriorityVisible() ? i18n.headerCell.priority + ' ' + ( col.sort.priority + 1 )  : null}}"
+          aria-hidden="true">
+        </i>
+        <sub
+          ui-grid-visible="isSortPriorityVisible()"
+          class="ui-grid-sort-priority-number">
+          {{col.sort.priority + 1}}
+        </sub>
+      </span>
+    </div>
+
+    
   </div>
 
   <div
@@ -38,7 +44,7 @@
     tabindex="0"
     ui-grid-one-bind-id-grid="col.uid + '-menu-button'"
     class="ui-grid-column-menu-button"
-    ng-if="grid.options.enableColumnMenus && !col.isRowHeader  && col.colDef.enableColumnMenu !== false"
+    ng-if="showColMenuButton"
     ng-click="toggleMenu($event)"
     ng-keydown="headerCellArrowKeyDown($event)"
     ng-class="{'ui-grid-column-menu-button-last-col': isLastCol}"


### PR DESCRIPTION
When resizing a column, the sort arrow and priority do not disappear and are attached intelligently to the right side of the column