### PR TITLE
fix: Japanese translation.

### DIFF
--- a/src/js/i18n/ja.js
+++ b/src/js/i18n/ja.js
@@ -84,10 +84,10 @@
             pageForward: '次のページ',
             pageToLast: '最後のページ'
           },
-          sizes: '項目/ページ',
-          totalItems: '項目',
+          sizes: '件/ページ',
+          totalItems: '件',
           through: 'から',
-          of: '項目/全'
+          of: '件/全'
         },
         grouping: {
           group: 'グループ化',


### PR DESCRIPTION
Fixed Japanese translation about pagination.
"件" or "行" rather than "項目" is better suited for Japanese nuances.
In Japanese, "項目" means "cell".