### PR TITLE
Fix bug with template for last row's bottom border

### DIFF
--- a/src/templates/ui-grid/ui-grid.html
+++ b/src/templates/ui-grid/ui-grid.html
@@ -10,7 +10,7 @@
     }
 
     .grid{{ grid.id }} .ui-grid-row:last-child .ui-grid-cell {
-      border-bottom-width: {{ ((grid.getTotalRowHeight() < grid.getViewportHeight()) && '1') || '0' }}px;
+      border-bottom-width: {{ (((grid.getVisibleRowCount() * grid.options.rowHeight) < grid.getViewportHeight()) && '1') || '0' }}px;
     }
 
     {{ grid.verticalScrollbarStyles }}


### PR DESCRIPTION
The logic that sets the bottom-border-width for the last row calls a function that doesn't exist - grid.getTotalRowHeight() (issue logged in #4413) so I've updated it slightly to calculate this value using the grid.getVisibleRowCount() multiplied by grid.options.rowHeight which should achieve the desired effect of the original logic.