### PR TITLE
Change grid header css to flexbox

### DIFF
--- a/src/less/header.less
+++ b/src/less/header.less
@@ -33,7 +33,8 @@
   // Clearfix for floating header cells
   &:before, &:after {
     content: "";
-    display: table;
+    display: -ms-flexbox;
+    display:flex;
     line-height: 0;
   }
 
@@ -44,15 +45,23 @@
   // .border-radius(@gridBorderRadius, 0, 0, @gridBorderRadius);
 }
 
+
 .ui-grid-header-cell-wrapper {
   position: relative;
-  display: table;
+  display: -ms-flexbox;
+  display:flex;
   box-sizing: border-box;
   height: 100%;
+  width:100%;
 }
 
 .ui-grid-header-cell-row {
-  display: table-row;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .ui-grid-header-cell {
@@ -61,7 +70,6 @@
   background-color: inherit;
   border-right: @gridBorderWidth solid;
   border-color: @headerVerticalBarColor;
-  display: table-cell;
 
   &:last-child {
     border-right: 0;
@@ -83,6 +91,11 @@
   .ui-grid-sort-priority-number {
     margin-left: -8px;
   }
+}
+/* Fixes IE word-wrap if needed on header cells */
+.ui-grid-header-cell > div {
+  -ms-flex-basis:100%;
+  flex-basis:100%;
 }
 
 // Make vertical bar in header row fill the height of the cell completely

--- a/src/less/header.less
+++ b/src/less/header.less
@@ -52,7 +52,7 @@
   display: flex;
   box-sizing: border-box;
   height: 100%;
-  width:100%;
+  width: 100%;
 }
 
 .ui-grid-header-cell-row {

--- a/src/less/header.less
+++ b/src/less/header.less
@@ -34,7 +34,7 @@
   &:before, &:after {
     content: "";
     display: -ms-flexbox;
-    display:flex;
+    display: flex;
     line-height: 0;
   }
 
@@ -49,7 +49,7 @@
 .ui-grid-header-cell-wrapper {
   position: relative;
   display: -ms-flexbox;
-  display:flex;
+  display: flex;
   box-sizing: border-box;
   height: 100%;
   width:100%;
@@ -94,8 +94,8 @@
 }
 /* Fixes IE word-wrap if needed on header cells */
 .ui-grid-header-cell > div {
-  -ms-flex-basis:100%;
-  flex-basis:100%;
+  -ms-flex-basis: 100%;
+  flex-basis: 100%;
 }
 
 // Make vertical bar in header row fill the height of the cell completely


### PR DESCRIPTION
Change grid header css to be flexbox based

Header display properties was previously table based while body is block based. This causes alignment issues between the two in some cases.

Note that if you have a custom header template based on table display properties, it will need to be updated to flexbox.

Fixes: #6799 #2592 