### PR TITLE
feat(uiGridCtrl): add uiGridCtrl to scope

### DIFF
--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -60,6 +60,8 @@
               return label;
             };
 
+            $scope.uiGridCtrl = uiGridCtrl;
+
             $scope.grid = uiGridCtrl.grid;
 
             $scope.renderContainer = uiGridCtrl.grid.renderContainers[renderContainerCtrl.containerId];


### PR DESCRIPTION
to allow access to menu items outside of stock ui grid header cell. This allows for creating custom header cell menus using the default menu items (uiGridCtrl.getDefaultMenuItems)

![image](https://user-images.githubusercontent.com/12875543/45049045-4f4b7a00-b032-11e8-89da-918d4766d47e.png)
