### PR TITLE
fix(tree-base.js): Call updateRowHeaderWidth even when no data exists.

### DIFF
--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -984,11 +984,12 @@
        * @returns {array} the updated rows
        */
       treeRows: function( renderableRows ) {
-        if (renderableRows.length === 0){
+        var grid = this;
+
+        if (renderableRows.length === 0) {
+          service.updateRowHeaderWidth( grid );
           return renderableRows;
         }
-
-        var grid = this;
 
         grid.treeBase.tree = service.createTree( grid, renderableRows );
         service.updateRowHeaderWidth( grid );


### PR DESCRIPTION
Ensure row header visiblity is respected when no data is present.

fix #5430