### PR TITLE
docs(201_editable.ngdoc): Fix typo in tutorial

### DIFF
--- a/misc/tutorial/201_editable.ngdoc
+++ b/misc/tutorial/201_editable.ngdoc
@@ -23,7 +23,7 @@ and `'boolean'` types, for all other fields a simple text editor is provided. (A
 to be enabled the datatype of the variable should also be "Date").
 
 A dropdown editor is also available, through setting the `editableCellTemplate` on the `columnDef` to `'ui-grid/dropdownEditor'`.
-When using a dropdown editor you need to provide an options array through the `editDropDownOptionsArray` property on the `columnDef`.
+When using a dropdown editor you need to provide an options array through the `editDropdownOptionsArray` property on the `columnDef`.
 This array by default should be an array of `{id: xxx, value: xxx}`, although the field tags can be changed through
 using the `editDropdownIdLabel` and `editDropdownValueLabel` options.
 


### PR DESCRIPTION
Change the capitalisation of the second d in editDropdownOptionsArray.

fix #5644