### PR TITLE
fix(menus): streamline menu positioning

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -139,7 +139,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
               $scope.shown = false;
               $scope.$emit('menu-hidden');
             }
-          }, 200);
+          }, 40);
         }
 
         angular.element(document).off('click touchstart', applyHideMenu);

--- a/src/less/header.less
+++ b/src/less/header.less
@@ -53,7 +53,6 @@
 
 .ui-grid-header-cell-row {
   display: table-row;
-  position: relative
 }
 
 .ui-grid-header-cell {
@@ -130,13 +129,8 @@
 
 /* Slide up/down animations */
 .ui-grid-column-menu .ui-grid-menu .ui-grid-menu-mid {
-  &.ng-hide-add {
+  &.ng-hide-add, &.ng-hide-remove {
     .transition(all, 0.04s, linear);
-    display: block !important;
-  }
-
-  &.ng-hide-remove {
-    .transition(all, 0.02s, linear);
     display: block !important;
   }
 
@@ -153,13 +147,8 @@
 
 /* Slide up/down animations */
 .ui-grid-menu-button .ui-grid-menu .ui-grid-menu-mid {
-  &.ng-hide-add {
+  &.ng-hide-add, &.ng-hide-remove {
     .transition(all, 0.04s, linear);
-    display: block !important;
-  }
-
-  &.ng-hide-remove {
-    .transition(all, 0.02s, linear);
     display: block !important;
   }
 

--- a/test/unit/core/directives/ui-grid-column-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-column-menu.spec.js
@@ -422,7 +422,7 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function() {
 		});
 
 		describe('repositionMenu: ', function() {
-			var column, left, positionData, renderContainerElm, $elm, $columnElement;
+			var column, left, positionData, renderContainerElm, $elm, $columnElement, myWidth;
 
 			beforeEach(function() {
 				column = {};
@@ -452,6 +452,8 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function() {
 				spyOn(gridUtil, 'closestElm').and.returnValue(renderContainerElm);
 				spyOn(gridUtil, 'elementWidth').and.returnValue(100);
 				spyOn(gridUtil, 'getStyles').and.returnValue({paddingRight: 30});
+
+				myWidth = gridUtil.elementWidth();
 			});
 			afterEach(function() {
 				gridUtil.closestElm.calls.reset();
@@ -497,7 +499,7 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function() {
 				});
 				it('should use the position data offset to calculate the left position of the element', function() {
 					uiGridColumnMenuService.repositionMenu($scope, column, positionData, $elm, $columnElement);
-					expect($elm.css).toHaveBeenCalledWith('left', positionData.offset + 'px');
+					expect($elm.css).toHaveBeenCalledWith('left', positionData.offset + myWidth + 'px');
 				});
 			});
 			describe('when ui-grid-menu-mid is defined and visible', function() {


### PR DESCRIPTION
Current behavior: https://plnkr.co/edit/kwyglaa2w9DxDmHtKt1Z?p=preview

Open the column menu for the first column.

New behavior: https://plnkr.co/edit/a2fLMi79c1W1WgKLxG82?p=preview

Menu width calculation was removed in #6588. Menu width needs to be calculated in order to properly position the menu (if there is not enough room to the left of the column). repositionMenu is now always called in the 'menu-shown' event listener to ensure the width can be properly calculated. Sorry I didn't catch this earlier.

The style attribute is removed from $elm in the 'menu-hidden' event listener to prevent the menu from appearing to slide from the left or right when opening another column menu while one is already open.

Menu animation speed was changed in #6588 to have different add/remove speeds. 0.04s has been chosen as a happy medium, and the $timeout duration has been changed to reflect the new transition duration (to reduce delay when hiding the menu).

`position: relative` has been removed from .ui-grid-header-cell-row to ensure consistent calculation of offsetParent across browsers.

Fixes #5396, #5990, #6085.