### PR TITLE
Update ui-i18n.js

### DIFF
--- a/src/js/i18n/ui-i18n.js
+++ b/src/js/i18n/ui-i18n.js
@@ -61,7 +61,7 @@
           if (!this._langs[lower]) {
             this._langs[lower] = {};
           }
-          angular.extend(this._langs[lower], strings);
+          angular.merge(this._langs[lower], strings);
         },
         getAllLangs: function () {
           var langs = [];


### PR DESCRIPTION
Use `merge()` instead of `extend()`. Extending *replaces the entire existing object* with the new one. Merging will add new strings *into existing objects*, thereby preserving any strings that have been defined/set previously. 

This change allows replacing/customizing *specific* existing locale strings, as show in following example where *only* the export menu labels are changed in the `gridMenu` string map:

	i18nService.add('en', {
	    gridMenu: {
	        exporterAllAsCsv: 'Export raw dataset as csv',
	        exporterVisibleAsCsv: 'Export current view as csv'
	    }
	});

Without changing from `extend()` to `merge()`, the above code will wipe out/remove the rest of the predefined strings for `gridMenu`. With `merge()` instead of `extend()`, *only* the desired two property's values are updated/replaced, leaving the rest of the `gridMenu` properties in place.

Currently, because of the `extend()` implementation, in order to change *just* the values of `exporterAllAsCsv` and `exporterVisibleAsCsv`, this (below) is required. We must redefine the *entire* `gridMenu` object even though we're only changing two property's values:

    gridMenu: {
        aria: {
            buttonLabel: 'Grid Menu'
        },
        columns: 'Columns:',
        importerTitle: 'Import file',
        exporterAllAsCsv: 'Export raw dataset as csv', // customized text
        exporterVisibleAsCsv: 'Export current view as csv', // customized text
        exporterSelectedAsCsv: 'Export selected data as csv',
        exporterAllAsPdf: 'Export all data as pdf',
        exporterVisibleAsPdf: 'Export visible data as pdf',
        exporterSelectedAsPdf: 'Export selected data as pdf',
        exporterAllAsExcel: 'Export all data as excel',
        exporterVisibleAsExcel: 'Export visible data as excel',
        exporterSelectedAsExcel: 'Export selected data as excel',
        clearAllFilters: 'Clear all filters'
    },