### PR TITLE
fix(tree-base.js) Allow treeIndent to be 0

### DIFF
--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -456,7 +456,7 @@
          *  but will make the tree row header wider
          *  <br/>Defaults to 10
          */
-        gridOptions.treeIndent = gridOptions.treeIndent || 10;
+        gridOptions.treeIndent = (gridOptions.treeIndent != null) ? gridOptions.treeIndent : 10;
 
         /**
          *  @ngdoc object


### PR DESCRIPTION
Fixes: #5114