### PR TITLE
test(ui-grid-column-menu): Fix test issue with angular 1.6.7

### DIFF
--- a/test/unit/core/directives/ui-grid-column-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-column-menu.spec.js
@@ -563,14 +563,12 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function() {
 
 			expect(sortChanged).toHaveBeenCalledWith(jasmine.any(Object), []);
 		});
-		// TODO: this does not seem to work in angular 1.6.7
-		if (angular.version.major === 1 && angular.version.minor < 6) {
-			it('should raise the columnVisibilityChanged event when hide column is clicked', function() {
-				$($('.ui-grid-menu-item')[3]).click();
-				$timeout.flush();
 
-				expect(columnVisibilityChanged).toHaveBeenCalled();
-			});
-		}
+    it('should raise the columnVisibilityChanged event when hide column is clicked', function() {
+      $($('.ui-grid-menu-item')[3]).click();
+
+      expect(columnVisibilityChanged).toHaveBeenCalled();
+    });
+
 	});
 });


### PR DESCRIPTION
Hi @mportuga 
this issue is related to this commit in 1.6.5, [$timeout/$interval: do not trigger a digest on cancel](https://github.com/angular/angular.js/commit/a222d0b452622624dc498ef0b9d3c43647fd4fbc), so there is no need to use $timeout.flush() for another digest. So as per test under 1.6, the test can also pass, so I just deleted.