### PR TITLE
Fix CSV export for objects

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -1137,7 +1137,6 @@
           if (typeof (field.value) === 'object') {
             return field.value.text;
           }
-          
           return JSON.stringify(field.value);
         },
 

--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -1134,7 +1134,10 @@
           if (typeof(field.value) === 'string') {
             return '"' + field.value.replace(/"/g,'""') + '"';
           }
-
+          if (typeof (field.value) === 'object') {
+            return field.value.text;
+          }
+          
           return JSON.stringify(field.value);
         },
 


### PR DESCRIPTION
When overriding exports with the method described in #5227, the CSV export should still only use the 'text' field of the object.  Otherwise the entire JSON is dumped into the file.