### PR TITLE
feat(i18n): Separate language files from ui-grid.base.js

### DIFF
--- a/grunt/concat.js
+++ b/grunt/concat.js
@@ -2,16 +2,27 @@ const fs = require('fs');
 const path = require('path');
 
 const getDirectories = p => fs.readdirSync(p).filter(f => fs.statSync(path.join(p, f)).isDirectory());
+const getLanguages = p => fs.readdirSync(p).filter(f => fs.statSync(path.join(p, f)).isFile());
 
 function getFiles() {
 	const files = {
 		'<%= dist %>/release/<%= pkg.name %>.js': ['src/js/core/bootstrap.js', 'src/js/**/*.js', 'src/features/*/js/**/*.js', '.tmp/template.js'],
-		'<%= dist %>/release/<%= pkg.name %>.base.js': ['src/js/core/bootstrap.js', 'src/js/**/*.js', '.tmp/template.js']
+		'<%= dist %>/release/<%= pkg.name %>.base.js': ['src/js/core/bootstrap.js', 'src/js/core/**/*.js', 'src/js/i18n/ui-18n.js',
+			'src/js/i18n/en.js', '.tmp/template.js']
 	};
 	const features = getDirectories('src/features/');
 
 	features.forEach((feat) => {
-		files[`<%= dist %>/release/<%= pkg.name %>.${feat}.js`] = [`src/features/${feat}/js/**/*.js`]
+		files[`<%= dist %>/release/<%= pkg.name %>.${feat}.js`] = [`src/features/${feat}/js/**/*.js`];
+	});
+
+	const languages = getLanguages('src/js/i18n/')
+		.filter((lang) => lang !== 'en.js' && lang !== 'ui-i18n.js');
+
+	files['<%= dist %>/release/i18n/<%= pkg.name %>.language.all.js'] = languages.map((lang) => `src/js/i18n/${lang}`);
+
+	languages.forEach((lang) => {
+		files[`<%= dist %>/release/i18n/<%= pkg.name %>.language.${lang}`] = [`src/js/i18n/${lang}`];
 	});
 
 	return files;

--- a/misc/tutorial/104_i18n.ngdoc
+++ b/misc/tutorial/104_i18n.ngdoc
@@ -19,6 +19,15 @@ Another option is to use the i18nService and use the setCurrentLang method
 
 For an example using angular-translate to translate your headers, refer to http://plnkr.co/edit/KnrKTst5dWXvlZNeIy9c?p=preview
 
+If you would like to get better performance out of your application, it is recommended that you take advantage of UI-Grid's multi-file
+support. By default ui-grid.base.js will contain just the english language, in order to load the other language follow the example bellow:
+<pre>
+   <script src="/release/ui-grid.base.js"></script>
+   <script src="/release/i18n/ui-grid.language.[YOUR_LANGUAGE_HERE].js"></script>
+
+   <!-- Alternatively you can load all languages provided with you grid by loading the following -->
+   <script src="/release/i18n/ui-grid.language.all.js"></script>
+</pre>
 
 @example
 <example module="app">


### PR DESCRIPTION
Improving load performance of ui-grid.base.js by separating out the language files(with the
exception of english, as that is the default language of the grid).