### PR TITLE
fix(uiGridHeader) stop preserving explicit header heights 

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2148,8 +2148,8 @@ angular.module('ui.grid')
         }
 
         if (container.header || container.headerCanvas) {
-          container.explicitHeaderHeight = container.explicitHeaderHeight || null;
-          container.explicitHeaderCanvasHeight = container.explicitHeaderCanvasHeight || null;
+          container.explicitHeaderHeight = null;
+          container.explicitHeaderCanvasHeight = null;
 
           containerHeadersToRecalc.push(container);
         }


### PR DESCRIPTION
Stop preserving explicit header heights when styles are rebuilt. The buildStyles function fails to expand header height when it was previously set explicitly, and if explicit definition is needed it will be reset to the same value below.

fixes #3705