### PR TITLE
docs(112_swapping_data.ngdoc): Fix display error due to use of /

### DIFF
--- a/misc/tutorial/112_swapping_data.ngdoc
+++ b/misc/tutorial/112_swapping_data.ngdoc
@@ -1,5 +1,5 @@
 @ngdoc overview
-@name Tutorial: 112 Add/Delete/Swap Data
+@name Tutorial: 112 Add Delete Swap Data
 @description
 
 You can swap out data in the grid by simply providing a different reference.


### PR DESCRIPTION
Fix display error on Tutorial 112 by removing `/`s in the Tutorial name. [#6833]