### PR TITLE
 Fix(cellnav.js), do not trigger edit on undefined event

### DIFF
--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -547,7 +547,7 @@
 
             // Broadcast the navigation
             if (gridRow !== null && gridCol !== null) {
-              grid.cellNav.broadcastCellNav(rowCol);
+              grid.cellNav.broadcastCellNav(rowCol, null, null);
             }
           });
 

--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -536,7 +536,7 @@
                   if ($scope.col.colDef.enableCellEditOnFocus) {
                     // Don't begin edit if the cell hasn't changed
                     if (newRowCol.row === $scope.row && newRowCol.col === $scope.col &&
-                      (!evt || (evt && (evt.type === 'click' || evt.type === 'keydown')))) {
+                      (evt === null || (evt && (evt.type === 'click' || evt.type === 'keydown')))) {
                       $timeout(function() {
                         beginEdit(evt);
                       });

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2444,6 +2444,11 @@ angular.module('ui.grid')
           //   to get the full position we need
           scrollPixels = self.renderContainers.body.prevScrollTop - (topBound - pixelsToSeeRow);
 
+          //Since scrollIfNecessary is called multiple times when enableCellEditOnFocus is true we need to make sure the scrollbarWidth and footerHeight is accounted for to not cause a loop.
+          if (gridCol.colDef.enableCellEditOnFocus === true) {
+            scrollPixels = scrollPixels - self.footerHeight - self.scrollbarWidth;
+          }
+
           scrollEvent.y = getScrollY(scrollPixels, scrollLength, self.renderContainers.body.prevScrolltopPercentage);
         }
         // Otherwise if the scroll position we need to see the row is MORE than the bottom boundary, i.e. obscured below the bottom of the self...

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2402,7 +2402,7 @@ angular.module('ui.grid')
 
       // The bottom boundary is the current Y scroll position, plus the height of the grid, but minus the header height.
       //   Basically this is the viewport height added on to the scroll position
-      var bottomBound = self.renderContainers.body.prevScrollTop + self.gridHeight - self.renderContainers.body.headerHeight - self.footerHeight -  self.scrollbarWidth;
+      var bottomBound = self.renderContainers.body.prevScrollTop + self.gridHeight - self.renderContainers.body.headerHeight - self.footerHeight -  self.scrollbarHeight;
 
       // If there's a horizontal scrollbar, remove its height from the bottom boundary, otherwise we'll be letting it obscure rows
       //if (self.horizontalScrollbarHeight) {
@@ -2439,20 +2439,20 @@ angular.module('ui.grid')
         var scrollPixels;
 
         // If the scroll position we need to see the row is LESS than the top boundary, i.e. obscured above the top of the self...
-        if (pixelsToSeeRow < topBound) {
+        if (pixelsToSeeRow < Math.floor(topBound)) {
           // Get the different between the top boundary and the required scroll position and subtract it from the current scroll position\
           //   to get the full position we need
           scrollPixels = self.renderContainers.body.prevScrollTop - (topBound - pixelsToSeeRow);
 
           //Since scrollIfNecessary is called multiple times when enableCellEditOnFocus is true we need to make sure the scrollbarWidth and footerHeight is accounted for to not cause a loop.
           if (gridCol && gridCol.colDef && gridCol.colDef.enableCellEditOnFocus) {
-            scrollPixels = scrollPixels - self.footerHeight - self.scrollbarWidth;
+            scrollPixels = scrollPixels - self.footerHeight - self.scrollbarHeight;
           }
 
           scrollEvent.y = getScrollY(scrollPixels, scrollLength, self.renderContainers.body.prevScrolltopPercentage);
         }
         // Otherwise if the scroll position we need to see the row is MORE than the bottom boundary, i.e. obscured below the bottom of the self...
-        else if (pixelsToSeeRow > bottomBound) {
+        else if (pixelsToSeeRow > Math.ceil(bottomBound)) {
           // Get the different between the bottom boundary and the required scroll position and add it to the current scroll position
           //   to get the full position we need
           scrollPixels = pixelsToSeeRow - bottomBound + self.renderContainers.body.prevScrollTop;

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -2445,7 +2445,7 @@ angular.module('ui.grid')
           scrollPixels = self.renderContainers.body.prevScrollTop - (topBound - pixelsToSeeRow);
 
           //Since scrollIfNecessary is called multiple times when enableCellEditOnFocus is true we need to make sure the scrollbarWidth and footerHeight is accounted for to not cause a loop.
-          if (gridCol.colDef.enableCellEditOnFocus === true) {
+          if (gridCol && gridCol.colDef && gridCol.colDef.enableCellEditOnFocus) {
             scrollPixels = scrollPixels - self.footerHeight - self.scrollbarWidth;
           }
 


### PR DESCRIPTION
Do not trigger a cell edit when the event is undefined, if needed through API pass a null object instead.

Fixes: #6591 