### PR TITLE
fix(uiGridAutoResize): Changed [0].clientHeight to gridUtil.elementHe…

### DIFF
--- a/src/features/auto-resize-grid/js/auto-resize.js
+++ b/src/features/auto-resize-grid/js/auto-resize.js
@@ -26,7 +26,7 @@
           function() {
             return gridUtil.elementHeight($elm);
           }], function(newValues, oldValues, scope) {
-          if (newValues.toString() !== oldValues.toString()) {
+          if (!angular.equals(newValues, oldValues)) {
             uiGridCtrl.grid.gridWidth = newValues[0];
             uiGridCtrl.grid.gridHeight = newValues[1];
             setTimeout(function(){

--- a/src/features/auto-resize-grid/js/auto-resize.js
+++ b/src/features/auto-resize-grid/js/auto-resize.js
@@ -19,21 +19,30 @@
       require: 'uiGrid',
       scope: false,
       link: function($scope, $elm, $attrs, uiGridCtrl) {
+        var timeout = null;
+
+        var debounce = function(width, height) {
+          if (timeout !== null) {
+            clearTimeout(timeout);
+          }
+          timeout = setTimeout(function() {
+            uiGridCtrl.grid.gridWidth = width;
+            uiGridCtrl.grid.gridHeight = height;
+            uiGridCtrl.grid.refresh();
+            timeout = null;
+          }, 400);
+        };
+
         $scope.$watchGroup([
           function() {
             return gridUtil.elementWidth($elm);
           },
           function() {
             return gridUtil.elementHeight($elm);
-          }], function(newValues, oldValues, scope) {
+          }
+        ], function(newValues, oldValues, scope) {
           if (!angular.equals(newValues, oldValues)) {
-            uiGridCtrl.grid.gridWidth = newValues[0];
-            uiGridCtrl.grid.gridHeight = newValues[1];
-            setTimeout(function(){
-              $scope.$apply(function(){
-                uiGridCtrl.grid.refresh();
-              });
-            },0);
+            debounce(newValues[0], newValues[1]);
           }
         });
       }

--- a/src/features/auto-resize-grid/js/auto-resize.js
+++ b/src/features/auto-resize-grid/js/auto-resize.js
@@ -19,25 +19,23 @@
       require: 'uiGrid',
       scope: false,
       link: function($scope, $elm, $attrs, uiGridCtrl) {
-
-        $scope.$watch(function() {
-          return $elm[0].clientWidth;
-        }, function(newVal, oldVal) {
-          if (newVal !== oldVal) {
-            uiGridCtrl.grid.gridWidth = newVal;
-            uiGridCtrl.grid.refresh();
+        $scope.$watchGroup([
+          function() {
+            return gridUtil.elementWidth($elm);
+          },
+          function() {
+            return gridUtil.elementHeight($elm);
+          }], function(newValues, oldValues, scope) {
+          if (newValues.toString() !== oldValues.toString()) {
+            uiGridCtrl.grid.gridWidth = newValues[0];
+            uiGridCtrl.grid.gridHeight = newValues[1];
+            setTimeout(function(){
+              $scope.$apply(function(){
+                uiGridCtrl.grid.refresh();
+              });
+            },0);
           }
         });
-
-        $scope.$watch(function() {
-          return $elm[0].clientHeight;
-        }, function(newVal, oldVal) {
-          if (newVal !== oldVal) {
-            uiGridCtrl.grid.gridHeight = newVal;
-            uiGridCtrl.grid.refresh();
-          }
-        });
-
       }
     };
   }]);


### PR DESCRIPTION
I made change based on this issue: https://github.com/angular-ui/ui-grid/issues/6481
I changed `$elm[0].clientHeight` to `gridUtil.elementHeight($elm)` and `$elm[0].clientHeight` to `gridUtil.elementWidth($elm)`.
I made another change too. I merged two watchers into one watchGroup. And I changed how `uiGridCtrl.grid.refresh();` is called. Looks like it needs to be called inside 
```
$scope.$apply(function(){
  uiGridCtrl.grid.refresh();
});
```
because without that it cause some problems when resizing grid with many columns. All tests still pass without problem.