### PR TITLE
fix(uiGridHeaderCell): Remove unncessary space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "JSV": {
@@ -50,7 +50,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -79,8 +79,8 @@
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
+        "extend": "3.0.1",
+        "semver": "5.0.3"
       },
       "dependencies": {
         "semver": {
@@ -97,10 +97,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "align-text": {
@@ -109,9 +109,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -127,11 +127,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bitsyntax": "~0.0.4",
-        "bluebird": "^3.4.6",
+        "bitsyntax": "0.0.4",
+        "bluebird": "3.5.1",
         "buffer-more-ints": "0.0.2",
-        "readable-stream": "1.x >=1.1.9",
-        "safe-buffer": "^5.0.1"
+        "readable-stream": "1.1.14",
+        "safe-buffer": "5.1.1"
       },
       "dependencies": {
         "isarray": {
@@ -148,10 +148,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -181,8 +181,8 @@
       "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "normalize-path": {
@@ -191,7 +191,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         }
       }
@@ -202,15 +202,15 @@
       "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
-        "async": "^2.0.0",
-        "buffer-crc32": "^0.2.1",
-        "glob": "^7.0.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0",
-        "tar-stream": "^1.5.0",
-        "walkdir": "^0.0.11",
-        "zip-stream": "^1.1.0"
+        "archiver-utils": "1.3.0",
+        "async": "2.6.0",
+        "buffer-crc32": "0.2.1",
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "readable-stream": "2.3.6",
+        "tar-stream": "1.5.5",
+        "walkdir": "0.0.11",
+        "zip-stream": "1.2.0"
       },
       "dependencies": {
         "async": {
@@ -219,7 +219,7 @@
           "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "glob": {
@@ -228,12 +228,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "lodash": {
@@ -248,7 +248,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -259,12 +259,12 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "graceful-fs": "^4.1.0",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.8.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.5",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "glob": {
@@ -273,12 +273,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -299,7 +299,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "normalize-path": {
@@ -308,7 +308,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         }
       }
@@ -319,7 +319,7 @@
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -328,7 +328,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -367,7 +367,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -482,7 +482,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.2.0"
+            "debug": "2.6.9"
           }
         }
       }
@@ -493,8 +493,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
@@ -557,7 +557,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -597,8 +597,8 @@
       "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "blob": {
@@ -613,7 +613,7 @@
       "integrity": "sha1-gdb9H+E6TA1pV99/kbdemNrEDLI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       }
     },
     "bluebird": {
@@ -629,15 +629,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "bytes": {
@@ -669,7 +669,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "hoek": {
@@ -697,7 +697,7 @@
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -707,9 +707,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "browserify-zlib": {
@@ -718,7 +718,7 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "~0.2.0"
+        "pako": "0.2.9"
       },
       "dependencies": {
         "pako": {
@@ -781,8 +781,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -797,8 +797,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -827,8 +827,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -837,11 +837,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "change-case": {
@@ -850,24 +850,24 @@
       "integrity": "sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==",
       "dev": true,
       "requires": {
-        "camel-case": "^3.0.0",
-        "constant-case": "^2.0.0",
-        "dot-case": "^2.1.0",
-        "header-case": "^1.0.0",
-        "is-lower-case": "^1.1.0",
-        "is-upper-case": "^1.1.0",
-        "lower-case": "^1.1.1",
-        "lower-case-first": "^1.0.0",
-        "no-case": "^2.3.2",
-        "param-case": "^2.1.0",
-        "pascal-case": "^2.0.0",
-        "path-case": "^2.1.0",
-        "sentence-case": "^2.1.0",
-        "snake-case": "^2.1.0",
-        "swap-case": "^1.1.0",
-        "title-case": "^2.1.0",
-        "upper-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "3.0.0",
+        "constant-case": "2.0.0",
+        "dot-case": "2.1.1",
+        "header-case": "1.0.1",
+        "is-lower-case": "1.1.3",
+        "is-upper-case": "1.1.2",
+        "lower-case": "1.1.4",
+        "lower-case-first": "1.0.2",
+        "no-case": "2.3.2",
+        "param-case": "2.1.1",
+        "pascal-case": "2.0.1",
+        "path-case": "2.1.1",
+        "sentence-case": "2.1.1",
+        "snake-case": "2.1.0",
+        "swap-case": "1.1.2",
+        "title-case": "2.1.1",
+        "upper-case": "1.1.3",
+        "upper-case-first": "1.1.2"
       }
     },
     "chokidar": {
@@ -876,15 +876,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.0",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -912,8 +912,8 @@
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "dev": true,
       "requires": {
-        "commander": "2.8.x",
-        "source-map": "0.4.x"
+        "commander": "2.8.1",
+        "source-map": "0.4.4"
       },
       "dependencies": {
         "commander": {
@@ -922,7 +922,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         }
       }
@@ -950,8 +950,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       }
     },
@@ -973,20 +973,20 @@
       "integrity": "sha1-dlcSXoSkCGotx5f/LWltgZpyD7U=",
       "dev": true,
       "requires": {
-        "mini-map": "^1.0.0",
-        "pop-arrayify": "^1.0.0",
-        "pop-clear": "^1.0.0",
-        "pop-clone": "^1.0.1",
-        "pop-compare": "^1.0.0",
-        "pop-equals": "^1.0.0",
-        "pop-has": "^1.0.0",
-        "pop-hash": "^1.0.0",
-        "pop-iterate": "^1.0.1",
-        "pop-observe": "^2.0.2",
-        "pop-swap": "^1.0.0",
-        "pop-zip": "^1.0.0",
+        "mini-map": "1.0.0",
+        "pop-arrayify": "1.0.0",
+        "pop-clear": "1.0.0",
+        "pop-clone": "1.0.1",
+        "pop-compare": "1.0.0",
+        "pop-equals": "1.0.0",
+        "pop-has": "1.0.0",
+        "pop-hash": "1.0.1",
+        "pop-iterate": "1.0.1",
+        "pop-observe": "2.0.2",
+        "pop-swap": "1.0.0",
+        "pop-zip": "1.0.0",
         "regexp-escape": "0.0.1",
-        "weak-map": "^1.0.4"
+        "weak-map": "1.0.5"
       }
     },
     "colors": {
@@ -1001,7 +1001,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "^4.5.0"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "lodash": {
@@ -1018,7 +1018,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -1027,7 +1027,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": ">= 1.0.0"
+        "graceful-readlink": "1.0.1"
       }
     },
     "comment-parser": {
@@ -1036,7 +1036,7 @@
       "integrity": "sha1-PAPwd2uGo239mgosl8YwfzMggv4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.4"
+        "readable-stream": "2.3.6"
       }
     },
     "compare-func": {
@@ -1045,8 +1045,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
+        "array-ify": "1.0.0",
+        "dot-prop": "3.0.0"
       }
     },
     "component-bind": {
@@ -1073,10 +1073,10 @@
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "^0.2.1",
-        "crc32-stream": "^2.0.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "buffer-crc32": "0.2.1",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "normalize-path": {
@@ -1085,7 +1085,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         }
       }
