### PR TITLE
fix(selection): SelectAllRows pays attention to isRowSelectable function

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -235,19 +235,17 @@
                  * @param {Event} evt object if raised from an event
                  */
                 selectAllRows: function (evt) {
-                  if (grid.options.multiSelect === false) {
-                    return;
+                  if (grid.options.multiSelect !== false) {
+                    var changedRows = [];
+                    grid.rows.forEach(function (row) {
+                      if (!row.isSelected && row.enableSelection !== false && grid.options.isRowSelectable(row) !== false) {
+                        row.setSelected(true);
+                        service.decideRaiseSelectionEvent(grid, row, changedRows, evt);
+                      }
+                    });
+                    service.decideRaiseSelectionBatchEvent(grid, changedRows, evt);
+                    grid.selection.selectAll = true;
                   }
-
-                  var changedRows = [];
-                  grid.rows.forEach(function (row) {
-                    if (!row.isSelected && row.enableSelection !== false) {
-                      row.setSelected(true);
-                      service.decideRaiseSelectionEvent(grid, row, changedRows, evt);
-                    }
-                  });
-                  service.decideRaiseSelectionBatchEvent(grid, changedRows, evt);
-                  grid.selection.selectAll = true;
                 },
                 /**
                  * @ngdoc function
@@ -261,7 +259,7 @@
                     var changedRows = [];
                     grid.rows.forEach(function(row) {
                       if (row.visible) {
-                        if (!row.isSelected && row.enableSelection !== false) {
+                        if (!row.isSelected && row.enableSelection !== false && grid.options.isRowSelectable(row) !== false) {
                           row.setSelected(true);
                           service.decideRaiseSelectionEvent(grid, row, changedRows, evt);
                         }

--- a/src/features/selection/test/uiGridSelectionService.spec.js
+++ b/src/features/selection/test/uiGridSelectionService.spec.js
@@ -223,8 +223,14 @@ describe('ui.grid.selection uiGridSelectionService', function () {
       }
       expect(grid.selection.selectAll).toBe(false);
 
+      grid.options.isRowSelectable = function(row) {
+        return row.isRowSelectable !== false;
+      };
+
+      grid.rows[6].isRowSelectable = false;
       grid.rows[8].enableSelection = false;
       grid.api.selection.selectAllRows();
+      expect(grid.rows[6].isSelected).toBe(false);
       expect(grid.rows[7].isSelected).toBe(true);
       expect(grid.rows[8].isSelected).toBe(false);
     });
@@ -244,7 +250,7 @@ describe('ui.grid.selection uiGridSelectionService', function () {
   });
 
   describe('selectAllVisibleRows function', function() {
-    it('should select all visible rows', function () {
+    it('should select all visible and selectable rows', function () {
       grid.api.selection.selectRow(grid.rows[4].entity);
       expect(grid.rows[4].isSelected).toBe(true);
 
@@ -252,10 +258,14 @@ describe('ui.grid.selection uiGridSelectionService', function () {
       expect(grid.rows[4].isSelected).toBe(true);
       expect(grid.rows[6].isSelected).toBe(true);
 
+      grid.options.isRowSelectable = function(row) {
+        return row.isRowSelectable !== false;
+      };
       grid.rows[3].visible = true;
       grid.rows[4].visible = true;
       grid.rows[6].visible = false;
       grid.rows[7].visible = true;
+      grid.rows[7].isRowSelectable = false;
       grid.rows[8].enableSelection = false;
       grid.rows[9].visible = true;
       expect(grid.selection.selectAll).toBe(false);
@@ -264,11 +274,11 @@ describe('ui.grid.selection uiGridSelectionService', function () {
       expect(grid.rows[3].isSelected).toBe(true);
       expect(grid.rows[4].isSelected).toBe(true);
       expect(grid.rows[6].isSelected).toBe(false);
-      expect(grid.rows[7].isSelected).toBe(true);
+      expect(grid.rows[7].isSelected).toBe(false);
       expect(grid.rows[8].isSelected).toBe(false);
       expect(grid.rows[9].isSelected).toBe(true);
       expect(grid.selection.selectAll).toBe(true);
-      expect(grid.selection.selectedCount).toBe(8);
+      expect(grid.selection.selectedCount).toBe(7);
     });
   });
 


### PR DESCRIPTION
Added a check to verify if rows are selectable prior to selecting them.

fix #6370