### PR TITLE
feat(i18n): Add fallback lang support

### DIFF
--- a/misc/tutorial/104_i18n.ngdoc
+++ b/misc/tutorial/104_i18n.ngdoc
@@ -59,13 +59,20 @@ support. By default ui-grid.base.js will contain just the english language, in o
   </file>
   <file name="index.html">
     <div ng-controller="MainCtrl as $ctrl">
-      <select id="langDropdown" ng-model="$ctrl.lang" ng-options="l for l in $ctrl.langs"></select><br>
+      <select id="langDropdown" ng-model="$ctrl.lang" ng-options="l for l in $ctrl.langs"></select>
+      <br />
 
       <div ui-i18n="{{$ctrl.lang}}">
-         <p>Using attribute:</p>
+         <h2>Using attribute:</h2>
          <p ui-t="groupPanel.description"></p>
-         <br/>
-         <p>Using Filter:</p>
+
+         <h2>Using attribute 2:</h2>
+         <p ui-translate>groupPanel.description</p>
+
+         <h2>Using Filter that updates with language:</h2>
+         <p>{{"groupPanel.description" | t:$ctrl.lang}}</p>
+
+         <h2>Using Filter that does not update after load:</h2>
          <p>{{"groupPanel.description" | t}}</p>
 
          <p>Click the header menu to see language.</p>

--- a/test/unit/i18n/directives.spec.js
+++ b/test/unit/i18n/directives.spec.js
@@ -34,35 +34,121 @@ describe('i18n Directives', function() {
       element = angular.element('<div ui-i18n="lang"><p ui-translate="search.placeholder"></p></div>');
       recompile();
     });