@@ -1102,9 +1102,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "connect": {
@@ -1115,7 +1115,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -1142,7 +1142,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "constant-case": {
@@ -1151,8 +1151,8 @@
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
       "dev": true,
       "requires": {
-        "snake-case": "^2.1.0",
-        "upper-case": "^1.1.1"
+        "snake-case": "2.1.0",
+        "upper-case": "1.1.3"
       }
     },
     "content-type": {
@@ -1167,17 +1167,17 @@
       "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^1.6.6",
-        "conventional-changelog-atom": "^0.2.8",
-        "conventional-changelog-codemirror": "^0.3.8",
-        "conventional-changelog-core": "^2.0.11",
-        "conventional-changelog-ember": "^0.3.12",
-        "conventional-changelog-eslint": "^1.0.9",
-        "conventional-changelog-express": "^0.3.6",
-        "conventional-changelog-jquery": "^0.1.0",
-        "conventional-changelog-jscs": "^0.1.0",
-        "conventional-changelog-jshint": "^0.3.8",
-        "conventional-changelog-preset-loader": "^1.1.8"
+        "conventional-changelog-angular": "1.6.6",
+        "conventional-changelog-atom": "0.2.8",
+        "conventional-changelog-codemirror": "0.3.8",
+        "conventional-changelog-core": "2.0.11",
+        "conventional-changelog-ember": "0.3.12",
+        "conventional-changelog-eslint": "1.0.9",
+        "conventional-changelog-express": "0.3.6",
+        "conventional-changelog-jquery": "0.1.0",
+        "conventional-changelog-jscs": "0.1.0",
+        "conventional-changelog-jshint": "0.3.8",
+        "conventional-changelog-preset-loader": "1.1.8"
       }
     },
     "conventional-changelog-angular": {
@@ -1186,8 +1186,8 @@
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-atom": {
@@ -1196,7 +1196,7 @@
       "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-codemirror": {
@@ -1205,7 +1205,7 @@
       "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-core": {
@@ -1214,19 +1214,19 @@
       "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "^3.0.9",
-        "conventional-commits-parser": "^2.1.7",
-        "dateformat": "^3.0.0",
-        "get-pkg-repo": "^1.0.0",
-        "git-raw-commits": "^1.3.6",
-        "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^1.3.6",
-        "lodash": "^4.2.1",
-        "normalize-package-data": "^2.3.5",
-        "q": "^1.5.1",
-        "read-pkg": "^1.1.0",
-        "read-pkg-up": "^1.0.1",
-        "through2": "^2.0.0"
+        "conventional-changelog-writer": "3.0.9",
+        "conventional-commits-parser": "2.1.7",
+        "dateformat": "3.0.3",
+        "get-pkg-repo": "1.4.0",
+        "git-raw-commits": "1.3.6",
+        "git-remote-origin-url": "2.0.0",
+        "git-semver-tags": "1.3.6",
+        "lodash": "4.17.10",
+        "normalize-package-data": "2.4.0",
+        "q": "1.5.1",
+        "read-pkg": "1.1.0",
+        "read-pkg-up": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "dateformat": {
@@ -1249,7 +1249,7 @@
       "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-eslint": {
@@ -1258,7 +1258,7 @@
       "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-express": {
@@ -1267,7 +1267,7 @@
       "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jquery": {
@@ -1276,7 +1276,7 @@
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -1285,7 +1285,7 @@
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jshint": {
@@ -1294,8 +1294,8 @@
       "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-preset-loader": {
@@ -1310,16 +1310,16 @@
       "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^1.1.6",
-        "dateformat": "^3.0.0",
-        "handlebars": "^4.0.2",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "semver": "^5.5.0",
-        "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "compare-func": "1.3.2",
+        "conventional-commits-filter": "1.1.6",
+        "dateformat": "3.0.3",
+        "handlebars": "4.0.11",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.10",
+        "meow": "4.0.1",
+        "semver": "5.5.0",
+        "split": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -1334,9 +1334,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "dateformat": {
@@ -1351,7 +1351,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "graceful-fs": {
@@ -1372,10 +1372,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash": {
@@ -1396,15 +1396,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -1413,8 +1413,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -1423,7 +1423,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -1438,9 +1438,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -1449,8 +1449,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -1459,8 +1459,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -1489,8 +1489,8 @@
       "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
-        "modify-values": "^1.0.0"
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.1"
       }
     },
     "conventional-commits-parser": {
@@ -1499,13 +1499,13 @@
       "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
-        "is-text-path": "^1.0.0",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
+        "lodash": "4.17.10",
+        "meow": "4.0.1",
+        "split2": "2.2.0",
+        "through2": "2.0.3",
+        "trim-off-newlines": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -1520,9 +1520,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "find-up": {
@@ -1531,7 +1531,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "graceful-fs": {
@@ -1552,10 +1552,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash": {
@@ -1576,15 +1576,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -1593,8 +1593,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -1603,7 +1603,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -1618,9 +1618,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -1629,8 +1629,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -1639,8 +1639,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -1675,11 +1675,11 @@
       "integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
       "dev": true,
       "requires": {
-        "js-yaml": "^3.6.1",
-        "lcov-parse": "^0.0.10",
-        "log-driver": "^1.2.5",
-        "minimist": "^1.2.0",
-        "request": "^2.79.0"
+        "js-yaml": "3.11.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.7",
+        "minimist": "1.2.0",
+        "request": "2.85.0"
       }
     },
     "crc32-stream": {
@@ -1688,8 +1688,8 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "^3.4.4",
-        "readable-stream": "^2.0.0"
+        "crc": "3.5.0",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "crc": {
@@ -1706,7 +1706,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -1715,7 +1715,7 @@
           "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           },
           "dependencies": {
             "hoek": {
@@ -1734,11 +1734,11 @@
       "integrity": "sha1-g+6Qids8JUvsHpjkmNmqzxGtzFQ=",
       "dev": true,
       "requires": {
-        "coffee-script": "^1.9.0",
-        "cson-parser": "^1.0.6",
-        "extract-opts": "^3.0.1",
-        "requirefresh": "^2.0.0",
-        "safefs": "^4.0.0"
+        "coffee-script": "1.12.7",
+        "cson-parser": "1.3.5",
+        "extract-opts": "3.3.1",
+        "requirefresh": "2.1.0",
+        "safefs": "4.1.0"
       },
       "dependencies": {
         "coffee-script": {
@@ -1755,7 +1755,7 @@
       "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
       "dev": true,
       "requires": {
-        "coffee-script": "^1.10.0"
+        "coffee-script": "1.12.7"
       },
       "dependencies": {
         "coffee-script": {
@@ -1772,9 +1772,9 @@
       "integrity": "sha512-U5ETe1IOjq2h56ZcBE3oe9rT7XryCH6IKgPMv0L7sSk6w29yR3p5egCK0T3BDNHHV95OoUBgXsqiVG+3a900Ag==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.9.2",
-        "babylon": "^6.8.1",
-        "source-map-support": "^0.4.0"
+        "babel-runtime": "6.26.0",
+        "babylon": "6.18.0",
+        "source-map-support": "0.4.18"
       }
     },
     "currently-unhandled": {
@@ -1783,7 +1783,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "custom-event": {
@@ -1804,11 +1804,11 @@
       "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
       "dev": true,
       "requires": {
-        "conventional-commit-types": "^2.0.0",
-        "lodash.map": "^4.5.1",
-        "longest": "^1.0.1",
-        "right-pad": "^1.0.1",
-        "word-wrap": "^1.0.3"
+        "conventional-commit-types": "2.2.0",
+        "lodash.map": "4.6.0",
+        "longest": "1.0.1",
+        "right-pad": "1.0.1",
+        "word-wrap": "1.2.3"
       }
     },
     "dargs": {
@@ -1817,7 +1817,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "dashdash": {
@@ -1826,7 +1826,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-uri-to-buffer": {
@@ -1854,7 +1854,7 @@
       "integrity": "sha1-GIdtC9pMGf5w3Tv0sDTygbEqQLY=",
       "dev": true,
       "requires": {
-        "time-zone": "^0.1.0"
+        "time-zone": "0.1.0"
       }
     },
     "dateformat": {
@@ -1863,8 +1863,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
       }
     },
     "debug": {
@@ -1888,8 +1888,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       }
     },
     "deep-equal": {
@@ -1911,9 +1911,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ast-types": "0.x.x",
-        "escodegen": "1.x.x",
-        "esprima": "3.x.x"
+        "ast-types": "0.11.3",
+        "escodegen": "1.7.1",
+        "esprima": "3.1.3"
       },
       "dependencies": {
         "esprima": {
@@ -1931,13 +1931,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.2.8"
       }
     },
     "delayed-stream": {
@@ -1970,10 +1970,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "void-elements": "2.0.1"
       }
     },
     "dom-serializer": {
@@ -1982,8 +1982,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -2012,7 +2012,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -2021,8 +2021,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-case": {
@@ -2031,7 +2031,7 @@
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "dot-prop": {
@@ -2040,7 +2040,7 @@
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "double-ended-queue": {
@@ -2056,8 +2056,8 @@
       "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
       "dev": true,
       "requires": {
-        "editions": "^1.1.1",
-        "typechecker": "^4.3.0"
+        "editions": "1.3.4",
+        "typechecker": "4.5.0"
       }
     },
     "ecc-jsbn": {
@@ -2067,7 +2067,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "editions": {
@@ -2094,7 +2094,7 @@
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -2103,13 +2103,13 @@
       "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "uws": "~9.14.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "uws": "9.14.0",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "cookie": {
@@ -2130,9 +2130,9 @@
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -2145,14 +2145,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -2168,9 +2168,9 @@
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -2182,10 +2182,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.2"
       }
     },
     "ent": {
@@ -2207,7 +2207,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -2216,7 +2216,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es6-promise": {
@@ -2244,11 +2244,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "esprima": "^1.2.2",
-        "estraverse": "^1.9.1",
-        "esutils": "^2.0.2",
-        "optionator": "^0.5.0",
-        "source-map": "~0.2.0"
+        "esprima": "1.2.5",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.5.0",
+        "source-map": "0.2.0"
       },
       "dependencies": {
         "esprima": {
@@ -2272,7 +2272,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -2325,9 +2325,9 @@
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "^0.2.3",
-        "array-unique": "^0.2.1",
-        "braces": "^0.1.2"
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
       },
       "dependencies": {
         "braces": {
@@ -2336,7 +2336,7 @@
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "^0.1.0"
+            "expand-range": "0.1.1"
           }
         },
         "expand-range": {
@@ -2345,8 +2345,8 @@
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
           "dev": true,
           "requires": {
-            "is-number": "^0.1.1",
-            "repeat-string": "^0.2.2"
+            "is-number": "0.1.1",
+            "repeat-string": "0.2.2"
           }
         },
         "is-number": {
@@ -2369,7 +2369,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -2378,7 +2378,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "extend": {
@@ -2393,7 +2393,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-opts": {
@@ -2402,9 +2402,9 @@
       "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
       "dev": true,
       "requires": {
-        "eachr": "^3.2.0",
-        "editions": "^1.1.1",
-        "typechecker": "^4.3.0"
+        "eachr": "3.2.0",
+        "editions": "1.3.4",
+        "typechecker": "4.5.0"
       }
     },
     "extract-zip": {
@@ -2467,7 +2467,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fd-slicer": {
@@ -2476,7 +2476,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -2485,8 +2485,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2514,11 +2514,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -2528,12 +2528,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -2559,8 +2559,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -2569,7 +2569,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "~5.0.0"
+        "glob": "5.0.15"
       },
       "dependencies": {
         "glob": {
@@ -2578,11 +2578,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -2593,7 +2593,7 @@
       "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       }
     },
     "for-in": {
@@ -2608,7 +2608,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -2623,9 +2623,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "fresh": {
@@ -2640,7 +2640,7 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "^1.0.0"
+        "null-check": "1.0.0"
       }
     },
     "fs-extra": {
@@ -2649,9 +2649,9 @@
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2669,7 +2669,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.2.4"
       }
     },
     "fs.realpath": {
@@ -2685,8 +2685,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.9.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.9.1"
       },
       "dependencies": {
         "abbrev": {
@@ -2699,8 +2699,8 @@
           "version": "4.11.8",
           "bundled": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
@@ -2720,8 +2720,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
           }
         },
         "asn1": {
@@ -2753,28 +2753,28 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
           "requires": {
-            "balanced-match": "^0.4.1",
+            "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
           }
         },
@@ -2799,7 +2799,7 @@
           "version": "1.0.5",
           "bundled": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
@@ -2819,14 +2819,14 @@
           "version": "2.0.5",
           "bundled": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2869,7 +2869,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "extend": {
@@ -2888,9 +2888,9 @@
           "version": "2.1.4",
           "bundled": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
           }
         },
         "fs.realpath": {
@@ -2901,19 +2901,19 @@
           "version": "1.0.11",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
           }
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
           }
         },
         "gauge": {
@@ -2922,21 +2922,21 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2949,12 +2949,12 @@
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -2969,8 +2969,8 @@
           "version": "4.2.1",
           "bundled": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "has-unicode": {
@@ -2983,10 +2983,10 @@
           "version": "3.1.3",
           "bundled": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -2997,17 +2997,17 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -3025,7 +3025,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
@@ -3045,7 +3045,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "jsbn": {
@@ -3061,7 +3061,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -3096,14 +3096,14 @@
           "version": "2.1.15",
           "bundled": true,
           "requires": {
-            "mime-db": "~1.27.0"
+            "mime-db": "1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
@@ -3128,16 +3128,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.2",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "4.4.1"
           },
           "dependencies": {
             "safe-buffer": {
@@ -3154,13 +3154,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "chownr": "^1.0.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.2.4",
-                "minizlib": "^1.1.0",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.1",
-                "yallist": "^3.0.2"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
               }
             }
           }
@@ -3171,8 +3171,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
@@ -3181,10 +3181,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -3206,7 +3206,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -3227,8 +3227,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -3257,10 +3257,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3275,48 +3275,48 @@
           "version": "2.2.9",
           "bundled": true,
           "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
           }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -3345,22 +3345,22 @@
           "version": "1.0.9",
           "bundled": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jodid25519": "^1.0.0",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "assert-plus": {
@@ -3374,16 +3374,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3395,7 +3395,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -3408,37 +3408,37 @@
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         },
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
           "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
           }
         },
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "tweetnacl": {
@@ -3471,7 +3471,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -3487,7 +3487,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "readable-stream": "1.1.x",
+        "readable-stream": "1.1.14",
         "xregexp": "2.0.0"
       },
       "dependencies": {
@@ -3505,10 +3505,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3526,7 +3526,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "^1.0.0"
+        "globule": "1.2.0"
       }
     },
     "generate-function": {
@@ -3543,7 +3543,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-pkg-repo": {
@@ -3552,11 +3552,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "meow": "^3.3.0",
-        "normalize-package-data": "^2.3.0",
-        "parse-github-repo-url": "^1.3.0",
-        "through2": "^2.0.0"
+        "hosted-git-info": "2.6.0",
+        "meow": "3.7.0",
+        "normalize-package-data": "2.4.0",
+        "parse-github-repo-url": "1.4.1",
+        "through2": "2.0.3"
       }
     },
     "get-stdin": {
@@ -3572,12 +3572,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "data-uri-to-buffer": "1",
-        "debug": "2",
-        "extend": "3",
-        "file-uri-to-path": "1",
-        "ftp": "~0.3.10",
-        "readable-stream": "2"
+        "data-uri-to-buffer": "1.2.0",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "file-uri-to-path": "1.0.0",
+        "ftp": "0.3.10",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "debug": {
@@ -3604,7 +3604,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "git-raw-commits": {
@@ -3613,11 +3613,11 @@
       "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "dev": true,
       "requires": {
-        "dargs": "^4.0.1",
-        "lodash.template": "^4.0.2",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0"
+        "dargs": "4.1.0",
+        "lodash.template": "4.4.0",
+        "meow": "4.0.1",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -3632,9 +3632,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "find-up": {
@@ -3643,7 +3643,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "graceful-fs": {
@@ -3664,10 +3664,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "map-obj": {
@@ -3682,15 +3682,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -3699,8 +3699,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -3709,7 +3709,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -3724,9 +3724,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -3735,8 +3735,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -3745,8 +3745,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -3769,8 +3769,8 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "^1.0.0",
-        "pify": "^2.3.0"
+        "gitconfiglocal": "1.0.0",
+        "pify": "2.3.0"
       }
     },
     "git-semver-tags": {
@@ -3779,8 +3779,8 @@
       "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "dev": true,
       "requires": {
-        "meow": "^4.0.0",
-        "semver": "^5.5.0"
+        "meow": "4.0.1",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "camelcase": {
@@ -3795,9 +3795,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "find-up": {
@@ -3806,7 +3806,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "graceful-fs": {
@@ -3827,10 +3827,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "map-obj": {
@@ -3845,15 +3845,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -3862,8 +3862,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -3872,7 +3872,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -3887,9 +3887,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -3898,8 +3898,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -3908,8 +3908,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -3932,7 +3932,7 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.2"
+        "ini": "1.3.5"
       }
     },
     "glob": {
@@ -3941,12 +3941,12 @@
       "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.2",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -3955,8 +3955,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -3965,7 +3965,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "globby": {
@@ -3974,12 +3974,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "glob": {
@@ -3988,12 +3988,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -4002,7 +4002,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -4013,9 +4013,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.4",
-        "minimatch": "~3.0.2"
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "glob": {
@@ -4024,12 +4024,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "lodash": {
@@ -4044,7 +4044,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -4061,22 +4061,22 @@
       "integrity": "sha1-TmpeaVtwRy/VME9fqeNCNoNqc7w=",
       "dev": true,
       "requires": {
-        "coffeescript": "~1.10.0",
-        "dateformat": "~1.0.12",
-        "eventemitter2": "~0.4.13",
-        "exit": "~0.1.1",
-        "findup-sync": "~0.3.0",
-        "glob": "~7.0.0",
-        "grunt-cli": "~1.2.0",
-        "grunt-known-options": "~1.1.0",
-        "grunt-legacy-log": "~1.0.0",
-        "grunt-legacy-util": "~1.0.0",
-        "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.5.2",
-        "minimatch": "~3.0.2",
-        "nopt": "~3.0.6",
-        "path-is-absolute": "~1.0.0",
-        "rimraf": "~2.2.8"
+        "coffeescript": "1.10.0",
+        "dateformat": "1.0.12",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.3.0",
+        "glob": "7.0.6",
+        "grunt-cli": "1.2.0",
+        "grunt-known-options": "1.1.0",
+        "grunt-legacy-log": "1.0.2",
+        "grunt-legacy-util": "1.0.0",
+        "iconv-lite": "0.4.21",
+        "js-yaml": "3.5.5",
+        "minimatch": "3.0.4",
+        "nopt": "3.0.6",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "esprima": {
@@ -4091,10 +4091,10 @@
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
-            "findup-sync": "~0.3.0",
-            "grunt-known-options": "~1.1.0",
-            "nopt": "~3.0.6",
-            "resolve": "~1.1.0"
+            "findup-sync": "0.3.0",
+            "grunt-known-options": "1.1.0",
+            "nopt": "3.0.6",
+            "resolve": "1.1.7"
           }
         },
         "js-yaml": {
@@ -4103,8 +4103,8 @@
           "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.2",
-            "esprima": "^2.6.0"
+            "argparse": "1.0.10",
+            "esprima": "2.7.3"
           }
         }
       }
@@ -4115,7 +4115,7 @@
       "integrity": "sha1-EJYDorlf8BAZtxjHA0EmjwnYvhk=",
       "dev": true,
       "requires": {
-        "html-minifier": "~2.1.2"
+        "html-minifier": "2.1.7"
       }
     },
     "grunt-bump": {
@@ -4124,7 +4124,7 @@
       "integrity": "sha1-0//gzzzws44JYHt4U49CpTHq/lU=",
       "dev": true,
       "requires": {
-        "semver": "^5.1.0"
+        "semver": "5.5.0"
       }
     },
     "grunt-contrib-clean": {
@@ -4133,8 +4133,8 @@
       "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
       "dev": true,
       "requires": {
-        "async": "^1.5.2",
-        "rimraf": "^2.5.1"
+        "async": "1.5.2",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "async": {
@@ -4149,12 +4149,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -4163,7 +4163,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -4172,7 +4172,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         }
       }
@@ -4183,8 +4183,8 @@
       "integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "source-map": "^0.5.3"
+        "chalk": "1.1.3",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -4201,15 +4201,15 @@
       "integrity": "sha1-XPkzuRpnOGBEJzwLJERgPNmIebo=",
       "dev": true,
       "requires": {
-        "async": "^1.5.2",
-        "connect": "^3.4.0",
-        "connect-livereload": "^0.5.0",
-        "http2": "^3.3.4",
-        "morgan": "^1.6.1",
-        "opn": "^4.0.0",
-        "portscanner": "^1.0.0",
-        "serve-index": "^1.7.1",
-        "serve-static": "^1.10.0"
+        "async": "1.5.2",
+        "connect": "3.6.6",
+        "connect-livereload": "0.5.4",
+        "http2": "3.3.7",
+        "morgan": "1.9.0",
+        "opn": "4.0.2",
+        "portscanner": "1.2.0",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.2"
       },
       "dependencies": {
         "async": {
@@ -4226,8 +4226,8 @@
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "file-sync-cmp": "^0.1.0"
+        "chalk": "1.1.3",
+        "file-sync-cmp": "0.1.1"
       }
     },
     "grunt-contrib-jasmine": {
@@ -4236,12 +4236,12 @@
       "integrity": "sha1-9oL3dX2il3Wf4+G0xl1GcMw66kk=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "grunt-lib-phantomjs": "^1.0.0",
-        "jasmine-core": "~2.4.0",
-        "lodash": "~2.4.1",
-        "rimraf": "^2.1.4",
-        "sprintf-js": "~1.0.3"
+        "chalk": "1.1.3",
+        "grunt-lib-phantomjs": "1.1.0",
+        "jasmine-core": "2.4.1",
+        "lodash": "2.4.2",
+        "rimraf": "2.2.8",
+        "sprintf-js": "1.0.3"
       },
       "dependencies": {
         "lodash": {
@@ -4258,9 +4258,9 @@
       "integrity": "sha1-Np2QmyWTxA6L55lAshNAhQx5Oaw=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "hooker": "^0.2.3",
-        "jshint": "~2.9.4"
+        "chalk": "1.1.3",
+        "hooker": "0.2.3",
+        "jshint": "2.9.5"
       }
     },
     "grunt-contrib-less": {
@@ -4269,10 +4269,10 @@
       "integrity": "sha1-O73sC3XRLOqlXWKUNiXAsIYc328=",
       "dev": true,
       "requires": {
-        "async": "^2.0.0",
-        "chalk": "^1.0.0",
-        "less": "~2.7.1",
-        "lodash": "^4.8.2"
+        "async": "2.6.0",
+        "chalk": "1.1.3",
+        "less": "2.7.3",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "async": {
@@ -4281,7 +4281,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.10"
           }
         },
         "lodash": {
@@ -4298,10 +4298,10 @@
       "integrity": "sha512-W9O7lJE3PlD8VCc5fyaf98QV7f5wEDiU4PBIh0+/6UBbk2LhgzEFS0/p+taH5UD3+PlEn7QPN0o06Z0To6SqXw==",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "maxmin": "^1.1.0",
-        "uglify-js": "~3.3.0",
-        "uri-path": "^1.0.0"
+        "chalk": "1.1.3",
+        "maxmin": "1.1.0",
+        "uglify-js": "3.3.22",
+        "uri-path": "1.0.0"
       },
       "dependencies": {
         "commander": {
@@ -4322,8 +4322,8 @@
           "integrity": "sha512-tqw96rL6/BG+7LM5VItdhDjTQmL5zG/I0b2RqWytlgeHe2eydZHuBHdA9vuGpCDhH/ZskNGcqDhivoR2xt8RIw==",
           "dev": true,
           "requires": {
-            "commander": "~2.15.0",
-            "source-map": "~0.6.1"
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -4334,10 +4334,10 @@
       "integrity": "sha512-8Zka/svGl6+ZwF7d6z/CfXwsb4cDODnajmZsY4nUAs9Ob0kJEcsLiDf5qm2HdDoEcm3NHjWCrFiWx+PZ2y4D7A==",
       "dev": true,
       "requires": {
-        "async": "^1.5.0",
-        "gaze": "^1.1.0",
-        "lodash": "^4.0.0",
-        "tiny-lr": "^0.2.1"
+        "async": "1.5.2",
+        "gaze": "1.1.2",
+        "lodash": "4.17.10",
+        "tiny-lr": "0.2.1"
       },
       "dependencies": {
         "async": {
@@ -4360,11 +4360,11 @@
       "integrity": "sha1-mL1b37Kw3mMWwFx8b6ykziTdFDU=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.0",
-        "concat-stream": "^1.5.0",
-        "conventional-changelog": "^1.1.0",
-        "plur": "^2.0.0",
-        "q": "^1.4.1"
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "conventional-changelog": "1.1.24",
+        "plur": "2.1.2",
+        "q": "1.5.1"
       }
     },
     "grunt-gh-pages": {
@@ -4374,11 +4374,11 @@
       "dev": true,
       "requires": {
         "async": "2.0.1",
-        "fs-extra": "^0.30.0",
+        "fs-extra": "0.30.0",
         "graceful-fs": "4.1.5",
         "q": "0.9.3",
         "q-io": "2.0.2",
-        "url-safe": "^2.0.0"
+        "url-safe": "2.0.0"
       },
       "dependencies": {
         "async": {
@@ -4387,7 +4387,7 @@
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "lodash": "^4.8.0"
+            "lodash": "4.17.10"
           }
         },
         "fs-extra": {
@@ -4396,11 +4396,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "4.1.5",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.2.8"
           }
         },
         "graceful-fs": {
@@ -4429,10 +4429,10 @@
       "integrity": "sha1-H65Q4+lV3546nZQlrsIqzK4AgJI=",
       "dev": true,
       "requires": {
-        "hooker": "~0.2.3",
-        "jscs": "~3.0.5",
-        "lodash": "~4.6.1",
-        "vow": "~0.4.1"
+        "hooker": "0.2.3",
+        "jscs": "3.0.7",
+        "lodash": "4.6.1",
+        "vow": "0.4.17"
       },
       "dependencies": {
         "lodash": {
@@ -4449,7 +4449,7 @@
       "integrity": "sha1-dTWD0RXf3AVf5X5Y+W1rPH5hIRg=",
       "dev": true,
       "requires": {
-        "lodash": "^3.10.1"
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -4472,10 +4472,10 @@
       "integrity": "sha512-WdedTJ/6zCXnI/coaouzqvkI19uwqbcPkdsXiDRKJyB5rOUlOxnCnTVbpeUdEckKVir2uHF3rDBYppj2p6N3+g==",
       "dev": true,
       "requires": {
-        "colors": "~1.1.2",
-        "grunt-legacy-log-utils": "~1.0.0",
-        "hooker": "~0.2.3",
-        "lodash": "~4.17.5"
+        "colors": "1.1.2",
+        "grunt-legacy-log-utils": "1.0.0",
+        "hooker": "0.2.3",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "colors": {
@@ -4492,8 +4492,8 @@
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
       "dev": true,
       "requires": {
-        "chalk": "~1.1.1",
-        "lodash": "~4.3.0"
+        "chalk": "1.1.3",
+        "lodash": "4.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -4510,13 +4510,13 @@
       "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
       "dev": true,
       "requires": {
-        "async": "~1.5.2",
-        "exit": "~0.1.1",
-        "getobject": "~0.1.0",
-        "hooker": "~0.2.3",
-        "lodash": "~4.3.0",
-        "underscore.string": "~3.2.3",
-        "which": "~1.2.1"
+        "async": "1.5.2",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "4.3.0",
+        "underscore.string": "3.2.3",
+        "which": "1.2.14"
       },
       "dependencies": {
         "lodash": {
@@ -4533,11 +4533,11 @@
       "integrity": "sha1-np7c3Z/S3UDgwYHJQ3HVcqpe6tI=",
       "dev": true,
       "requires": {
-        "eventemitter2": "^0.4.9",
-        "phantomjs-prebuilt": "^2.1.3",
-        "rimraf": "^2.5.2",
-        "semver": "^5.1.0",
-        "temporary": "^0.0.8"
+        "eventemitter2": "0.4.14",
+        "phantomjs-prebuilt": "2.1.16",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "temporary": "0.0.8"
       },
       "dependencies": {
         "glob": {
@@ -4546,12 +4546,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -4560,7 +4560,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -4569,7 +4569,7 @@
           "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         }
       }
@@ -4580,8 +4580,8 @@
       "integrity": "sha1-g8y3od2ny9irI7BZAk6+YUrS80I=",
       "dev": true,
       "requires": {
-        "async": "^1.5.2",
-        "rimraf": "^2.5.2"
+        "async": "1.5.2",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "async": {
@@ -4596,12 +4596,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -4610,7 +4610,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -4619,7 +4619,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         }
       }
@@ -4629,8 +4629,8 @@
       "integrity": "sha512-RNf3ArHvZiRCEgN+5xFDsoCVTx3Iwe9bsHeVtYFTrEwqs+pK/4LevqoPE71iknTz1ey4BBZKppbbR4cuBkbFCA==",
       "dev": true,
       "requires": {
-        "marked": "~0.3.2",
-        "shelljs": "~0.3.0"
+        "marked": "0.3.19",
+        "shelljs": "0.3.0"
       },
       "dependencies": {
         "shelljs": {
@@ -4647,9 +4647,9 @@
       "integrity": "sha1-hi1DwroPgq2TZOhh3Eqnmw5kJsE=",
       "dev": true,
       "requires": {
-        "protractor": "^5.0.0",
-        "split": "~1.0.0",
-        "through2": "~2.0.0"
+        "protractor": "5.3.1",
+        "split": "1.0.1",
+        "through2": "2.0.3"
       }
     },
     "grunt-shell-spawn": {
@@ -4658,8 +4658,8 @@
       "integrity": "sha1-gbuNRX7EfTGCqH1jCO+EXd+5SI8=",
       "dev": true,
       "requires": {
-        "grunt": ">=0.4.x",
-        "sync-exec": "~0.6.2"
+        "grunt": "1.0.2",
+        "sync-exec": "0.6.2"
       }
     },
     "gzip-size": {
@@ -4668,8 +4668,8 @@
       "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
       "dev": true,
       "requires": {
-        "browserify-zlib": "^0.1.4",
-        "concat-stream": "^1.4.1"
+        "browserify-zlib": "0.1.4",
+        "concat-stream": "1.6.0"
       }
     },
     "handlebars": {
@@ -4678,10 +4678,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "async": {
@@ -4696,7 +4696,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "uglify-js": {
@@ -4706,9 +4706,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -4727,9 +4727,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -4747,8 +4747,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -4757,7 +4757,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -4801,8 +4801,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "hawk": {
@@ -4811,10 +4811,10 @@
       "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "dev": true,
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       },
       "dependencies": {
         "hoek": {
@@ -4837,8 +4837,8 @@
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.3"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "hipchat-notifier": {
@@ -4848,8 +4848,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "^4.0.0",
-        "request": "^2.0.0"
+        "lodash": "4.17.5",
+        "request": "2.85.0"
       },
       "dependencies": {
         "lodash": {
@@ -4885,13 +4885,13 @@
       "integrity": "sha1-kFHW/LvPIU7TB+GtdPQyu5rWVcw=",
       "dev": true,
       "requires": {
-        "change-case": "3.0.x",
-        "clean-css": "3.4.x",
-        "commander": "2.9.x",
-        "he": "1.1.x",
-        "ncname": "1.0.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "2.6.x"
+        "change-case": "3.0.2",
+        "clean-css": "3.4.28",
+        "commander": "2.9.0",
+        "he": "1.1.1",
+        "ncname": "1.0.0",
+        "relateurl": "0.2.7",
+        "uglify-js": "2.6.4"
       }
     },
     "htmlparser2": {
@@ -4900,11 +4900,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.3",
-        "domutils": "1.5",
-        "entities": "1.0",
-        "readable-stream": "1.1"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -4919,10 +4919,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -4939,10 +4939,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.5.0"
       }
     },
     "http-parser-js": {
@@ -4957,9 +4957,9 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.0.1",
+        "follow-redirects": "1.4.1",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-agent": {
@@ -4968,9 +4968,9 @@
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -4990,9 +4990,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "http2": {
@@ -5007,8 +5007,8 @@
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
       "requires": {
-        "httpreq": ">=0.4.22",
-        "underscore": "~1.7.0"
+        "httpreq": "0.4.24",
+        "underscore": "1.7.0"
       }
     },
     "httpreq": {
@@ -5023,9 +5023,9 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -5045,9 +5045,9 @@
       "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
       "dev": true,
       "requires": {
-        "is-ci": "^1.0.10",
-        "normalize-path": "^1.0.0",
-        "strip-indent": "^2.0.0"
+        "is-ci": "1.1.0",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
       }
     },
     "i": {
@@ -5062,7 +5062,7 @@
       "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
       "dev": true,
       "requires": {
-        "safer-buffer": "^2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore-walk": {
@@ -5072,7 +5072,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -5082,7 +5082,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -5106,7 +5106,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexof": {
@@ -5128,8 +5128,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherit": {
@@ -5181,7 +5181,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -5196,7 +5196,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
@@ -5205,7 +5205,7 @@
       "integrity": "sha1-JH5BYueGDOu9rzC3dNawrH3P56U=",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-dotfile": {
@@ -5220,7 +5220,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -5241,7 +5241,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -5250,7 +5250,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-lower-case": {
@@ -5259,7 +5259,7 @@
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.0"
+        "lower-case": "1.1.4"
       }
     },
     "is-my-ip-valid": {
@@ -5276,11 +5276,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-number": {
@@ -5289,7 +5289,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-obj": {
@@ -5310,7 +5310,7 @@
       "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -5319,7 +5319,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -5365,7 +5365,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "^1.0.0"
+        "text-extensions": "1.7.0"
       }
     },
     "is-typedarray": {
@@ -5380,7 +5380,7 @@
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "dev": true,
       "requires": {
-        "upper-case": "^1.1.0"
+        "upper-case": "1.1.3"
       }
     },
     "is-utf8": {
@@ -5428,20 +5428,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.x",
-        "async": "1.x",
-        "escodegen": "1.8.x",
-        "esprima": "2.7.x",
-        "glob": "^5.0.15",
-        "handlebars": "^4.0.1",
-        "js-yaml": "3.x",
-        "mkdirp": "0.5.x",
-        "nopt": "3.x",
-        "once": "1.x",
-        "resolve": "1.1.x",
-        "supports-color": "^3.1.0",
-        "which": "^1.1.1",
-        "wordwrap": "^1.0.0"
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.11",
+        "js-yaml": "3.11.0",
+        "mkdirp": "0.5.0",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5462,11 +5462,11 @@
           "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
           "dev": true,
           "requires": {
-            "esprima": "^2.7.1",
-            "estraverse": "^1.9.1",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.2.0"
+            "esprima": "2.7.3",
+            "estraverse": "1.9.3",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.2.0"
           }
         },
         "esprima": {
@@ -5487,11 +5487,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "levn": {
@@ -5500,8 +5500,8 @@
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "dev": true,
           "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
           }
         },
         "minimatch": {
@@ -5510,7 +5510,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "nopt": {
@@ -5519,7 +5519,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1.0.9"
           }
         },
         "optionator": {
@@ -5528,12 +5528,12 @@
           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
           "dev": true,
           "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.4",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "wordwrap": "~1.0.0"
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
           }
         },
         "source-map": {
@@ -5543,7 +5543,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "supports-color": {
@@ -5552,7 +5552,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         },
         "which": {
@@ -5561,7 +5561,7 @@
           "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "wordwrap": {
@@ -5578,9 +5578,9 @@
       "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
       "dev": true,
       "requires": {
-        "exit": "^0.1.2",
-        "glob": "^7.0.6",
-        "jasmine-core": "~2.8.0"
+        "exit": "0.1.2",
+        "glob": "7.1.2",
+        "jasmine-core": "2.8.0"
       },
       "dependencies": {
         "glob": {
@@ -5589,12 +5589,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "jasmine-core": {
@@ -5609,7 +5609,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -5638,8 +5638,8 @@
       "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -5655,32 +5655,32 @@
       "integrity": "sha1-cUG03/W4bjLQ6Z12S4NnZ8MNIBo=",
       "dev": true,
       "requires": {
-        "chalk": "~1.1.0",
-        "cli-table": "~0.3.1",
-        "commander": "~2.9.0",
-        "cst": "^0.4.3",
-        "estraverse": "^4.1.0",
-        "exit": "~0.1.2",
-        "glob": "^5.0.1",
+        "chalk": "1.1.3",
+        "cli-table": "0.3.1",
+        "commander": "2.9.0",
+        "cst": "0.4.10",
+        "estraverse": "4.2.0",
+        "exit": "0.1.2",
+        "glob": "5.0.15",
         "htmlparser2": "3.8.3",
-        "js-yaml": "~3.4.0",
-        "jscs-jsdoc": "^2.0.0",
-        "jscs-preset-wikimedia": "~1.0.0",
-        "jsonlint": "~1.6.2",
-        "lodash": "~3.10.0",
-        "minimatch": "~3.0.0",
-        "natural-compare": "~1.2.2",
-        "pathval": "~0.1.1",
-        "prompt": "~0.2.14",
-        "reserved-words": "^0.1.1",
-        "resolve": "^1.1.6",
-        "strip-bom": "^2.0.0",
-        "strip-json-comments": "~1.0.2",
-        "to-double-quotes": "^2.0.0",
-        "to-single-quotes": "^2.0.0",
-        "vow": "~0.4.8",
-        "vow-fs": "~0.3.4",
-        "xmlbuilder": "^3.1.0"
+        "js-yaml": "3.4.6",
+        "jscs-jsdoc": "2.0.0",
+        "jscs-preset-wikimedia": "1.0.1",
+        "jsonlint": "1.6.3",
+        "lodash": "3.10.1",
+        "minimatch": "3.0.4",
+        "natural-compare": "1.2.2",
+        "pathval": "0.1.1",
+        "prompt": "0.2.14",
+        "reserved-words": "0.1.2",
+        "resolve": "1.1.7",
+        "strip-bom": "2.0.0",
+        "strip-json-comments": "1.0.4",
+        "to-double-quotes": "2.0.0",
+        "to-single-quotes": "2.0.1",
+        "vow": "0.4.17",
+        "vow-fs": "0.3.6",
+        "xmlbuilder": "3.1.0"
       },
       "dependencies": {
         "esprima": {
@@ -5701,11 +5701,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "js-yaml": {
@@ -5714,9 +5714,9 @@
           "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.2",
-            "esprima": "^2.6.0",
-            "inherit": "^2.2.2"
+            "argparse": "1.0.10",
+            "esprima": "2.7.3",
+            "inherit": "2.2.6"
           }
         },
         "lodash": {
@@ -5731,7 +5731,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "xmlbuilder": {
@@ -5740,7 +5740,7 @@
           "integrity": "sha1-LIaIjy1OrehQ+jjKf3Ij9yCVFuE=",
           "dev": true,
           "requires": {
-            "lodash": "^3.5.0"
+            "lodash": "3.10.1"
           }
         }
       }
@@ -5751,8 +5751,8 @@
       "integrity": "sha1-9T684CmqMSW9iCkLpQ1k1FEKSHE=",
       "dev": true,
       "requires": {
-        "comment-parser": "^0.3.1",
-        "jsdoctypeparser": "~1.2.0"
+        "comment-parser": "0.3.2",
+        "jsdoctypeparser": "1.2.0"
       }
     },
     "jscs-preset-wikimedia": {
@@ -5767,7 +5767,7 @@
       "integrity": "sha1-597cFToRhJ/8UUEUSuhqfvDCU5I=",
       "dev": true,
       "requires": {
-        "lodash": "^3.7.0"
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -5784,14 +5784,14 @@
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
-        "cli": "~1.0.0",
-        "console-browserify": "1.1.x",
-        "exit": "0.1.x",
-        "htmlparser2": "3.8.x",
-        "lodash": "3.7.x",
-        "minimatch": "~3.0.2",
-        "shelljs": "0.3.x",
-        "strip-json-comments": "1.0.x"
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
       },
       "dependencies": {
         "cli": {
@@ -5801,7 +5801,7 @@
           "dev": true,
           "requires": {
             "exit": "0.1.2",
-            "glob": "^7.1.1"
+            "glob": "7.1.2"
           }
         },
         "glob": {
@@ -5810,12 +5810,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "lodash": {
@@ -5830,7 +5830,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "shelljs": {
@@ -5847,12 +5847,12 @@
       "integrity": "sha1-JCCCosA1rgP9gQROBXDMQgjPbmE=",
       "dev": true,
       "requires": {
-        "beeper": "^1.1.0",
-        "chalk": "^1.0.0",
-        "log-symbols": "^1.0.0",
-        "plur": "^2.1.0",
-        "string-length": "^1.0.0",
-        "text-table": "^0.2.0"
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "plur": "2.1.2",
+        "string-length": "1.0.1",
+        "text-table": "0.2.0"
       }
     },
     "json-parse-better-errors": {
@@ -5880,7 +5880,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -5895,7 +5895,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "graceful-fs": {
@@ -5920,8 +5920,8 @@
       "integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
       "dev": true,
       "requires": {
-        "JSV": "^4.0.x",
-        "nomnom": "^1.5.x"
+        "JSV": "4.0.2",
+        "nomnom": "1.8.1"
       }
     },
     "jsonparse": {
@@ -5955,11 +5955,11 @@
       "integrity": "sha1-48KmxtcGrG5gMxQDbUPNQL7v3zc=",
       "dev": true,
       "requires": {
-        "core-js": "~2.3.0",
-        "es6-promise": "~3.0.2",
-        "lie": "~3.1.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.0.6"
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
       },
       "dependencies": {
         "es6-promise": {
@@ -5980,12 +5980,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -6002,31 +6002,31 @@
       "integrity": "sha1-TS25QChQpmVR+nhLAWT7CCTtjEs=",
       "dev": true,
       "requires": {
-        "bluebird": "^3.3.0",
-        "body-parser": "^1.16.1",
-        "chokidar": "^1.4.1",
-        "colors": "^1.1.0",
-        "combine-lists": "^1.0.0",
-        "connect": "^3.6.0",
-        "core-js": "^2.2.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.0",
-        "expand-braces": "^0.1.1",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "http-proxy": "^1.13.0",
-        "isbinaryfile": "^3.0.0",
-        "lodash": "^4.17.4",
-        "log4js": "^2.3.9",
-        "mime": "^1.3.4",
-        "minimatch": "^3.0.2",
-        "optimist": "^0.6.1",
-        "qjobs": "^1.1.4",
-        "range-parser": "^1.2.0",
-        "rimraf": "^2.6.0",
-        "safe-buffer": "^5.0.1",
+        "bluebird": "3.5.1",
+        "body-parser": "1.18.2",
+        "chokidar": "1.7.0",
+        "colors": "1.2.1",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.6",
+        "core-js": "2.3.0",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "http-proxy": "1.17.0",
+        "isbinaryfile": "3.0.2",
+        "lodash": "4.17.5",
+        "log4js": "2.5.3",
+        "mime": "1.6.0",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.2.0",
+        "range-parser": "1.2.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.1",
         "socket.io": "2.0.4",
-        "source-map": "^0.6.1",
+        "source-map": "0.6.1",
         "tmp": "0.0.33",
         "useragent": "2.2.1"
       },
@@ -6045,7 +6045,7 @@
           "requires": {
             "debug": "2.6.9",
             "finalhandler": "1.1.0",
-            "parseurl": "~1.3.2",
+            "parseurl": "1.3.2",
             "utils-merge": "1.0.1"
           }
         },
@@ -6064,12 +6064,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -6096,7 +6096,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "range-parser": {
@@ -6111,7 +6111,7 @@
           "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "source-map": {
@@ -6126,7 +6126,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         }
       }
@@ -6137,8 +6137,8 @@
       "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
-        "fs-access": "^1.0.0",
-        "which": "^1.2.1"
+        "fs-access": "1.0.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "which": {
@@ -6147,7 +6147,7 @@
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         }
       }
@@ -6158,11 +6158,11 @@
       "integrity": "sha1-Wv+LOc9plNwi3kyENix2ABtjfPY=",
       "dev": true,
       "requires": {
-        "dateformat": "^1.0.6",
-        "istanbul": "^0.4.0",
-        "lodash": "^3.8.0",
-        "minimatch": "^3.0.0",
-        "source-map": "^0.5.1"
+        "dateformat": "1.0.12",
+        "istanbul": "0.4.5",
+        "lodash": "3.10.1",
+        "minimatch": "3.0.4",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "dateformat": {
@@ -6171,8 +6171,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "lodash": {
@@ -6187,7 +6187,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "source-map": {
@@ -6210,7 +6210,7 @@
       "integrity": "sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=",
       "dev": true,
       "requires": {
-        "lodash": "^4.6.1"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "lodash": {
@@ -6233,8 +6233,8 @@
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "^4.0.1",
-        "phantomjs-prebuilt": "^2.1.7"
+        "lodash": "4.17.5",
+        "phantomjs-prebuilt": "2.1.16"
       },
       "dependencies": {
         "lodash": {
@@ -6257,10 +6257,10 @@
       "integrity": "sha1-byVY3e889Wh5+idUDIrp+L/Ra8o=",
       "dev": true,
       "requires": {
-        "q": "^1.5.0",
-        "sauce-connect-launcher": "^1.2.2",
-        "saucelabs": "^1.4.0",
-        "wd": "^1.4.0"
+        "q": "1.5.1",
+        "sauce-connect-launcher": "1.2.3",
+        "saucelabs": "1.4.0",
+        "wd": "1.6.2"
       },
       "dependencies": {
         "q": {
@@ -6275,7 +6275,7 @@
           "integrity": "sha1-uTSpr52ih0s/QKrh/N5QpEZvXzg=",
           "dev": true,
           "requires": {
-            "https-proxy-agent": "^1.0.0"
+            "https-proxy-agent": "1.0.0"
           }
         }
       }
@@ -6298,7 +6298,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -6307,7 +6307,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "graceful-fs": {
@@ -6331,7 +6331,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.6"
       }
     },
     "lcov-parse": {
@@ -6346,14 +6346,14 @@
       "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
       "dev": true,
       "requires": {
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "mime": "^1.2.11",
-        "mkdirp": "^0.5.0",
-        "promise": "^7.1.1",
+        "errno": "0.1.7",
+        "graceful-fs": "4.1.11",
+        "image-size": "0.5.5",
+        "mime": "1.4.1",
+        "mkdirp": "0.5.0",
+        "promise": "7.3.1",
         "request": "2.81.0",
-        "source-map": "^0.5.3"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "ajv": {
@@ -6363,8 +6363,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "assert-plus": {
@@ -6387,7 +6387,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "cryptiles": {
@@ -6397,7 +6397,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "form-data": {
@@ -6407,9 +6407,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "graceful-fs": {
@@ -6433,8 +6433,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "hawk": {
@@ -6444,10 +6444,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -6463,9 +6463,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "performance-now": {
@@ -6489,28 +6489,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -6520,7 +6520,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "source-map": {
@@ -6539,8 +6539,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prelude-ls": "~1.1.0",
-        "type-check": "~0.3.1"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "libbase64": {
@@ -6580,7 +6580,7 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "dev": true,
       "requires": {
-        "immediate": "~3.0.5"
+        "immediate": "3.0.6"
       }
     },
     "livereload-js": {
@@ -6595,12 +6595,12 @@
       "integrity": "sha1-UgkNSiDG5j90p2SPJJsZ57f87CQ=",
       "dev": true,
       "requires": {
-        "cson": "~3.0.2",
-        "glob": "~5.0.15",
-        "jit-grunt": "~0.10.0",
-        "js-yaml": "~3.4.3",
-        "load-grunt-tasks": "~3.3.0",
-        "lodash": "~3.10.1"
+        "cson": "3.0.2",
+        "glob": "5.0.15",
+        "jit-grunt": "0.10.0",
+        "js-yaml": "3.4.6",
+        "load-grunt-tasks": "3.3.0",
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "esprima": {
@@ -6615,11 +6615,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "js-yaml": {
@@ -6628,9 +6628,9 @@
           "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.2",
-            "esprima": "^2.6.0",
-            "inherit": "^2.2.2"
+            "argparse": "1.0.10",
+            "esprima": "2.7.3",
+            "inherit": "2.2.6"
           }
         },
         "lodash": {
@@ -6645,7 +6645,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -6656,9 +6656,9 @@
       "integrity": "sha1-vliSkJRY2T3fdp60vGhRAggMYyE=",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "multimatch": "^2.0.0",
-        "pkg-up": "^1.0.0"
+        "arrify": "1.0.1",
+        "multimatch": "2.1.0",
+        "pkg-up": "1.0.0"
       }
     },
     "load-json-file": {
@@ -6667,11 +6667,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -6688,8 +6688,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -6730,8 +6730,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -6740,7 +6740,7 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "log-driver": {
@@ -6755,7 +6755,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "log4js": {
@@ -6764,19 +6764,19 @@
       "integrity": "sha512-YL/qpTxYtK0iWWbuKCrevDZz5lh+OjyHHD+mICqpjnYGKdNRBvPeh/1uYjkKUemT1CSO4wwLOwphWMpKAnD9kw==",
       "dev": true,
       "requires": {
-        "amqplib": "^0.5.2",
-        "axios": "^0.15.3",
-        "circular-json": "^0.5.1",
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "hipchat-notifier": "^1.1.0",
-        "loggly": "^1.1.0",
-        "mailgun-js": "^0.7.0",
-        "nodemailer": "^2.5.0",
-        "redis": "^2.7.1",
-        "semver": "^5.3.0",
-        "slack-node": "~0.2.0",
-        "streamroller": "^0.7.0"
+        "amqplib": "0.5.2",
+        "axios": "0.15.3",
+        "circular-json": "0.5.3",
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "hipchat-notifier": "1.1.0",
+        "loggly": "1.1.1",
+        "mailgun-js": "0.7.15",
+        "nodemailer": "2.7.2",
+        "redis": "2.8.0",
+        "semver": "5.5.0",
+        "slack-node": "0.2.0",
+        "streamroller": "0.7.0"
       }
     },
     "loggly": {
@@ -6786,9 +6786,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "json-stringify-safe": "5.0.x",
-        "request": "2.75.x",
-        "timespan": "2.3.x"
+        "json-stringify-safe": "5.0.1",
+        "request": "2.75.0",
+        "timespan": "2.3.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -6812,7 +6812,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "readable-stream": "~2.0.5"
+            "readable-stream": "2.0.6"
           }
         },
         "boom": {
@@ -6821,7 +6821,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "caseless": {
@@ -6845,7 +6845,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "form-data": {
@@ -6855,9 +6855,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.11"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "har-validator": {
@@ -6867,10 +6867,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
+            "chalk": "1.1.3",
+            "commander": "2.15.1",
+            "is-my-json-valid": "2.17.2",
+            "pinkie-promise": "2.0.1"
           }
         },
         "hawk": {
@@ -6880,10 +6880,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -6899,9 +6899,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "node-uuid": {
@@ -6932,12 +6932,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
@@ -6947,27 +6947,27 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "bl": "~1.1.2",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.0.0",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "node-uuid": "~1.4.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.2.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.0.0",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.3",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3"
           }
         },
         "sntp": {
@@ -6977,7 +6977,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "string_decoder": {
@@ -7008,8 +7008,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lower-case": {
@@ -7024,7 +7024,7 @@
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.2"
+        "lower-case": "1.1.4"
       }
     },
     "mailcomposer": {
@@ -7045,15 +7045,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "~2.1.2",
-        "debug": "~2.2.0",
-        "form-data": "~2.1.1",
-        "inflection": "~1.10.0",
-        "is-stream": "^1.1.0",
-        "path-proxy": "~1.0.0",
-        "proxy-agent": "~2.0.0",
-        "q": "~1.4.0",
-        "tsscmp": "~1.0.0"
+        "async": "2.1.5",
+        "debug": "2.2.0",
+        "form-data": "2.1.4",
+        "inflection": "1.10.0",
+        "is-stream": "1.1.0",
+        "path-proxy": "1.0.0",
+        "proxy-agent": "2.0.0",
+        "q": "1.4.1",
+        "tsscmp": "1.0.5"
       },
       "dependencies": {
         "async": {
@@ -7063,7 +7063,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "debug": {
@@ -7083,9 +7083,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "lodash": {
@@ -7129,10 +7129,10 @@
       "integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "figures": "^1.0.1",
-        "gzip-size": "^1.0.0",
-        "pretty-bytes": "^1.0.0"
+        "chalk": "1.1.3",
+        "figures": "1.7.0",
+        "gzip-size": "1.0.0",
+        "pretty-bytes": "1.0.4"
       }
     },
     "media-typer": {
@@ -7147,16 +7147,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       }
     },
     "micromatch": {
@@ -7165,19 +7165,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       },
       "dependencies": {
         "normalize-path": {
@@ -7186,7 +7186,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         }
       }
@@ -7209,7 +7209,7 @@
       "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimeparse": {
@@ -7230,7 +7230,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -7245,8 +7245,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "minipass": {
@@ -7255,8 +7255,8 @@
       "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.1",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.1",
+        "yallist": "3.0.2"
       }
     },
     "minizlib": {
@@ -7266,7 +7266,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.2.4"
       }
     },
     "mkdirp": {
@@ -7298,11 +7298,11 @@
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
       "dev": true,
       "requires": {
-        "basic-auth": "~2.0.0",
+        "basic-auth": "2.0.0",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.1"
+        "depd": "1.1.2",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -7328,10 +7328,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -7340,7 +7340,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -7370,7 +7370,7 @@
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
       "dev": true,
       "requires": {
-        "xml-char-classes": "^1.0.0"
+        "xml-char-classes": "1.0.0"
       }
     },
     "ncp": {
@@ -7386,9 +7386,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.21",
+        "sax": "1.2.4"
       },
       "dependencies": {
         "debug": {
@@ -7408,7 +7408,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         }
       }
@@ -7432,7 +7432,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "nodemailer": {
@@ -7465,8 +7465,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ip": "^1.1.2",
-            "smart-buffer": "^1.0.4"
+            "ip": "1.1.5",
+            "smart-buffer": "1.1.15"
           }
         }
       }
@@ -7533,8 +7533,8 @@
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
+        "chalk": "0.4.0",
+        "underscore": "1.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7549,9 +7549,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
           }
         },
         "strip-ansi": {
@@ -7574,7 +7574,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -7583,10 +7583,10 @@
       "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -7601,115 +7601,115 @@
       "integrity": "sha512-DowXzQwtSWDtbAjuWecuEiismR0VdNEYaL3VxNTYTdW6AGkYxfGk9LUZ/rt6etEyiH4IEk95HkJeGfXE5Rz9xQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.3.2",
-        "abbrev": "~1.1.1",
-        "ansi-regex": "~3.0.0",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
-        "archy": "~1.0.0",
-        "bin-links": "^1.1.0",
-        "bluebird": "~3.5.1",
-        "cacache": "^10.0.4",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "cli-table2": "~0.2.0",
-        "cmd-shim": "~2.0.2",
-        "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.6.0",
-        "iferr": "~0.1.5",
-        "imurmurhash": "*",
-        "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
-        "ini": "^1.3.5",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "~1.0.0",
-        "json-parse-better-errors": "^1.0.1",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^1.6.0",
-        "libnpx": "^10.0.1",
-        "lockfile": "~1.0.3",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "~4.1.1",
-        "meant": "~1.0.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "move-concurrently": "^1.0.1",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.0.1",
-        "npm-package-arg": "~6.0.0",
-        "npm-packlist": "~1.1.10",
-        "npm-profile": "^3.0.1",
-        "npm-registry-client": "^8.5.1",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "~1.4.3",
-        "osenv": "^0.1.5",
-        "pacote": "^7.6.1",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
-        "qrcode-terminal": "~0.11.0",
-        "query-string": "^5.1.0",
-        "qw": "~1.0.1",
-        "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
-        "read-package-tree": "~5.1.6",
-        "readable-stream": "^2.3.5",
-        "readdir-scoped-modules": "*",
-        "request": "~2.83.0",
-        "retry": "~0.10.1",
-        "rimraf": "~2.6.2",
-        "safe-buffer": "~5.1.1",
-        "semver": "^5.5.0",
-        "sha": "~2.0.1",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^5.2.4",
-        "strip-ansi": "~4.0.0",
-        "tar": "^4.4.0",
-        "text-table": "~0.2.0",
+        "JSONStream": "1.3.2",
+        "abbrev": "1.1.1",
+        "ansi-regex": "3.0.0",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.0",
+        "bluebird": "3.5.1",
+        "cacache": "10.0.4",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-table2": "0.2.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.6.0",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "1.0.0",
+        "json-parse-better-errors": "1.0.1",
+        "lazy-property": "1.0.0",
+        "libcipm": "1.6.0",
+        "libnpx": "10.0.1",
+        "lockfile": "1.0.3",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.1",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.1",
+        "npm-package-arg": "6.0.0",
+        "npm-packlist": "1.1.10",
+        "npm-profile": "3.0.1",
+        "npm-registry-client": "8.5.1",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.5",
+        "pacote": "7.6.1",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.11.0",
+        "query-string": "5.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.1.6",
+        "readable-stream": "2.3.5",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.83.0",
+        "retry": "0.10.1",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.1",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "5.2.4",
+        "strip-ansi": "4.0.0",
+        "tar": "4.4.0",
+        "text-table": "0.2.0",
         "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
-        "unpipe": "~1.0.0",
-        "update-notifier": "~2.3.0",
-        "uuid": "^3.2.1",
-        "validate-npm-package-license": "*",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "~1.3.0",
-        "worker-farm": "^1.5.4",
-        "wrappy": "~1.0.2",
-        "write-file-atomic": "^2.3.0"
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.3.0",
+        "uuid": "3.2.1",
+        "validate-npm-package-license": "3.0.1",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.0",
+        "worker-farm": "1.5.4",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -7717,8 +7717,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
           },
           "dependencies": {
             "jsonparse": {
@@ -7768,12 +7768,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "fs-write-stream-atomic": "^1.0.10",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
-            "slide": "^1.1.6"
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "fs-write-stream-atomic": "1.0.10",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "slide": "1.1.6"
           }
         },
         "bluebird": {
@@ -7786,19 +7786,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.1",
-            "mississippi": "^2.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^5.2.4",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.1",
+            "mississippi": "2.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "5.2.4",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
           },
           "dependencies": {
             "mississippi": {
@@ -7806,16 +7806,16 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.1",
+                "duplexify": "3.5.4",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.4.0",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
               },
               "dependencies": {
                 "concat-stream": {
@@ -7823,9 +7823,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5",
+                    "typedarray": "0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -7840,10 +7840,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "end-of-stream": "^1.0.0",
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0",
-                    "stream-shift": "^1.0.0"
+                    "end-of-stream": "1.4.1",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5",
+                    "stream-shift": "1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -7858,7 +7858,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "once": "^1.4.0"
+                    "once": "1.4.0"
                   }
                 },
                 "flush-write-stream": {
@@ -7866,8 +7866,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.4"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
                   }
                 },
                 "from2": {
@@ -7875,8 +7875,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
                   }
                 },
                 "parallel-transform": {
@@ -7884,9 +7884,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "cyclist": "~0.2.2",
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.1.5"
+                    "cyclist": "0.2.2",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
                   },
                   "dependencies": {
                     "cyclist": {
@@ -7901,8 +7901,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
                   }
                 },
                 "pumpify": {
@@ -7910,9 +7910,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "duplexify": "^3.5.3",
-                    "inherits": "^2.0.3",
-                    "pump": "^2.0.0"
+                    "duplexify": "3.5.4",
+                    "inherits": "2.0.3",
+                    "pump": "2.0.1"
                   }
                 },
                 "stream-each": {
@@ -7920,8 +7920,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "stream-shift": "^1.0.0"
+                    "end-of-stream": "1.4.1",
+                    "stream-shift": "1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -7936,8 +7936,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "readable-stream": "^2.1.5",
-                    "xtend": "~4.0.1"
+                    "readable-stream": "2.3.5",
+                    "xtend": "4.0.1"
                   },
                   "dependencies": {
                     "xtend": {
@@ -7971,9 +7971,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "colors": "^1.1.2",
-            "lodash": "^3.10.1",
-            "string-width": "^1.0.1"
+            "colors": "1.1.2",
+            "lodash": "3.10.1",
+            "string-width": "1.0.2"
           },
           "dependencies": {
             "colors": {
@@ -7992,9 +7992,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               },
               "dependencies": {
                 "code-point-at": {
@@ -8007,7 +8007,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "^1.0.0"
+                    "number-is-nan": "1.0.1"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -8022,7 +8022,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -8041,8 +8041,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
           }
         },
         "columnify": {
@@ -8050,8 +8050,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
           },
           "dependencies": {
             "strip-ansi": {
@@ -8059,7 +8059,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -8074,7 +8074,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "defaults": "^1.0.3"
+                "defaults": "1.0.3"
               },
               "dependencies": {
                 "defaults": {
@@ -8082,7 +8082,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "clone": "^1.0.2"
+                    "clone": "1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -8101,8 +8101,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
           },
           "dependencies": {
             "proto-list": {
@@ -8132,8 +8132,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
           },
           "dependencies": {
             "asap": {
@@ -8158,9 +8158,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
           }
         },
         "fs-write-stream-atomic": {
@@ -8168,10 +8168,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.5"
           }
         },
         "gentle-fs": {
@@ -8179,14 +8179,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
           }
         },
         "glob": {
@@ -8194,12 +8194,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           },
           "dependencies": {
             "fs.realpath": {
@@ -8212,7 +8212,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -8220,7 +8220,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "^1.0.0",
+                    "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -8275,8 +8275,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -8294,14 +8294,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
-            "validate-npm-package-name": "^3.0.0"
+            "glob": "7.1.2",
+            "npm-package-arg": "6.0.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.1",
+            "validate-npm-package-name": "3.0.0"
           },
           "dependencies": {
             "promzard": {
@@ -8309,7 +8309,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "read": "1"
+                "read": "1.0.7"
               }
             }
           }
@@ -8344,19 +8344,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bin-links": "^1.1.0",
-            "bluebird": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "lock-verify": "^2.0.0",
-            "npm-lifecycle": "^2.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.0.0",
-            "pacote": "^7.5.1",
-            "protoduck": "^5.0.0",
-            "read-package-json": "^2.0.12",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.5.4"
+            "bin-links": "1.1.0",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.0",
+            "npm-lifecycle": "2.0.1",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.0.0",
+            "pacote": "7.6.1",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.5.4"
           },
           "dependencies": {
             "lock-verify": {
@@ -8364,8 +8364,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "npm-package-arg": "^5.1.2",
-                "semver": "^5.4.1"
+                "npm-package-arg": "5.1.2",
+                "semver": "5.5.0"
               },
               "dependencies": {
                 "npm-package-arg": {
@@ -8373,10 +8373,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hosted-git-info": "^2.4.2",
-                    "osenv": "^0.1.4",
-                    "semver": "^5.1.0",
-                    "validate-npm-package-name": "^3.0.0"
+                    "hosted-git-info": "2.6.0",
+                    "osenv": "0.1.5",
+                    "semver": "5.5.0",
+                    "validate-npm-package-name": "3.0.0"
                   }
                 }
               }
@@ -8391,7 +8391,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "genfun": "^4.0.1"
+                "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -8406,8 +8406,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "errno": "~0.1.7",
-                "xtend": "~4.0.1"
+                "errno": "0.1.7",
+                "xtend": "4.0.1"
               },
               "dependencies": {
                 "errno": {
@@ -8415,7 +8415,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "prr": "~1.0.1"
+                    "prr": "1.0.1"
                   },
                   "dependencies": {
                     "prr": {
@@ -8439,14 +8439,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "update-notifier": "2.3.0",
+            "which": "1.3.0",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
           },
           "dependencies": {
             "dotenv": {
@@ -8464,18 +8464,18 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "cliui": "4.0.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
               },
               "dependencies": {
                 "cliui": {
@@ -8483,9 +8483,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "string-width": "^2.1.1",
-                    "strip-ansi": "^4.0.0",
-                    "wrap-ansi": "^2.0.0"
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
+                    "wrap-ansi": "2.1.0"
                   },
                   "dependencies": {
                     "wrap-ansi": {
@@ -8493,8 +8493,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
                       },
                       "dependencies": {
                         "string-width": {
@@ -8502,9 +8502,9 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -8517,7 +8517,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -8534,7 +8534,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "ansi-regex": "^2.0.0"
+                            "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -8558,7 +8558,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "locate-path": "^2.0.0"
+                    "locate-path": "2.0.0"
                   },
                   "dependencies": {
                     "locate-path": {
@@ -8566,8 +8566,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                       },
                       "dependencies": {
                         "p-locate": {
@@ -8575,7 +8575,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "p-limit": "^1.1.0"
+                            "p-limit": "1.2.0"
                           },
                           "dependencies": {
                             "p-limit": {
@@ -8583,7 +8583,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "p-try": "^1.0.0"
+                                "p-try": "1.0.0"
                               },
                               "dependencies": {
                                 "p-try": {
@@ -8614,9 +8614,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "execa": "^0.7.0",
-                    "lcid": "^1.0.0",
-                    "mem": "^1.1.0"
+                    "execa": "0.7.0",
+                    "lcid": "1.0.0",
+                    "mem": "1.1.0"
                   },
                   "dependencies": {
                     "execa": {
@@ -8624,13 +8624,13 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
@@ -8638,9 +8638,9 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
+                            "lru-cache": "4.1.1",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
                           },
                           "dependencies": {
                             "shebang-command": {
@@ -8648,7 +8648,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "shebang-regex": "^1.0.0"
+                                "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -8675,7 +8675,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "path-key": "^2.0.0"
+                            "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
@@ -8707,7 +8707,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
@@ -8722,7 +8722,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "mimic-fn": "1.2.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
@@ -8754,8 +8754,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -8780,7 +8780,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "camelcase": "^4.1.0"
+                    "camelcase": "4.1.0"
                   },
                   "dependencies": {
                     "camelcase": {
@@ -8809,8 +8809,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
           },
           "dependencies": {
             "lodash._createset": {
@@ -8840,7 +8840,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._getnative": "^3.0.0"
+            "lodash._getnative": "3.9.1"
           }
         },
         "lodash._getnative": {
@@ -8878,8 +8878,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           },
           "dependencies": {
             "pseudomap": {
@@ -8904,16 +8904,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "concat-stream": "1.6.1",
+            "duplexify": "3.5.4",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.4.0",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
           },
           "dependencies": {
             "concat-stream": {
@@ -8921,9 +8921,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5",
+                "typedarray": "0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -8938,10 +8938,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -8956,7 +8956,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
               }
             },
             "flush-write-stream": {
@@ -8964,8 +8964,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5"
               }
             },
             "from2": {
@@ -8973,8 +8973,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5"
               }
             },
             "parallel-transform": {
@@ -8982,9 +8982,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5"
               },
               "dependencies": {
                 "cyclist": {
@@ -8999,8 +8999,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             },
             "pumpify": {
@@ -9008,9 +9008,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "duplexify": "^3.5.3",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.5.4",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
               },
               "dependencies": {
                 "pump": {
@@ -9018,8 +9018,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
                   }
                 }
               }
@@ -9029,8 +9029,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -9045,8 +9045,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.5",
+                "xtend": "4.0.1"
               },
               "dependencies": {
                 "xtend": {
@@ -9078,12 +9078,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           },
           "dependencies": {
             "copy-concurrently": {
@@ -9091,12 +9091,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
               }
             },
             "run-queue": {
@@ -9104,7 +9104,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
               }
             }
           }
@@ -9114,8 +9114,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "normalize-package-data": {
@@ -9123,10 +9123,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
@@ -9134,7 +9134,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -9156,7 +9156,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "5.5.0"
           }
         },
         "npm-lifecycle": {
@@ -9164,14 +9164,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.6.2",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
             "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.0"
+            "umask": "1.1.0",
+            "which": "1.3.0"
           },
           "dependencies": {
             "byline": {
@@ -9184,19 +9184,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "2",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
+                "fstream": "1.0.11",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.5",
+                "request": "2.83.0",
+                "rimraf": "2.6.2",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.3.0"
               },
               "dependencies": {
                 "fstream": {
@@ -9204,10 +9204,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "inherits": "~2.0.0",
-                    "mkdirp": ">=0.5 0",
-                    "rimraf": "2"
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.2"
                   }
                 },
                 "minimatch": {
@@ -9215,7 +9215,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.11"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -9223,7 +9223,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -9246,7 +9246,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "abbrev": "1"
+                    "abbrev": "1.1.1"
                   }
                 },
                 "semver": {
@@ -9259,9 +9259,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "block-stream": "*",
-                    "fstream": "^1.0.2",
-                    "inherits": "2"
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
                   },
                   "dependencies": {
                     "block-stream": {
@@ -9269,7 +9269,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "inherits": "~2.0.0"
+                        "inherits": "2.0.3"
                       }
                     }
                   }
@@ -9288,10 +9288,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.5.0",
-            "osenv": "^0.1.4",
-            "semver": "^5.4.1",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-packlist": {
@@ -9299,8 +9299,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           },
           "dependencies": {
             "ignore-walk": {
@@ -9308,7 +9308,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "minimatch": "^3.0.4"
+                "minimatch": "3.0.4"
               },
               "dependencies": {
                 "minimatch": {
@@ -9316,7 +9316,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -9324,7 +9324,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -9356,8 +9356,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "make-fetch-happen": "^2.5.0"
+            "aproba": "1.2.0",
+            "make-fetch-happen": "2.6.0"
           },
           "dependencies": {
             "make-fetch-happen": {
@@ -9365,17 +9365,17 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "agentkeepalive": "^3.3.0",
-                "cacache": "^10.0.0",
-                "http-cache-semantics": "^3.8.0",
-                "http-proxy-agent": "^2.0.0",
-                "https-proxy-agent": "^2.1.0",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.2.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.0.0"
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.1.1",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.2.4"
               },
               "dependencies": {
                 "agentkeepalive": {
@@ -9383,7 +9383,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "humanize-ms": "^1.2.1"
+                    "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
@@ -9391,7 +9391,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ms": "^2.0.0"
+                        "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
@@ -9413,8 +9413,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "4",
-                    "debug": "2"
+                    "agent-base": "4.2.0",
+                    "debug": "2.6.9"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -9422,7 +9422,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -9430,7 +9430,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -9464,8 +9464,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -9473,7 +9473,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -9481,7 +9481,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -9515,16 +9515,16 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^1.0.0",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
+                    "concat-stream": "1.6.0",
+                    "duplexify": "3.5.3",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
                   },
                   "dependencies": {
                     "concat-stream": {
@@ -9532,9 +9532,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5",
+                        "typedarray": "0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -9549,10 +9549,10 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "end-of-stream": "^1.0.0",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5",
+                        "stream-shift": "1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -9567,7 +9567,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                       }
                     },
                     "flush-write-stream": {
@@ -9575,8 +9575,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.4"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "from2": {
@@ -9584,8 +9584,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "parallel-transform": {
@@ -9593,9 +9593,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "cyclist": "~0.2.2",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.1.5"
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -9610,8 +9610,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
                       }
                     },
                     "pumpify": {
@@ -9619,9 +9619,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "duplexify": "^3.5.3",
-                        "inherits": "^2.0.3",
-                        "pump": "^2.0.0"
+                        "duplexify": "3.5.3",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
                       },
                       "dependencies": {
                         "pump": {
@@ -9629,8 +9629,8 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         }
                       }
@@ -9640,8 +9640,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -9656,8 +9656,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -9674,9 +9674,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
@@ -9684,7 +9684,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "iconv-lite": "~0.4.13"
+                        "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -9706,8 +9706,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
                   },
                   "dependencies": {
                     "err-code": {
@@ -9722,8 +9722,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -9731,7 +9731,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -9739,7 +9739,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -9756,8 +9756,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
                       },
                       "dependencies": {
                         "ip": {
@@ -9783,18 +9783,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
+            "concat-stream": "1.6.1",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.0.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.83.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.1",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.2.4"
           },
           "dependencies": {
             "concat-stream": {
@@ -9802,9 +9802,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5",
+                "typedarray": "0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -9826,10 +9826,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
@@ -9837,8 +9837,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.5"
               },
               "dependencies": {
                 "delegates": {
@@ -9858,14 +9858,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
               },
               "dependencies": {
                 "object-assign": {
@@ -9883,9 +9883,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -9898,7 +9898,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -9915,7 +9915,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -9930,7 +9930,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "string-width": "^1.0.2"
+                    "string-width": "1.0.2"
                   }
                 }
               }
@@ -9947,7 +9947,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "opener": {
@@ -9960,8 +9960,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           },
           "dependencies": {
             "os-homedir": {
@@ -9981,30 +9981,30 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^10.0.4",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.1",
-            "make-fetch-happen": "^2.6.0",
-            "minimatch": "^3.0.4",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.0.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.1",
-            "semver": "^5.5.0",
-            "ssri": "^5.2.4",
-            "tar": "^4.4.0",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "bluebird": "3.5.1",
+            "cacache": "10.0.4",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.1",
+            "make-fetch-happen": "2.6.0",
+            "minimatch": "3.0.4",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.0.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "semver": "5.5.0",
+            "ssri": "5.2.4",
+            "tar": "4.4.0",
+            "unique-filename": "1.1.0",
+            "which": "1.3.0"
           },
           "dependencies": {
             "get-stream": {
@@ -10017,17 +10017,17 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "agentkeepalive": "^3.3.0",
-                "cacache": "^10.0.0",
-                "http-cache-semantics": "^3.8.0",
-                "http-proxy-agent": "^2.0.0",
-                "https-proxy-agent": "^2.1.0",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.2.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.0.0"
+                "agentkeepalive": "3.4.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.0",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.2.4"
               },
               "dependencies": {
                 "agentkeepalive": {
@@ -10035,7 +10035,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "humanize-ms": "^1.2.1"
+                    "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
@@ -10043,7 +10043,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ms": "^2.0.0"
+                        "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
@@ -10065,7 +10065,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "4",
+                    "agent-base": "4.2.0",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -10074,7 +10074,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -10082,7 +10082,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -10116,8 +10116,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -10125,7 +10125,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -10133,7 +10133,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -10167,16 +10167,16 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^1.0.0",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
+                    "concat-stream": "1.6.1",
+                    "duplexify": "3.5.4",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
                   },
                   "dependencies": {
                     "concat-stream": {
@@ -10184,9 +10184,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5",
+                        "typedarray": "0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -10201,10 +10201,10 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "end-of-stream": "^1.0.0",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5",
+                        "stream-shift": "1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -10219,7 +10219,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                       }
                     },
                     "flush-write-stream": {
@@ -10227,8 +10227,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.4"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "from2": {
@@ -10236,8 +10236,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "parallel-transform": {
@@ -10245,9 +10245,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "cyclist": "~0.2.2",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.1.5"
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -10262,8 +10262,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
                       }
                     },
                     "pumpify": {
@@ -10271,9 +10271,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "duplexify": "^3.5.3",
-                        "inherits": "^2.0.3",
-                        "pump": "^2.0.0"
+                        "duplexify": "3.5.4",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
                       },
                       "dependencies": {
                         "pump": {
@@ -10281,8 +10281,8 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         }
                       }
@@ -10292,8 +10292,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -10308,8 +10308,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -10326,9 +10326,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
@@ -10336,7 +10336,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "iconv-lite": "~0.4.13"
+                        "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -10358,8 +10358,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -10367,7 +10367,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -10375,7 +10375,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -10392,8 +10392,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
                       },
                       "dependencies": {
                         "ip": {
@@ -10417,7 +10417,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -10425,7 +10425,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "^1.0.0",
+                    "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -10448,8 +10448,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "npm-package-arg": "^6.0.0",
-                "semver": "^5.4.1"
+                "npm-package-arg": "6.0.0",
+                "semver": "5.5.0"
               }
             },
             "promise-retry": {
@@ -10457,8 +10457,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "err-code": "^1.0.0",
-                "retry": "^0.10.0"
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
               },
               "dependencies": {
                 "err-code": {
@@ -10473,7 +10473,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "genfun": "^4.0.1"
+                "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -10505,9 +10505,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
+            "decode-uri-component": "0.2.0",
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
           },
           "dependencies": {
             "decode-uri-component": {
@@ -10537,7 +10537,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "~0.0.4"
+            "mute-stream": "0.0.7"
           },
           "dependencies": {
             "mute-stream": {
@@ -10552,7 +10552,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2"
+            "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
@@ -10560,13 +10560,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
           },
           "dependencies": {
             "util-extend": {
@@ -10581,11 +10581,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.1",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
           },
           "dependencies": {
             "json-parse-better-errors": {
@@ -10605,11 +10605,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
@@ -10617,13 +10617,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
             "core-util-is": {
@@ -10646,7 +10646,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
               }
             },
             "util-deprecate": {
@@ -10661,10 +10661,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
           }
         },
         "request": {
@@ -10672,28 +10672,28 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           },
           "dependencies": {
             "aws-sign2": {
@@ -10716,7 +10716,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -10741,9 +10741,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
               },
               "dependencies": {
                 "asynckit": {
@@ -10758,8 +10758,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.2.3",
+                "har-schema": "2.0.0"
               },
               "dependencies": {
                 "ajv": {
@@ -10767,10 +10767,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "co": "^4.6.0",
-                    "fast-deep-equal": "^1.0.0",
-                    "json-schema-traverse": "^0.3.0",
-                    "json-stable-stringify": "^1.0.1"
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.0.0",
+                    "json-schema-traverse": "0.3.1",
+                    "json-stable-stringify": "1.0.1"
                   },
                   "dependencies": {
                     "co": {
@@ -10793,7 +10793,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "jsonify": "~0.0.0"
+                        "jsonify": "0.0.0"
                       },
                       "dependencies": {
                         "jsonify": {
@@ -10817,10 +10817,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.0.2"
               },
               "dependencies": {
                 "boom": {
@@ -10828,7 +10828,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "4.x.x"
+                    "hoek": "4.2.0"
                   }
                 },
                 "cryptiles": {
@@ -10836,7 +10836,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "5.x.x"
+                    "boom": "5.2.0"
                   },
                   "dependencies": {
                     "boom": {
@@ -10844,7 +10844,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "hoek": "4.x.x"
+                        "hoek": "4.2.0"
                       }
                     }
                   }
@@ -10859,7 +10859,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "4.x.x"
+                    "hoek": "4.2.0"
                   }
                 }
               }
@@ -10869,9 +10869,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
               },
               "dependencies": {
                 "assert-plus": {
@@ -10905,9 +10905,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "assert-plus": "^1.0.0",
+                        "assert-plus": "1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "^1.2.0"
+                        "extsprintf": "1.3.0"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -10924,14 +10924,14 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "asn1": "~0.2.3",
-                    "assert-plus": "^1.0.0",
-                    "bcrypt-pbkdf": "^1.0.0",
-                    "dashdash": "^1.12.0",
-                    "ecc-jsbn": "~0.1.1",
-                    "getpass": "^0.1.1",
-                    "jsbn": "~0.1.0",
-                    "tweetnacl": "~0.14.0"
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
                   },
                   "dependencies": {
                     "asn1": {
@@ -10945,7 +10945,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "^0.14.3"
+                        "tweetnacl": "0.14.5"
                       }
                     },
                     "dashdash": {
@@ -10953,7 +10953,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "assert-plus": "^1.0.0"
+                        "assert-plus": "1.0.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -10962,7 +10962,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "~0.1.0"
+                        "jsbn": "0.1.1"
                       }
                     },
                     "getpass": {
@@ -10970,7 +10970,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "assert-plus": "^1.0.0"
+                        "assert-plus": "1.0.0"
                       }
                     },
                     "jsbn": {
@@ -11009,7 +11009,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "mime-db": "~1.30.0"
+                "mime-db": "1.30.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -11044,7 +11044,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
               },
               "dependencies": {
                 "punycode": {
@@ -11059,7 +11059,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -11074,7 +11074,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -11092,8 +11092,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.5"
           }
         },
         "slide": {
@@ -11111,8 +11111,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
           },
           "dependencies": {
             "from2": {
@@ -11120,8 +11120,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
               },
               "dependencies": {
                 "readable-stream": {
@@ -11129,10 +11129,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
                     "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
+                    "string_decoder": "0.10.31"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -11159,8 +11159,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "^2.1.5",
-                "stream-shift": "^1.0.0"
+                "readable-stream": "2.3.5",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -11177,7 +11177,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -11185,7 +11185,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -11200,12 +11200,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.3",
-            "minipass": "^2.2.1",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.1",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "fs-minipass": {
@@ -11213,7 +11213,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.1"
               }
             },
             "minipass": {
@@ -11221,7 +11221,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "yallist": "^3.0.0"
+                "yallist": "3.0.2"
               }
             },
             "minizlib": {
@@ -11229,7 +11229,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.1"
               }
             },
             "yallist": {
@@ -11259,7 +11259,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "2.0.0"
           },
           "dependencies": {
             "unique-slug": {
@@ -11267,7 +11267,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
               }
             }
           }
@@ -11282,15 +11282,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "boxen": "1.2.1",
+            "chalk": "2.1.0",
+            "configstore": "3.1.1",
+            "import-lazy": "2.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
           },
           "dependencies": {
             "boxen": {
@@ -11298,13 +11298,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^1.0.0"
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.1.0",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "1.0.0"
               },
               "dependencies": {
                 "ansi-align": {
@@ -11312,7 +11312,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "string-width": "^2.0.0"
+                    "string-width": "2.1.1"
                   }
                 },
                 "camelcase": {
@@ -11330,8 +11330,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -11346,7 +11346,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "execa": "^0.7.0"
+                    "execa": "0.7.0"
                   },
                   "dependencies": {
                     "execa": {
@@ -11354,13 +11354,13 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
@@ -11368,9 +11368,9 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
+                            "lru-cache": "4.1.1",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
                           },
                           "dependencies": {
                             "shebang-command": {
@@ -11378,7 +11378,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "shebang-regex": "^1.0.0"
+                                "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -11405,7 +11405,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "path-key": "^2.0.0"
+                            "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
@@ -11439,7 +11439,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "string-width": "^1.0.1"
+                    "string-width": "1.0.2"
                   },
                   "dependencies": {
                     "string-width": {
@@ -11447,9 +11447,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -11462,7 +11462,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "number-is-nan": "^1.0.0"
+                            "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -11477,7 +11477,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "ansi-regex": "^2.0.0"
+                            "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -11498,9 +11498,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.1.0",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^4.0.0"
+                "ansi-styles": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "4.4.0"
               },
               "dependencies": {
                 "ansi-styles": {
@@ -11508,7 +11508,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "color-convert": "^1.9.0"
+                    "color-convert": "1.9.0"
                   },
                   "dependencies": {
                     "color-convert": {
@@ -11516,7 +11516,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "color-name": "^1.1.1"
+                        "color-name": "1.1.3"
                       },
                       "dependencies": {
                         "color-name": {
@@ -11538,7 +11538,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "has-flag": "^2.0.0"
+                    "has-flag": "2.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
@@ -11555,12 +11555,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.0.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.3.0",
+                "xdg-basedir": "3.0.0"
               },
               "dependencies": {
                 "dot-prop": {
@@ -11568,7 +11568,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-obj": "^1.0.0"
+                    "is-obj": "1.0.1"
                   },
                   "dependencies": {
                     "is-obj": {
@@ -11583,7 +11583,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "pify": "^2.3.0"
+                    "pify": "2.3.0"
                   },
                   "dependencies": {
                     "pify": {
@@ -11598,7 +11598,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "crypto-random-string": "^1.0.0"
+                    "crypto-random-string": "1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
@@ -11620,8 +11620,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
+                "global-dirs": "0.1.0",
+                "is-path-inside": "1.0.0"
               },
               "dependencies": {
                 "global-dirs": {
@@ -11629,7 +11629,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ini": "^1.3.4"
+                    "ini": "1.3.5"
                   }
                 },
                 "is-path-inside": {
@@ -11637,7 +11637,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "path-is-inside": "^1.0.1"
+                    "path-is-inside": "1.0.2"
                   }
                 }
               }
@@ -11652,7 +11652,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "package-json": "^4.0.0"
+                "package-json": "4.0.1"
               },
               "dependencies": {
                 "package-json": {
@@ -11660,10 +11660,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "got": "^6.7.1",
-                    "registry-auth-token": "^3.0.1",
-                    "registry-url": "^3.0.3",
-                    "semver": "^5.1.0"
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.3.1",
+                    "registry-url": "3.1.0",
+                    "semver": "5.5.0"
                   },
                   "dependencies": {
                     "got": {
@@ -11671,17 +11671,17 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "create-error-class": "^3.0.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-redirect": "^1.0.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "lowercase-keys": "^1.0.0",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "unzip-response": "^2.0.1",
-                        "url-parse-lax": "^1.0.0"
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.0",
+                        "safe-buffer": "5.1.1",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
                       },
                       "dependencies": {
                         "create-error-class": {
@@ -11689,7 +11689,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "capture-stack-trace": "^1.0.0"
+                            "capture-stack-trace": "1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
@@ -11744,7 +11744,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "prepend-http": "^1.0.1"
+                            "prepend-http": "1.0.4"
                           },
                           "dependencies": {
                             "prepend-http": {
@@ -11761,8 +11761,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "rc": "^1.1.6",
-                        "safe-buffer": "^5.0.1"
+                        "rc": "1.2.1",
+                        "safe-buffer": "5.1.1"
                       },
                       "dependencies": {
                         "rc": {
@@ -11770,10 +11770,10 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "deep-extend": "~0.4.0",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
+                            "deep-extend": "0.4.2",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -11800,7 +11800,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "rc": "^1.0.1"
+                        "rc": "1.2.1"
                       },
                       "dependencies": {
                         "rc": {
@@ -11808,10 +11808,10 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "deep-extend": "~0.4.0",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
+                            "deep-extend": "0.4.2",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -11842,7 +11842,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "semver": "^5.0.3"
+                "semver": "5.5.0"
               }
             },
             "xdg-basedir": {
@@ -11862,8 +11862,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "~1.0.0",
-            "spdx-expression-parse": "~1.0.0"
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
           },
           "dependencies": {
             "spdx-correct": {
@@ -11871,7 +11871,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-license-ids": "^1.0.2"
+                "spdx-license-ids": "1.2.2"
               },
               "dependencies": {
                 "spdx-license-ids": {
@@ -11893,7 +11893,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtins": "^1.0.3"
+            "builtins": "1.0.3"
           },
           "dependencies": {
             "builtins": {
@@ -11908,7 +11908,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           },
           "dependencies": {
             "isexe": {
@@ -11923,8 +11923,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "errno": "~0.1.7",
-            "xtend": "~4.0.1"
+            "errno": "0.1.7",
+            "xtend": "4.0.1"
           },
           "dependencies": {
             "errno": {
@@ -11932,7 +11932,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "prr": "~1.0.1"
+                "prr": "1.0.1"
               },
               "dependencies": {
                 "prr": {
@@ -11959,9 +11959,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -11987,8 +11987,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.3"
       }
     },
     "null-check": {
@@ -12027,8 +12027,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "on-finished": {
@@ -12052,7 +12052,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "opn": {
@@ -12061,8 +12061,8 @@
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
       }
     },
     "optimist": {
@@ -12071,8 +12071,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -12090,12 +12090,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "deep-is": "~0.1.2",
-        "fast-levenshtein": "~1.0.0",
-        "levn": "~0.2.5",
-        "prelude-ls": "~1.1.1",
-        "type-check": "~0.3.1",
-        "wordwrap": "~0.0.2"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "1.0.7",
+        "levn": "0.2.5",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "0.0.2"
       }
     },
     "options": {
@@ -12116,7 +12116,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -12125,7 +12125,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-try": {
@@ -12141,15 +12141,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3",
-        "get-uri": "2",
-        "http-proxy-agent": "1",
-        "https-proxy-agent": "1",
-        "pac-resolver": "~2.0.0",
-        "raw-body": "2",
-        "socks-proxy-agent": "2"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "get-uri": "2.0.1",
+        "http-proxy-agent": "1.0.0",
+        "https-proxy-agent": "1.0.0",
+        "pac-resolver": "2.0.0",
+        "raw-body": "2.3.2",
+        "socks-proxy-agent": "2.1.1"
       },
       "dependencies": {
         "debug": {
@@ -12171,11 +12171,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "co": "~3.0.6",
-        "degenerator": "~1.0.2",
+        "co": "3.0.6",
+        "degenerator": "1.0.4",
         "ip": "1.0.1",
-        "netmask": "~1.0.4",
-        "thunkify": "~2.1.1"
+        "netmask": "1.0.6",
+        "thunkify": "2.1.2"
       },
       "dependencies": {
         "co": {
@@ -12205,7 +12205,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parse-github-repo-url": {
@@ -12220,10 +12220,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -12232,7 +12232,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-ms": {
@@ -12247,7 +12247,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -12256,7 +12256,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -12271,8 +12271,8 @@
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
       "dev": true,
       "requires": {
-        "camel-case": "^3.0.0",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "3.0.0",
+        "upper-case-first": "1.1.2"
       }
     },
     "path-case": {
@@ -12281,7 +12281,7 @@
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "path-exists": {
@@ -12290,7 +12290,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -12312,7 +12312,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "inflection": "~1.3.0"
+        "inflection": "1.3.8"
       },
       "dependencies": {
         "inflection": {
@@ -12330,9 +12330,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -12367,15 +12367,15 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
+        "es6-promise": "4.2.4",
+        "extract-zip": "1.6.6",
+        "fs-extra": "1.0.0",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.85.0",
+        "request-progress": "2.0.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "which": {
@@ -12384,7 +12384,7 @@
           "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         }
       }
@@ -12407,7 +12407,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-up": {
@@ -12416,7 +12416,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pkginfo": {
@@ -12431,7 +12431,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pop-arrayify": {
@@ -12452,8 +12452,8 @@
       "integrity": "sha1-YY1GJJfpbQb5zaMVsyXMo6JjYDg=",
       "dev": true,
       "requires": {
-        "mini-map": "^1.0.0",
-        "pop-equals": "^1.0.0"
+        "mini-map": "1.0.0",
+        "pop-equals": "1.0.0"
       }
     },
     "pop-compare": {
@@ -12468,7 +12468,7 @@
       "integrity": "sha1-kEFPj9pxo3+IHR5eOi4C7ww7fgs=",
       "dev": true,
       "requires": {
-        "mini-map": "^1.0.0"
+        "mini-map": "1.0.0"
       }
     },
     "pop-has": {
@@ -12477,7 +12477,7 @@
       "integrity": "sha1-myJrWblgq2XqsLQS3VVw3OkOZRw=",
       "dev": true,
       "requires": {
-        "pop-equals": "^1.0.0"
+        "pop-equals": "1.0.0"
       }
     },
     "pop-hash": {
@@ -12486,7 +12486,7 @@
       "integrity": "sha1-vNaUVL0vmd7SC1/Iork9a1+rRMw=",
       "dev": true,
       "requires": {
-        "weak-map": "^1.0.5"
+        "weak-map": "1.0.5"
       }
     },
     "pop-iterate": {
@@ -12501,9 +12501,9 @@
       "integrity": "sha1-WstaxvJMfG/6ssMhUbCtt0Du82M=",
       "dev": true,
       "requires": {
-        "pop-equals": "^1.0.0",
-        "pop-has": "^1.0.0",
-        "pop-swap": "^1.0.0"
+        "pop-equals": "1.0.0",
+        "pop-has": "1.0.0",
+        "pop-swap": "1.0.0"
       }
     },
     "pop-swap": {
@@ -12553,8 +12553,8 @@
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.1.0"
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
       }
     },
     "pretty-ms": {
@@ -12563,9 +12563,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.1",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
+        "is-finite": "1.0.2",
+        "parse-ms": "1.0.1",
+        "plur": "1.0.0"
       },
       "dependencies": {
         "plur": {
@@ -12595,7 +12595,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "prompt": {
@@ -12604,11 +12604,11 @@
       "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
       "dev": true,
       "requires": {
-        "pkginfo": "0.x.x",
-        "read": "1.0.x",
-        "revalidator": "0.1.x",
-        "utile": "0.2.x",
-        "winston": "0.8.x"
+        "pkginfo": "0.4.1",
+        "read": "1.0.7",
+        "revalidator": "0.1.8",
+        "utile": "0.2.1",
+        "winston": "0.8.3"
       }
     },
     "protractor": {
@@ -12617,21 +12617,21 @@
       "integrity": "sha1-uLisStIni7ekYbmaNNeVMglfFLg=",
       "dev": true,
       "requires": {
-        "@types/node": "^6.0.46",
-        "@types/q": "^0.0.32",
-        "@types/selenium-webdriver": "~2.53.39",
-        "blocking-proxy": "^1.0.0",
-        "chalk": "^1.1.3",
-        "glob": "^7.0.3",
+        "@types/node": "6.0.105",
+        "@types/q": "0.0.32",
+        "@types/selenium-webdriver": "2.53.43",
+        "blocking-proxy": "1.0.1",
+        "chalk": "1.1.3",
+        "glob": "7.1.2",
         "jasmine": "2.8.0",
-        "jasminewd2": "^2.1.0",
-        "optimist": "~0.6.0",
+        "jasminewd2": "2.2.0",
+        "optimist": "0.6.1",
         "q": "1.4.1",
-        "saucelabs": "~1.3.0",
+        "saucelabs": "1.3.0",
         "selenium-webdriver": "3.6.0",
-        "source-map-support": "~0.4.0",
-        "webdriver-js-extender": "^1.0.0",
-        "webdriver-manager": "^12.0.6"
+        "source-map-support": "0.4.18",
+        "webdriver-js-extender": "1.0.0",
+        "webdriver-manager": "12.0.6"
       },
       "dependencies": {
         "adm-zip": {
@@ -12646,12 +12646,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -12660,7 +12660,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "q": {
@@ -12675,7 +12675,7 @@
           "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "selenium-webdriver": {
@@ -12684,10 +12684,10 @@
           "integrity": "sha1-K6h6FmLAILiYjJga5iyyoBKY6vw=",
           "dev": true,
           "requires": {
-            "jszip": "^3.1.3",
-            "rimraf": "^2.5.4",
+            "jszip": "3.1.5",
+            "rimraf": "2.6.2",
             "tmp": "0.0.30",
-            "xml2js": "^0.4.17"
+            "xml2js": "0.4.19"
           }
         },
         "webdriver-manager": {
@@ -12696,17 +12696,17 @@
           "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
           "dev": true,
           "requires": {
-            "adm-zip": "^0.4.7",
-            "chalk": "^1.1.1",
-            "del": "^2.2.0",
-            "glob": "^7.0.3",
-            "ini": "^1.3.4",
-            "minimist": "^1.2.0",
-            "q": "^1.4.1",
-            "request": "^2.78.0",
-            "rimraf": "^2.5.2",
-            "semver": "^5.3.0",
-            "xml2js": "^0.4.17"
+            "adm-zip": "0.4.7",
+            "chalk": "1.1.3",
+            "del": "2.2.2",
+            "glob": "7.1.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "q": "1.4.1",
+            "request": "2.85.0",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "xml2js": "0.4.19"
           }
         }
       }
@@ -12718,14 +12718,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3",
-        "http-proxy-agent": "1",
-        "https-proxy-agent": "1",
-        "lru-cache": "~2.6.5",
-        "pac-proxy-agent": "1",
-        "socks-proxy-agent": "2"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "http-proxy-agent": "1.0.0",
+        "https-proxy-agent": "1.0.0",
+        "lru-cache": "2.6.5",
+        "pac-proxy-agent": "1.1.0",
+        "socks-proxy-agent": "2.1.1"
       },
       "dependencies": {
         "debug": {
@@ -12772,12 +12772,12 @@
       "integrity": "sha1-GTNM5KlL2r/42dMBXz07csm+O/U=",
       "dev": true,
       "requires": {
-        "collections": "^2.0.1",
-        "mime": "^1.2.11",
-        "mimeparse": "^0.1.4",
-        "q": "^2.0.1",
-        "qs": "^0.6.6",
-        "url2": "^1.0.1"
+        "collections": "2.0.3",
+        "mime": "1.4.1",
+        "mimeparse": "0.1.4",
+        "q": "2.0.3",
+        "qs": "0.6.6",
+        "url2": "1.0.4"
       },
       "dependencies": {
         "q": {
@@ -12786,9 +12786,9 @@
           "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
           "dev": true,
           "requires": {
-            "asap": "^2.0.0",
-            "pop-iterate": "^1.0.1",
-            "weak-map": "^1.0.5"
+            "asap": "2.0.6",
+            "pop-iterate": "1.0.1",
+            "weak-map": "1.0.5"
           }
         },
         "qs": {
@@ -12823,8 +12823,8 @@
       "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -12833,7 +12833,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12842,7 +12842,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -12853,7 +12853,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -12897,7 +12897,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.5.0"
           }
         },
         "iconv-lite": {
@@ -12920,7 +12920,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-pkg": {
@@ -12929,9 +12929,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -12940,8 +12940,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -12950,13 +12950,13 @@
       "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -12965,10 +12965,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -12983,7 +12983,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -12994,7 +12994,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.1.7"
       }
     },
     "redent": {
@@ -13003,8 +13003,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       },
       "dependencies": {
         "strip-indent": {
@@ -13013,7 +13013,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         }
       }
@@ -13025,9 +13025,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "double-ended-queue": "2.1.0-0",
+        "redis-commands": "1.3.5",
+        "redis-parser": "2.6.0"
       }
     },
     "redis-commands": {
@@ -13056,7 +13056,7 @@
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regexp-escape": {
@@ -13095,7 +13095,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -13104,28 +13104,28 @@
       "integrity": "sha1-WgNhWkfGFCCz65m326IE+DYD4fo=",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "request-progress": {
@@ -13134,7 +13134,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "^1.0.0"
+        "throttleit": "1.0.0"
       }
     },
     "requestretry": {
@@ -13144,10 +13144,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "extend": "^3.0.0",
-        "lodash": "^4.15.0",
-        "request": "^2.74.0",
-        "when": "^3.7.7"
+        "extend": "3.0.1",
+        "lodash": "4.17.5",
+        "request": "2.85.0",
+        "when": "3.7.8"
       },
       "dependencies": {
         "lodash": {
@@ -13165,7 +13165,7 @@
       "integrity": "sha1-dC3Mwg86lpGNZsbxWX3I/+vE9vU=",
       "dev": true,
       "requires": {
-        "editions": "^1.1.1"
+        "editions": "1.3.4"
       }
     },
     "requirejs": {
@@ -13204,7 +13204,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "right-pad": {
@@ -13231,8 +13231,8 @@
       "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
       "dev": true,
       "requires": {
-        "editions": "^1.1.1",
-        "graceful-fs": "^4.1.4"
+        "editions": "1.3.4",
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "graceful-fs": {
@@ -13255,11 +13255,11 @@
       "integrity": "sha1-0vkxrXro/avxlopEDnsgQXrKf4Y=",
       "dev": true,
       "requires": {
-        "adm-zip": "~0.4.3",
-        "async": "^2.1.2",
-        "https-proxy-agent": "~1.0.0",
-        "lodash": "^4.16.6",
-        "rimraf": "^2.5.4"
+        "adm-zip": "0.4.4",
+        "async": "2.6.0",
+        "https-proxy-agent": "1.0.0",
+        "lodash": "4.17.5",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "async": {
@@ -13268,7 +13268,7 @@
           "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "glob": {
@@ -13277,12 +13277,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "lodash": {
@@ -13297,7 +13297,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -13306,7 +13306,7 @@
           "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         }
       }
@@ -13317,7 +13317,7 @@
       "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "^1.0.0"
+        "https-proxy-agent": "1.0.0"
       }
     },
     "sax": {
@@ -13332,7 +13332,7 @@
       "integrity": "sha512-udTvYWhlERoCfhYGFebjoHtqWBzEIV2VMcsatMwk7Bacln7BXuWKikmU5cSE4iwlmA8RYYw+EoUZ/AqnbP69Vg==",
       "dev": true,
       "requires": {
-        "npm": "^5.8.0"
+        "npm": "5.8.0"
       }
     },
     "selenium-webdriver": {
@@ -13341,10 +13341,10 @@
       "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
-        "jszip": "^3.1.3",
-        "rimraf": "^2.5.4",
+        "jszip": "3.1.5",
+        "rimraf": "2.6.2",
         "tmp": "0.0.30",
-        "xml2js": "^0.4.17"
+        "xml2js": "0.4.19"
       },
       "dependencies": {
         "glob": {
@@ -13353,12 +13353,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -13367,7 +13367,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -13376,7 +13376,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         }
       }
@@ -13394,18 +13394,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -13431,8 +13431,8 @@
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case-first": "^1.1.2"
+        "no-case": "2.3.2",
+        "upper-case-first": "1.1.2"
       }
     },
     "serve-index": {
@@ -13441,13 +13441,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -13467,9 +13467,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -13491,9 +13491,9 @@
       "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.0.6",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       }
     },
     "signal-exit": {
@@ -13509,7 +13509,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "requestretry": "^1.2.2"
+        "requestretry": "1.13.0"
       }
     },
     "smart-buffer": {
@@ -13534,7 +13534,7 @@
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "sntp": {
@@ -13543,7 +13543,7 @@
       "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "hoek": {
@@ -13560,11 +13560,11 @@
       "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
       "dev": true,
       "requires": {
-        "debug": "~2.6.6",
-        "engine.io": "~3.1.0",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "2.6.9",
+        "engine.io": "3.1.5",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.0.4",
-        "socket.io-parser": "~3.1.1"
+        "socket.io-parser": "3.1.3"
       },
       "dependencies": {
         "debug": {
@@ -13594,14 +13594,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "engine.io-client": "~3.1.0",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.6",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.1.1",
+        "socket.io-parser": "3.1.3",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -13623,8 +13623,8 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "has-binary2": "1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -13642,8 +13642,8 @@
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
       "requires": {
-        "ip": "^1.1.4",
-        "smart-buffer": "^1.0.13"
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
       },
       "dependencies": {
         "ip": {
@@ -13660,9 +13660,9 @@
       "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "extend": "3",
-        "socks": "~1.1.5"
+        "agent-base": "2.1.1",
+        "extend": "3.0.1",
+        "socks": "1.1.10"
       }
     },
     "source-map": {
@@ -13671,7 +13671,7 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "source-map-support": {
@@ -13680,7 +13680,7 @@
       "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -13697,8 +13697,8 @@
       "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -13713,8 +13713,8 @@
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -13729,7 +13729,7 @@
       "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split2": {
@@ -13738,7 +13738,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "^2.0.2"
+        "through2": "2.0.3"
       }
     },
     "sprintf-js": {
@@ -13753,14 +13753,14 @@
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-trace": {
@@ -13781,10 +13781,10 @@
       "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "readable-stream": "^2.3.0"
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "mkdirp": "0.5.1",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "minimist": {
@@ -13810,7 +13810,7 @@
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "dev": true,
       "requires": {
-        "strip-ansi": "^3.0.0"
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -13819,7 +13819,7 @@
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -13834,7 +13834,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -13843,7 +13843,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-indent": {
@@ -13870,8 +13870,8 @@
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1",
-        "upper-case": "^1.1.1"
+        "lower-case": "1.1.4",
+        "upper-case": "1.1.3"
       }
     },
     "sync-exec": {
@@ -13886,10 +13886,10 @@
       "integrity": "sha1-XK2Ed59FyDsfJQjZawnYjHIYr1U=",
       "dev": true,
       "requires": {
-        "bl": "^1.0.0",
-        "end-of-stream": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "temporary": {
@@ -13898,7 +13898,7 @@
       "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
       "dev": true,
       "requires": {
-        "package": ">= 1.0.0 < 1.2.0"
+        "package": "1.0.1"
       }
     },
     "text-extensions": {
@@ -13931,8 +13931,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "thunkify": {
@@ -13948,13 +13948,13 @@
       "integrity": "sha1-BiIT5mDJB+hvRAVWwB6mWXtxJCA=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "date-time": "^1.1.0",
-        "figures": "^1.0.0",
-        "hooker": "^0.2.3",
-        "number-is-nan": "^1.0.0",
-        "pretty-ms": "^2.1.0",
-        "text-table": "^0.2.0"
+        "chalk": "1.1.3",
+        "date-time": "1.1.0",
+        "figures": "1.7.0",
+        "hooker": "0.2.3",
+        "number-is-nan": "1.0.1",
+        "pretty-ms": "2.1.0",
+        "text-table": "0.2.0"
       }
     },
     "time-zone": {
@@ -13976,12 +13976,12 @@
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
       "requires": {
-        "body-parser": "~1.14.0",
-        "debug": "~2.2.0",
-        "faye-websocket": "~0.10.0",
-        "livereload-js": "^2.2.0",
-        "parseurl": "~1.3.0",
-        "qs": "~5.1.0"
+        "body-parser": "1.14.2",
+        "debug": "2.2.0",
+        "faye-websocket": "0.10.0",
+        "livereload-js": "2.3.0",
+        "parseurl": "1.3.2",
+        "qs": "5.1.0"
       },
       "dependencies": {
         "body-parser": {
@@ -13991,15 +13991,15 @@
           "dev": true,
           "requires": {
             "bytes": "2.2.0",
-            "content-type": "~1.0.1",
-            "debug": "~2.2.0",
-            "depd": "~1.1.0",
-            "http-errors": "~1.3.1",
+            "content-type": "1.0.4",
+            "debug": "2.2.0",
+            "depd": "1.1.2",
+            "http-errors": "1.3.1",
             "iconv-lite": "0.4.13",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "5.2.0",
-            "raw-body": "~2.1.5",
-            "type-is": "~1.6.10"
+            "raw-body": "2.1.7",
+            "type-is": "1.6.16"
           },
           "dependencies": {
             "qs": {
@@ -14025,8 +14025,8 @@
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
-            "statuses": "1"
+            "inherits": "2.0.3",
+            "statuses": "1.5.0"
           }
         },
         "iconv-lite": {
@@ -14074,8 +14074,8 @@
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.0.3"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "tmp": {
@@ -14084,7 +14084,7 @@
       "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-array": {
@@ -14111,7 +14111,7 @@
       "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "trim-newlines": {
@@ -14139,7 +14139,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -14155,7 +14155,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -14165,7 +14165,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.18"
       }
     },
     "typechecker": {
@@ -14174,7 +14174,7 @@
       "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
       "dev": true,
       "requires": {
-        "editions": "^1.3.4"
+        "editions": "1.3.4"
       }
     },
     "typedarray": {
@@ -14189,10 +14189,10 @@
       "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
       "dev": true,
       "requires": {
-        "async": "~0.2.6",
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "async": "0.2.10",
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "async": {
@@ -14251,7 +14251,7 @@
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "dev": true,
       "requires": {
-        "upper-case": "^1.1.1"
+        "upper-case": "1.1.3"
       }
     },
     "uri-path": {
@@ -14298,8 +14298,8 @@
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.x",
-        "tmp": "0.0.x"
+        "lru-cache": "2.2.4",
+        "tmp": "0.0.30"
       },
       "dependencies": {
         "lru-cache": {
@@ -14322,12 +14322,12 @@
       "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
       "dev": true,
       "requires": {
-        "async": "~0.2.9",
-        "deep-equal": "*",
-        "i": "0.3.x",
-        "mkdirp": "0.x.x",
-        "ncp": "0.4.x",
-        "rimraf": "2.x.x"
+        "async": "0.2.10",
+        "deep-equal": "1.0.1",
+        "i": "0.3.6",
+        "mkdirp": "0.5.0",
+        "ncp": "0.4.2",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "async": {
@@ -14369,8 +14369,8 @@
       "integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vargs": {
@@ -14385,9 +14385,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "void-elements": {
@@ -14408,10 +14408,10 @@
       "integrity": "sha1-LUxZviLivyYY3fWXq0uqkjvnIA0=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5",
-        "uuid": "^2.0.2",
-        "vow": "^0.4.7",
-        "vow-queue": "^0.4.1"
+        "glob": "7.1.2",
+        "uuid": "2.0.3",
+        "vow": "0.4.17",
+        "vow-queue": "0.4.3"
       },
       "dependencies": {
         "glob": {
@@ -14420,12 +14420,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -14434,7 +14434,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "uuid": {
@@ -14451,7 +14451,7 @@
       "integrity": "sha512-/poAKDTFL3zYbeQg7cl4BGcfP4sGgXKrHnRFSKj97dteUFu8oyXMwIcdwu8NSx/RmPGIuYx1Bik/y5vU4H/VKw==",
       "dev": true,
       "requires": {
-        "vow": "^0.4.17"
+        "vow": "0.4.17"
       }
     },
     "walkdir": {
@@ -14469,7 +14469,7 @@
         "archiver": "1.3.0",
         "async": "2.0.1",
         "lodash": "4.16.2",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "0.5.1",
         "q": "1.4.1",
         "request": "2.85.0",
         "underscore.string": "3.3.4",
@@ -14482,7 +14482,7 @@
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "lodash": "^4.8.0"
+            "lodash": "4.16.2"
           }
         },
         "lodash": {
@@ -14518,8 +14518,8 @@
           "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
           "dev": true,
           "requires": {
-            "sprintf-js": "^1.0.3",
-            "util-deprecate": "^1.0.2"
+            "sprintf-js": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -14536,8 +14536,8 @@
       "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
       "dev": true,
       "requires": {
-        "@types/selenium-webdriver": "^2.53.35",
-        "selenium-webdriver": "^2.53.2"
+        "@types/selenium-webdriver": "2.53.43",
+        "selenium-webdriver": "2.53.3"
       },
       "dependencies": {
         "sax": {
@@ -14553,9 +14553,9 @@
           "dev": true,
           "requires": {
             "adm-zip": "0.4.4",
-            "rimraf": "^2.2.8",
+            "rimraf": "2.2.8",
             "tmp": "0.0.24",
-            "ws": "^1.0.1",
+            "ws": "1.1.5",
             "xml2js": "0.4.4"
           }
         },
@@ -14571,8 +14571,8 @@
           "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
           "dev": true,
           "requires": {
-            "sax": "0.6.x",
-            "xmlbuilder": ">=1.0.0"
+            "sax": "0.6.1",
+            "xmlbuilder": "2.4.6"
           }
         }
       }
@@ -14583,17 +14583,17 @@
       "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
       "dev": true,
       "requires": {
-        "adm-zip": "^0.4.7",
-        "chalk": "^1.1.1",
-        "del": "^2.2.0",
-        "glob": "^7.0.3",
-        "ini": "^1.3.4",
-        "minimist": "^1.2.0",
-        "q": "^1.4.1",
-        "request": "^2.78.0",
-        "rimraf": "^2.5.2",
-        "semver": "^5.3.0",
-        "xml2js": "^0.4.17"
+        "adm-zip": "0.4.8",
+        "chalk": "1.1.3",
+        "del": "2.2.2",
+        "glob": "7.1.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "q": "1.5.1",
+        "request": "2.85.0",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "xml2js": "0.4.19"
       },
       "dependencies": {
         "adm-zip": {
@@ -14608,12 +14608,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -14622,7 +14622,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "q": {
@@ -14637,7 +14637,7 @@
           "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         }
       }
@@ -14648,8 +14648,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.12",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -14671,7 +14671,7 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "window-size": {
@@ -14686,13 +14686,13 @@
       "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
       "dev": true,
       "requires": {
-        "async": "0.2.x",
-        "colors": "0.6.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "pkginfo": "0.3.x",
-        "stack-trace": "0.0.x"
+        "async": "0.2.10",
+        "colors": "0.6.2",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.10"
       },
       "dependencies": {
         "async": {
@@ -14733,8 +14733,8 @@
       "integrity": "sha1-y9nm514J/F0skAFfIfDECHXg3VE=",
       "dev": true,
       "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "xml-char-classes": {
@@ -14749,8 +14749,8 @@
       "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
       "dev": true,
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       },
       "dependencies": {
         "xmlbuilder": {
@@ -14767,7 +14767,7 @@
       "integrity": "sha1-QsZk8TWIZOW+sUYbQ0auyHtjRQ8=",
       "dev": true,
       "requires": {
-        "lodash-node": "~2.4.1"
+        "lodash-node": "2.4.1"
       }
     },
     "xmlhttprequest-ssl": {
@@ -14801,9 +14801,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
         "window-size": "0.1.0"
       }
     },
@@ -14813,7 +14813,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "1.0.1"
       }
     },
     "yeast": {
@@ -14828,10 +14828,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
-        "compress-commons": "^1.2.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0"
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.2",
+        "lodash": "4.17.5",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "lodash": {

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -10,11 +10,7 @@
     class="ui-grid-cell-contents ui-grid-header-cell-primary-focus"
     col-index="renderIndex"
     title="TOOLTIP">
-    <span
-      class="ui-grid-header-cell-label"
-      ui-grid-one-bind-id-grid="col.uid + '-header-text'">
-      {{ col.displayName CUSTOM_FILTERS }}
-    </span>
+    <span class="ui-grid-header-cell-label" ui-grid-one-bind-id-grid="col.uid + '-header-text'">{{ col.displayName CUSTOM_FILTERS }}</span>
 
     <span
       ui-grid-one-bind-id-grid="col.uid + '-sortdir-text'"


### PR DESCRIPTION
The latest version of grunt-angular-templates adds an extra white space to the end of the header
cell label when it is minifying the html. By putting it all in one line, that issue is avoided.