### PR TITLE
fix(GridColumn): Respect minimumColumnSize when a valid minWidth isn't present

### DIFF
--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -262,7 +262,8 @@ angular.module('ui.grid')
    * @ngdoc property
    * @name minWidth
    * @propertyOf ui.grid.class:GridOptions.columnDef
-   * @description sets the minimum column width.  Should be a number.
+   * @description Sets the minimum column width.  Should be a number.
+   * Defaults to gridOptions.minimumColumnSize if minWidth is not provided.
    * @example
    * <pre>  $scope.gridOptions.columnDefs = [ { field: 'field1', minWidth: 100}]; </pre>
    *
@@ -502,12 +503,21 @@ angular.module('ui.grid')
       }
     }
 
+    function isValidWidthValue(value) {
+      return angular.isString(value) || angular.isNumber(value);
+    }
+
     ['minWidth', 'maxWidth'].forEach(function (name) {
       var minOrMaxWidth = colDef[name];
       var parseErrorMsg = "Cannot parse column " + name + " '" + minOrMaxWidth + "' for column named '" + colDef.name + "'";
 
-      if (!angular.isString(minOrMaxWidth) && !angular.isNumber(minOrMaxWidth)) {
-        //Sets default minWidth and maxWidth values
+      // default minWidth to the minimumColumnSize
+      if (name === 'minWidth' && !isValidWidthValue(minOrMaxWidth) && angular.isDefined(self.grid.options.minimumColumnSize)) {
+        minOrMaxWidth = self.grid.options.minimumColumnSize;
+      }
+
+      if (!isValidWidthValue(minOrMaxWidth)) {
+        // Sets default minWidth and maxWidth values
         self[name] = ((name === 'minWidth') ? 30 : 9000);
       } else if (angular.isString(minOrMaxWidth)) {
         if (minOrMaxWidth.match(/^(\d+)$/)) {
@@ -871,13 +881,13 @@ angular.module('ui.grid')
   GridColumn.prototype.unsort = function () {
     //Decrease priority for every col where priority is higher than the removed sort's priority.
     var thisPriority = this.sort.priority;
-    
+
     this.grid.columns.forEach(function (col) {
       if (col.sort && col.sort.priority !== undefined && col.sort.priority > thisPriority) {
         col.sort.priority -= 1;
       }
     });
-    
+
     this.sort = {};
     this.grid.api.core.raise.sortChanged( this.grid, this.grid.getColumnSorting() );
   };

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -438,9 +438,11 @@ angular.module('ui.grid')
        * @ngdoc boolean
        * @name minimumColumnSize
        * @propertyOf ui.grid.class:GridOptions
-       * @description Columns can't be smaller than this, defaults to 10 pixels
+       * @description Sets the default minimum column width, in other words,
+       * it defines the default value for a column minWidth attribute if that is not otherwise specified.
+       * Should be a number. Defaults to 30 pixels.
        */
-      baseOptions.minimumColumnSize = typeof(baseOptions.minimumColumnSize) !== "undefined" ? baseOptions.minimumColumnSize : 10;
+      baseOptions.minimumColumnSize = typeof(baseOptions.minimumColumnSize) !== "undefined" ? baseOptions.minimumColumnSize : 30;
 
       /**
        * @ngdoc function

--- a/test/unit/core/factories/GridColumn.spec.js
+++ b/test/unit/core/factories/GridColumn.spec.js
@@ -562,9 +562,23 @@ describe('GridColumn factory', function () {
       expect(updateCol(colDef.width)).toThrow();
     });
 
-    it ('should set the value of minWidth to 30 when colDef.minWidth is undefined', invalidMinOrMaxWidthDef(undefined, 'minWidth'));
-    it ('should set the value of minWidth to 30 when colDef.minWidth is null', invalidMinOrMaxWidthDef(null, 'minWidth'));
-    it ('should set the value of minWidth to 30 when colDef.minWidth is an object', invalidMinOrMaxWidthDef({}, 'minWidth'));
+    it ('should set the value of minWidth to 30 when colDef.minWidth and options.minimumColumnSize are undefined', invalidMinOrMaxWidthDef(undefined, 'minWidth'));
+    it ('should set the value of minWidth to 30 when colDef.minWidth and options.minimumColumnSize are null', invalidMinOrMaxWidthDef(null, 'minWidth'));
+    it ('should set the value of minWidth to 30 when colDef.minWidth and options.minimumColumnSize are an object', invalidMinOrMaxWidthDef({}, 'minWidth'));
+
+    describe('when options.minimumColumnSize is valid', function() {
+      function validMinimumColumnSize(colSize, colMinWidth) {
+        return function() {
+          col.grid.options.minimumColumnSize = colSize;
+          colDef.minWidth = colMinWidth;
+          col.updateColumnDef(colDef);
+          expect(col.minWidth).toBe(parseInt(grid.options.minimumColumnSize));
+        };
+      }
+      it ('should set the value of minWidth to options.minimumColumnSize when colDef.minWidth is undefined', validMinimumColumnSize(50, undefined));
+      it ('should set the value of minWidth to options.minimumColumnSize when colDef.minWidth is null', validMinimumColumnSize('60', null));
+      it ('should set the value of minWidth to options.minimumColumnSize when colDef.minWidth is an object', validMinimumColumnSize(70, {}));
+    });
 
     it ('should set the value of minWidth to the parsed integer colDef.minWidth when it is a string', function () {
       colDef.minWidth = '90';
@@ -632,6 +646,7 @@ describe('GridColumn factory', function () {
 
     function invalidMinOrMaxWidthDef(width, minOrMax) {
       return function () {
+        col.grid.options.minimumColumnSize = width;
         colDef[minOrMax] = width;
         col.updateColumnDef(colDef);
         expect(col[minOrMax]).toBe(minOrMax === 'minWidth' ? 30 : 9000);

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -45,7 +45,7 @@ describe('GridOptions factory', function () {
         enableVerticalScrollbar: 1,
         enableHorizontalScrollbar: 1,
         enableMinHeightCheck: true,
-        minimumColumnSize: 10,
+        minimumColumnSize: 30,
         rowEquality: jasmine.any(Function),
         headerTemplate: null,
         footerTemplate: 'ui-grid/ui-grid-footer',
@@ -238,4 +238,3 @@ describe('GridOptions factory', function () {
     });
   });
 });
-


### PR DESCRIPTION
GridOptions.minimumColumnSize is now used as the default minWidth for all columns when it is
provided and it is valid. However, minWidth will still take precedence over minimumColumnSize if
provided.

fix #3941