### PR TITLE
fix(Export): Eliminate selection column. Add export scale factor for …

### DIFF
--- a/misc/tutorial/410_excel_exporting_data_and_header.ngdoc
+++ b/misc/tutorial/410_excel_exporting_data_and_header.ngdoc
@@ -39,12 +39,6 @@ Additionally, information about the Excel Builder may be found at https://github
 
 If the example below we show how to make a custom header based on a callback method and
 
-For better performance with the following example, you can choose to load the ui-grid.core.js and specific feature files instead:
-<pre>
-  <script src="/release/ui-grid.core.min.js"></script>
-  <script src="/release/ui-grid.exporter.min.js"></script>
-  <script src="/release/ui-grid.selection.min.js"></script>
-</pre>
 
 @example
 In this example we use the native grid menu buttons, and we show the pdf, csv and excel export options.
@@ -180,6 +174,7 @@ In this example we use the native grid menu buttons, and we show the pdf, csv an
            return null;
          }
         },
+        exporterColumnScaleFactor: 4.5,
         exporterFieldApplyFilters: true,
         onRegisterApi: function(gridApi){
           $scope.gridApi = gridApi;

--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -62,13 +62,13 @@
   module.constant('uiGridExporterConstants', {
     featureName: 'exporter',
     rowHeaderColName: 'treeBaseRowHeaderCol',
+    selectionRowHeaderColName: 'selectionRowHeaderCol',
     ALL: 'all',
     VISIBLE: 'visible',
     SELECTED: 'selected',
     CSV_CONTENT: 'CSV_CONTENT',
     BUTTON_LABEL: 'BUTTON_LABEL',
-    FILE_NAME: 'FILE_NAME',
-    PIXEL_PER_UNIT: 75
+    FILE_NAME: 'FILE_NAME'
   });
 
   /**
@@ -559,6 +559,18 @@
            * </pre>
            */
           gridOptions.exporterFieldFormatCallback = gridOptions.exporterFieldFormatCallback ? gridOptions.exporterFieldFormatCallback : function( grid, row, col, value ) { return null; };
+
+          /**
+           * @ngdoc object
+           * @name exporterColumnScaleFactor
+           * @propertyOf  ui.grid.exporter.api:GridOptions
+           * @description A scaling factor to divide the drawnwidth of a column to convert to target excel column
+           * format size
+           * @example
+           * In this example we add a number to divide the drawnwidth of a column to get the excel width.
+           * <br/>Defaults to 3.5
+           */
+          gridOptions.exporterColumnScaleFactor = gridOptions.exporterColumnScaleFactor ? gridOptions.exporterColumnScaleFactor : 3.5;
 
           /**
            * @ngdoc object
@@ -1537,8 +1549,10 @@
             var colWidths = [];
             var startDataIndex = grid.treeBase ? grid.treeBase.numberLevels : (grid.enableRowSelection ? 1 : 0);
             for (var i = startDataIndex; i < grid.columns.length; i++) {
-              if (grid.columns[i].field !== uiGridExporterConstants.rowHeaderColName) {
-                colWidths.push({width: (grid.columns[i].drawnWidth / uiGridExporterConstants.PIXEL_PER_UNIT) * 10});
+              if (grid.columns[i].field !== uiGridExporterConstants.rowHeaderColName &&
+                grid.columns[i].field !== uiGridExporterConstants.selectionRowHeaderColName) {
+
+                colWidths.push({width: (grid.columns[i].drawnWidth / grid.options.exporterColumnScaleFactor)});
               }
             }
             sheet.setColumns(colWidths);
@@ -1555,7 +1569,8 @@
             sheet.setData(sheet.data.concat(excelContent));
 
             ExcelBuilder.Builder.createFile(workbook, {type:"blob"}).then(function(result) {
-              self.downloadFile (grid.options.exporterExcelFilename, result, grid.options.exporterCsvColumnSeparator, grid.options.exporterOlderExcelCompatibility);
+              self.downloadFile (grid.options.exporterExcelFilename, result, grid.options.exporterCsvColumnSeparator,
+                grid.options.exporterOlderExcelCompatibility);
             });
 
           });

--- a/src/features/exporter/test/exporter.spec.js
+++ b/src/features/exporter/test/exporter.spec.js
@@ -122,6 +122,50 @@ describe('ui.grid.exporter', function() {
         options = {};
       });
 
+      it('set all options to default', function () {
+        uiGridExporterService.defaultGridOptions(options);
+        expect(options).toEqual({
+          exporterSuppressMenu: false,
+          exporterMenuLabel: 'Export',
+          exporterCsvColumnSeparator: ',',
+          exporterCsvFilename: 'download.csv',
+          exporterPdfFilename: 'download.pdf',
+          exporterOlderExcelCompatibility: false,
+          exporterIsExcelCompatible: false,
+          exporterPdfDefaultStyle: {fontSize: 11},
+          exporterPdfTableStyle: {margin: [0, 5, 0, 15]},
+          exporterPdfTableHeaderStyle: {bold: true, fontSize: 12, color: 'black'},
+          exporterPdfHeader: null,
+          exporterPdfFooter: null,
+          exporterPdfOrientation: 'landscape',
+          exporterPdfPageSize: 'A4',
+          exporterPdfMaxGridWidth: 720,
+          exporterPdfCustomFormatter: jasmine.any(Function),
+          exporterHeaderFilterUseName: false,
+          exporterMenuAllData: true,
+          exporterMenuVisibleData: true,
+          exporterMenuSelectedData: true,
+          exporterMenuCsv: true,
+          exporterMenuPdf: true,
+          exporterMenuExcel: true,
+          exporterFieldCallback: jasmine.any(Function),
+          exporterFieldFormatCallback: jasmine.any(Function),
+          exporterFieldApplyFilters: false,
+          exporterAllDataFn: null,
+          exporterSuppressColumns: [],
+          exporterColumnScaleFactor: 3.5,
+          exporterMenuItemOrder: 200
+        });
+      });
+    });
+
+    describe('defaultGridOptions', function() {
+      var options;
+
+      beforeEach(function() {
+        options = {};
+      });
+
       it('should set all options to default', function() {
         uiGridExporterService.defaultGridOptions(options);
         expect(options).toEqual({
@@ -153,6 +197,7 @@ describe('ui.grid.exporter', function() {
           exporterFieldApplyFilters: false,
           exporterAllDataFn: null,
           exporterSuppressColumns: [],
+          exporterColumnScaleFactor: 3.5,
           exporterMenuItemOrder: 200
         });
       });
@@ -194,6 +239,7 @@ describe('ui.grid.exporter', function() {
           exporterExcelSheetName: 'Sheet1',
           exporterExcelHeader: 'My Header',
           exporterExcelFooter: 'My Footer',
+          exporterColumnScaleFactor: 3.5,
           exporterMenuItemOrder: 75
         };
         uiGridExporterService.defaultGridOptions(options);
@@ -231,6 +277,7 @@ describe('ui.grid.exporter', function() {
           exporterExcelSheetName: 'Sheet1',
           exporterExcelHeader: 'My Header',
           exporterExcelFooter: 'My Footer',
+          exporterColumnScaleFactor: 3.5,
           exporterMenuItemOrder: 75,
           exporterAllDataFn: callback
         });


### PR DESCRIPTION
…excel and fonts

This will fix when a selection column is present vs a tree selection column and not put the drawnwidth column into an array of column definitions for exporting resulting in all columns being the wrong size.

It also introduces a scaling factor used for excel to scale the width for fonts or implementation specific exports.

@mportuga  - I think there is a bug in your change to defaultExporterFieldCallback on 4/5/18. The issue is that when you have a cellFilter like 'cellFilter: currency' the raw data is converted in line 984 using the cellFilter. So, in this case the data goes from 100 to '$100'. It then goes through the exporterFieldFormatCallback and applies the filter for a second time. '$100' | currency become an empty string resulting in all empties in the export. I think you need to review that check in as it broke our code