### PR TITLE
fix(Grid.js): ScrollIfNecessary will not scroll if percentage hasn't changed

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2347,6 +2347,29 @@ angular.module('ui.grid')
       return percentage <= 1 ? percentage : 1;
     }
 
+    // Only returns the scroll Y position if the percentage is different from the previous
+    function getScrollY(scrollPixels, scrollLength, prevScrolltopPercentage) {
+      var scrollPercentage = getScrollPercentage(scrollPixels, scrollLength);
+
+      if (scrollPercentage !== prevScrolltopPercentage) {
+        return { percentage: getScrollPercentage(scrollPixels, scrollLength) };
+      }
+
+      return undefined;
+    }
+
+    // Only returns the scroll X position if the percentage is different from the previous
+    function getScrollX(horizScrollPixels, horizScrollLength, prevScrollleftPercentage) {
+      var horizPercentage = horizScrollPixels / horizScrollLength;
+      horizPercentage = (horizPercentage > 1) ? 1 : horizPercentage;
+
+      if (horizPercentage !== prevScrollleftPercentage) {
+        return { percentage: horizPercentage  };
+      }
+
+      return undefined;
+    }
+
     /**
      * @ngdoc method
      * @methodOf  ui.grid.class:Grid
@@ -2421,7 +2444,7 @@ angular.module('ui.grid')
           //   to get the full position we need
           scrollPixels = self.renderContainers.body.prevScrollTop - (topBound - pixelsToSeeRow);
 
-          scrollEvent.y = { percentage: getScrollPercentage(scrollPixels, scrollLength) };
+          scrollEvent.y = getScrollY(scrollPixels, scrollLength, self.renderContainers.body.prevScrolltopPercentage);
         }
         // Otherwise if the scroll position we need to see the row is MORE than the bottom boundary, i.e. obscured below the bottom of the self...
         else if (pixelsToSeeRow > bottomBound) {
@@ -2429,7 +2452,7 @@ angular.module('ui.grid')
           //   to get the full position we need
           scrollPixels = pixelsToSeeRow - bottomBound + self.renderContainers.body.prevScrollTop;
 
-          scrollEvent.y = { percentage: getScrollPercentage(scrollPixels, scrollLength) };
+          scrollEvent.y = getScrollY(scrollPixels, scrollLength,self.renderContainers.body.prevScrolltopPercentage);
         }
       }
 
@@ -2454,7 +2477,7 @@ angular.module('ui.grid')
         // Don't let the pixels required to see the column be less than zero
         columnRightEdge = (columnRightEdge < 0) ? 0 : columnRightEdge;
 
-        var horizScrollPixels, horizPercentage;
+        var horizScrollPixels;
 
         // If the scroll position we need to see the column is LESS than the left boundary, i.e. obscured before the left of the self...
         if (columnLeftEdge < leftBound) {
@@ -2463,9 +2486,7 @@ angular.module('ui.grid')
           horizScrollPixels = self.renderContainers.body.prevScrollLeft - (leftBound - columnLeftEdge);
 
           // Turn the scroll position into a percentage and make it an argument for a scroll event
-          horizPercentage = horizScrollPixels / horizScrollLength;
-          horizPercentage = (horizPercentage > 1) ? 1 : horizPercentage;
-          scrollEvent.x = { percentage: horizPercentage  };
+          scrollEvent.x = getScrollX(horizScrollPixels, horizScrollLength, self.renderContainers.body.prevScrollleftPercentage);
         }
         // Otherwise if the scroll position we need to see the column is MORE than the right boundary, i.e. obscured after the right of the self...
         else if (columnRightEdge > rightBound) {
@@ -2474,9 +2495,7 @@ angular.module('ui.grid')
           horizScrollPixels = columnRightEdge - rightBound + self.renderContainers.body.prevScrollLeft;
 
           // Turn the scroll position into a percentage and make it an argument for a scroll event
-          horizPercentage = horizScrollPixels / horizScrollLength;
-          horizPercentage = (horizPercentage > 1) ? 1 : horizPercentage;
-          scrollEvent.x = { percentage: horizPercentage  };
+          scrollEvent.x = getScrollX(horizScrollPixels, horizScrollLength, self.renderContainers.body.prevScrollleftPercentage);
         }
       }
 


### PR DESCRIPTION
Doing this will prevent us from getting stuck in an infinite loop of triggering the scrollEnd event.

fix #6653, fix #4221