### PR TITLE
fix(fonts): Change font files path.

### DIFF
--- a/grunt/connect.js
+++ b/grunt/connect.js
@@ -1,7 +1,7 @@
 module.exports = {
   dev: {
     options: {
-      port: process.env.DEV_PORT || 9002,
+      port: process.env.DEV_PORT || 9004,
       base: '.',
       livereload: true
     }

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -24,25 +24,25 @@ module.exports = function ( grunt ) {
           expand: true,
           cwd: 'src/font',
           src: '**/*.eot',
-          dest: '<%= dist %>/release/'
+          dest: '<%= dist %>/release/fonts'
         },
         {
           expand: true,
           cwd: 'src/font',
           src: '**/*.svg',
-          dest: '<%= dist %>/release/'
+          dest: '<%= dist %>/release/fonts'
         },
         {
           expand: true,
           cwd: 'src/font',
           src: '**/*.ttf',
-          dest: '<%= dist %>/release/'
+          dest: '<%= dist %>/release/fonts'
         },
         {
           expand: true,
           cwd: 'src/font',
           src: '**/*.woff',
-          dest: '<%= dist %>/release/'
+          dest: '<%= dist %>/release/fonts'
         }
       ]
     },

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -87,6 +87,6 @@
 /**
 * @section font library path
 */
-@font-path: '';
+@font-path: 'fonts/';
 
 /*-- END VARIABLES (DO NOT REMOVE THESE COMMENTS) --*/


### PR DESCRIPTION
BREAKING CHANGE: If you take the new CSS and do not relocate the icon files your icons will cease to
show in the grid.

fix #3751