### PR TITLE
fix(validate): missing getErrorMessages method

### DIFF
--- a/src/features/validate/js/gridValidate.js
+++ b/src/features/validate/js/gridValidate.js
@@ -410,6 +410,8 @@
 
           isInvalid: service.isInvalid,
 
+          getErrorMessages: service.getErrorMessages,
+
           getFormattedErrors: service.getFormattedErrors,
 
           getTitleFormattedErrors: service.getTitleFormattedErrors,

--- a/src/features/validate/test/uiGridValidateService.spec.js
+++ b/src/features/validate/test/uiGridValidateService.spec.js
@@ -229,4 +229,21 @@ describe('ui.grid.validate uiGridValidateService', function() {
 			expect(uiGridValidateService.setValidator.calls.count()).toBe(3);
 		});
 	});
+
+	it('should initialize grid', function() {
+		var scope = {};
+		var grid = {
+			api: {
+				registerEventsFromObject: function() {},
+				registerMethodsFromObject: function() {}
+			}
+		};
+
+		uiGridValidateService.initializeGrid(scope, grid);
+		expect(grid.validate.isInvalid).toBeDefined();
+		expect(grid.validate.getErrorMessages).toBeDefined();
+		expect(grid.validate.getFormattedErrors).toBeDefined();
+		expect(grid.validate.getTitleFormattedErrors).toBeDefined();
+		expect(grid.validate.runValidators).toBeDefined();
+	});
 });


### PR DESCRIPTION
* Although it was defined in the service (and in the docs), it was never exposed in the grid API's validate object.
* Fixes the ```validate.getErrorMessages is not a function``` error I was seeing.
* Also added unit tests.