### PR TITLE
Asking for grid $elm sizing in a digest loop always triggers `refresh`, not conditionally as designed.

### DIFF
--- a/src/features/auto-resize-grid/js/auto-resize.js
+++ b/src/features/auto-resize-grid/js/auto-resize.js
@@ -19,30 +19,35 @@
       require: 'uiGrid',
       scope: false,
       link: function($scope, $elm, $attrs, uiGridCtrl) {
-        var timeout = null;
+        var elementWidth,
+          elementHeight;
 
-        var debounce = function(width, height) {
-          if (timeout !== null) {
-            clearTimeout(timeout);
-          }
-          timeout = setTimeout(function() {
-            uiGridCtrl.grid.gridWidth = width;
-            uiGridCtrl.grid.gridHeight = height;
-            uiGridCtrl.grid.refresh();
-            timeout = null;
-          }, 400);
-        };
+        var updateWidth = gridUtil.throttle(function() {
+          elementWidth = gridUtil.elementWidth($elm);
+        }, 200);
+
+        var updateHeight = gridUtil.throttle(function() {
+          elementHeight = gridUtil.elementHeight($elm);
+        }, 200);
+
+        var refresh = gridUtil.throttle(function(width, height) {
+          uiGridCtrl.grid.gridWidth = width;
+          uiGridCtrl.grid.gridHeight = height;
+          uiGridCtrl.grid.refresh();
+        }, 300);
 
         $scope.$watchGroup([
           function() {
-            return gridUtil.elementWidth($elm);
+            updateWidth();
+            return elementWidth;
           },
           function() {
-            return gridUtil.elementHeight($elm);
+            updateHeight();
+            return elementHeight;
           }
         ], function(newValues, oldValues, scope) {
           if (!angular.equals(newValues, oldValues)) {
-            debounce(newValues[0], newValues[1]);
+            refresh(newValues[0], newValues[1]);
           }
         });
       }


### PR DESCRIPTION
We allow `elementWidth` and `elementHeight` call only once per 200ms to prevent from perf degradation.
This fixes #6561 and #6499.