### PR TITLE
Ensure that getting selected rows returns row entities, excluding the grouping entities

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -301,6 +301,8 @@
                 getSelectedRows: function () {
                   return service.getSelectedRows(grid).map(function (gridRow) {
                     return gridRow.entity;
+                  }).filter(function (entity) {
+                    return entity.hasOwnProperty('$$hashKey');
                   });
                 },
                 /**


### PR DESCRIPTION
The _getSelectedRows(grid)_ function in uiGridSelectionService returns all selected rows. However, the _getSelectedRows()_ function being registered into the grid api returns the selected row's entities.

Because grouping header entities are now also selected, this could lead to confusion. 

**getSelectedGridRows()** will return all selected rows -for  **grouping headers** + standard rows
**getSelectedRows()** will return selected row entities - for **standard rows only**