### PR TITLE
fix(Grid.js): ScrollIfNecessary determines top boundary wrong

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2392,7 +2392,8 @@ angular.module('ui.grid')
       /*-- Get the top, left, right, and bottom "scrolled" edges of the grid --*/
 
       // The top boundary is the current Y scroll position PLUS the header height, because the header can obscure rows when the grid is scrolled downwards
-      var topBound = self.renderContainers.body.prevScrollTop + self.headerHeight;
+      // var topBound = self.renderContainers.body.prevScrollTop + self.headerHeight;
+      var topBound = self.renderContainers.body.prevScrollTop;
 
       // Don't the let top boundary be less than 0
       topBound = (topBound < 0) ? 0 : topBound;


### PR DESCRIPTION
Adding headerHeight to topBoundary calculation makes it always larger than pixelsToSeeRow causing an infinite loop.

fixes #6653 