### PR TITLE
(treeBase): allow setting row.$$treeLevel to undefined

### DIFF
--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -1095,7 +1095,7 @@
         var aggregations = service.getAggregations( grid );
 
         function createNode( row ) {
-          if ( typeof(row.entity.$$treeLevel) !== 'undefined' && row.treeLevel !== row.entity.$$treeLevel ) {
+          if ( !row.internalRow && row.treeLevel !== row.entity.$$treeLevel ) {
             row.treeLevel = row.entity.$$treeLevel;
           }
 


### PR DESCRIPTION
Setting the $$treeLevel to undefined allows you to change a header row into a non-header row

Fixes #5548