### PR TITLE
 fix(selection.js): Group header and primitive data types.

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -748,6 +748,7 @@
               uiGridSelectionService.toggleRowSelection(self, row, evt, self.options.multiSelect, self.options.noUnselect);
             }
             else if (row.groupHeader) {
+              uiGridSelectionService.toggleRowSelection(self, row, evt, self.options.multiSelect, self.options.noUnselect);
               for (var i = 0; i < row.treeNode.children.length; i++) {
                 uiGridSelectionService.toggleRowSelection(self, row.treeNode.children[i].row, evt, self.options.multiSelect, self.options.noUnselect);
               }

--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -292,7 +292,7 @@
                   return service.getSelectedRows(grid).map(function (gridRow) {
                     return gridRow.entity;
                   }).filter(function (entity) {
-                    return entity.hasOwnProperty('$$hashKey');
+                    return entity.hasOwnProperty('$$hashKey') || !angular.isObject(entity);
                   });
                 },
                 /**


### PR DESCRIPTION
* Allow group header selection.
* getSelectedRows will work on primitive data types.

fix #6698, fix #6704