+    afterEach(function() {
+      element.remove();
+    });
     it('should translate', function() {
       expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should translate even if token is on the html instead of the attribute', function() {
+      element = angular.element('<div ui-i18n="en"><p ui-translate>search.placeholder</p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should be able to interpolate languages and default to english when the language is not defined', function() {
+      element = angular.element('<div ui-i18n="{{lang}}"><p ui-translate="search.placeholder"></p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should be able to interpolate properties', function() {
+      scope.lang = 'en';
+      scope.property = 'search.placeholder';
+      element = angular.element('<div ui-i18n="{{lang}}"><p ui-translate="{{property}}"></p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should get missing text for missing property', function() {
+      element = angular.element('<div ui-i18n="en"><p ui-translate="search.bad.text"></p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('[MISSING]search.bad.text');
     });
   });
 
   describe('ui-t directive', function() {
+    afterEach(function() {
+      element.remove();
+    });
     it('should translate', function() {
       element = angular.element('<div ui-i18n="en"><p ui-t="search.placeholder"></p></div>');
       recompile();
 
       expect(element.find('p').text()).toBe('Search...');
     });
+    it('should translate even if token is on the html instead of the attribute', function() {
+      element = angular.element('<div ui-i18n="en"><p ui-t>search.placeholder</p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should be able to interpolate languages and default to english when the language is not defined', function() {
+      element = angular.element('<div ui-i18n="{{lang}}"><p ui-t="search.placeholder"></p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should be able to interpolate properties', function() {
+      scope.lang = 'en';
+      scope.property = 'search.placeholder';
+      element = angular.element('<div ui-i18n="{{lang}}"><p ui-t="{{property}}"></p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should get missing text for missing property', function() {
+      element = angular.element('<div ui-i18n="en"><p ui-t="search.bad.text"></p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('[MISSING]search.bad.text');
+
+      $rootScope.$broadcast('$uiI18n');
+
+      expect(element.find('p').text()).toBe('[MISSING]search.bad.text');
+    });
   });
 
   describe('t filter', function() {
+    afterEach(function() {
+      element.remove();
+    });
     it('should translate', function() {
       element = angular.element('<div ui-i18n="en"><p>{{"search.placeholder" | t}}</p></div>');
       recompile();
 
       expect(element.find('p').text()).toBe('Search...');
     });
+    it('should get missing text for missing property', function() {
+      element = angular.element('<div ui-i18n="en"><p>{{"search.bad.text" | t}}</p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('[MISSING]search.bad.text');
+    });
   });
 
   describe('uiTranslate filter', function() {
+    afterEach(function() {
+      element.remove();
+    });
     it('should translate', function() {
       element = angular.element('<div ui-i18n="en"><p>{{"search.placeholder" | uiTranslate}}</p></div>');
       recompile();
 
       expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should translate even without the ui-i18n directive', function() {
+      element = angular.element('<div><p>{{"search.placeholder" | uiTranslate:"en"}}</p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('Search...');
+    });
+    it('should get missing text for missing property', function() {
+      element = angular.element('<div ui-i18n="en"><p>{{"search.bad.text" | uiTranslate}}</p></div>');
+      recompile();
+
+      expect(element.find('p').text()).toBe('[MISSING]search.bad.text');
     });
   });
 });

--- a/test/unit/i18n/i18nService.spec.js
+++ b/test/unit/i18n/i18nService.spec.js
@@ -19,6 +19,15 @@ describe('i18nService', function () {
       expect(i18nService.getCurrentLang()).toBe('fr');
       expect(i18nService.get().search.placeholder).toBe('Recherche...');
     });
+    describe('get', function() {
+      it('should return the language passed to it if a language is passed', function() {
+        expect(i18nService.get('fr').search.placeholder).toBe('Recherche...');
+      });
+      it('should the current language no language is passed to it', function() {
+        i18nService.setCurrentLang('en');
+        expect(i18nService.get().search.placeholder).toBe('Search...');
+      });
+    });
     describe('add', function() {
       it('should add a language when langs is a string', function() {
         i18nService.add('tst',{test:'testlang'});
@@ -40,18 +49,58 @@ describe('i18nService', function () {
     });
     it('should return all langs', function() {
       var langs = i18nService.getAllLangs();
+
       expect(langs.length).toBeGreaterThan(8);
     });
+    describe('fallback lang', function() {
+      it('getFallbackLang should default to english when a fallback language is not set', function() {
+        expect(i18nService.getFallbackLang()).toEqual(i18nConstants.DEFAULT_LANG);
+      });
+      it('getFallbackLang should return the user set language when the user calls setFallbackLang', function() {
+        var fallback = 'es';
 
+        i18nService.setFallbackLang(fallback);
+        expect(i18nService.getFallbackLang()).toEqual(fallback);
+      });
+      it('getFallbackLang should return english when the user calls setFallbackLang with an empty string', function() {
+        var fallback = '';
+
+        i18nService.setFallbackLang(fallback);
+        expect(i18nService.getFallbackLang()).toEqual(i18nConstants.DEFAULT_LANG);
+      });
+    });
     describe('getSafeText', function() {
+      beforeEach(function() {
+        i18nService.setCurrentLang('en');
+        i18nService.setFallbackLang('en');
+      });
       it('should get safe text when text is defined', function() {
         expect(i18nService.getSafeText('search.placeholder')).toBe('Search...');
       });
-      it('should get safe text for missing property', function() {
-        expect(i18nService.getSafeText('search.bad.text')).toBe('[MISSING]');
+      it('should get missing text for missing property', function() {
+        var badText = 'search.bad.text';
+
+        expect(i18nService.getSafeText(badText)).toBe(i18nConstants.MISSING + badText);
       });
-      it('should get missing text when language is missing or nonexistent', function() {
-        expect(i18nService.getSafeText('search.placeholder', 'valerian')).toBe(i18nConstants.MISSING);
+      it('should get fallback text when language is missing or nonexistent', function() {
+        expect(i18nService.getSafeText('search.placeholder', 'valerian')).toBe('Search...');
+      });
+      it('should get missing text when language is missing or nonexistent and there is no fallback', function() {
+        var badText = 'bad.text';
+
+        expect(i18nService.getSafeText(badText, 'valerian')).toBe(i18nConstants.MISSING + badText);
+      });
+      it('should get missing text when language is missing or nonexistent and the fallback language is the same', function() {
+        var missingProperty = 'search.placeholder';
+
+        i18nService.setFallbackLang('valerian');
+        expect(i18nService.getSafeText(missingProperty, 'valerian')).toBe(i18nConstants.MISSING + missingProperty);
+      });
+      it('should get missing text when language is missing or nonexistent and the fallback language is also missing it', function() {
+        var missingProperty = 'search.placeholder';
+
+        i18nService.setFallbackLang('orcish');
+        expect(i18nService.getSafeText(missingProperty, 'valerian')).toBe(i18nConstants.MISSING + missingProperty);
       });
     });
   });


### PR DESCRIPTION
Adding the ability to have a fallback language in order to improve
usability for languages that have not been fully translated.

BREAKING CHANGE: getSafeText() will now return [MISSING] + the path to
the missing property or the fallback value if the property is available
on the fallback language.

fix #6396