### PR TITLE
fix(footer.less): Empty footer cells now take the full available height.

### DIFF
--- a/src/less/footer.less
+++ b/src/less/footer.less
@@ -24,6 +24,14 @@
   width: 100%;
 }
 
+.ui-grid-footer-viewport,
+.ui-grid-footer-canvas {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  height: 100%;
+}
+
 .ui-grid-footer-viewport {
   overflow: hidden; // Disable so menus show up
 }


### PR DESCRIPTION
fix #3416