### PR TITLE
fix(Grid.js): Select All button should be disabled when no data is present.

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1180,7 +1180,7 @@ angular.module('ui.grid')
       }
     });
 
-    if (self.selection) {
+    if (self.selection && self.rows.length) {
       self.selection.selectAll = allRowsSelected;
     }
 

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -530,6 +530,39 @@ describe('Grid factory', function () {
     });
   });
 
+  describe('selection', function() {
+    var grid;
+
+    beforeEach(function() {
+      grid = new Grid({ id: 1, enableRowHashing: false });
+      spyOn(grid, 'getRow').and.callFake(function(newEntity) {
+        return newEntity;
+      });
+
+      grid.rows = [];
+      grid.selection = {selectAll: false};
+    });
+    afterEach(function() {
+      grid.getRow.calls.reset();
+    });
+
+    it('should enable selectAll if a new row is added that is already selected', function() {
+      grid.modifyRows([{isSelected: true}]);
+
+      expect(grid.selection.selectAll).toBe(true);
+    });
+    it('should disable selectAll if a new row is added that is not selected', function() {
+      grid.modifyRows([{isSelected: false}]);
+
+      expect(grid.selection.selectAll).toBe(false);
+    });
+    it('should not update selectAll if there are no rows', function() {
+      grid.modifyRows([]);
+
+      expect(grid.selection.selectAll).toBe(false);
+    });
+  });
+
   describe('follow source array', function() {
     var dataRows, grid;
 


### PR DESCRIPTION
Ensuring Select All button is disabled by default when no data is present.

fix #6582