### PR TITLE
fix(utils.js): Remove IE9 from supported browsers list.

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -102,13 +102,6 @@ var util = module.exports = {
         platform: 'Mac 10.12',
         version: '11'
       },
-      'SL_IE_9': {
-        base: 'SauceLabs',
-        browserName: 'internet explorer',
-        platform: 'Windows 7',
-        version: '9',
-        'X-UA-Compatible': 'IE=edge,chrome=1'
-      },
       'SL_IE_10': {
         base: 'SauceLabs',
         browserName: 'internet explorer',


### PR DESCRIPTION
Since this browser is frequently the one that gives us issues for new changes and we are moving
towards angular 5 support, I am dropping it from our supported list.

BREAKING CHANGE: IE9 is no longer officially supported.

Closes #2273, #2552, #3593, #3854, #4439