### PR TITLE
fix(ui-grid.js): Ignore scrollbar height prior to checking if autoAdj…

### DIFF
--- a/src/js/core/directives/ui-grid.js
+++ b/src/js/core/directives/ui-grid.js
@@ -280,7 +280,7 @@ function uiGridDirective($window, gridUtil, uiGridConstants) {
             grid.gridHeight = $scope.gridHeight = gridUtil.elementHeight($elm);
 
             // If the grid isn't tall enough to fit a single row, it's kind of useless. Resize it to fit a minimum number of rows
-            if (grid.gridHeight <= grid.options.rowHeight && grid.options.enableMinHeightCheck) {
+            if (grid.gridHeight - grid.scrollbarHeight <= grid.options.rowHeight && grid.options.enableMinHeightCheck) {
               autoAdjustHeight();
             }
 


### PR DESCRIPTION
…ustHeight is needed.

Subtract scrollbar height from grid height during the check for whether or not the grid is tall
enough to fit a single row.

fix #5231