### PR TITLE
Wrap rowSortFn while loop innards in IIFE to prevent webpack compress bug

### DIFF
--- a/src/js/core/services/rowSorter.js
+++ b/src/js/core/services/rowSorter.js
@@ -456,17 +456,21 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
 
         sortFn = rowSorter.getSortFn(grid, col, r);
 
-        var propA, propB;
-
-        if ( col.sortCellFiltered ) {
-          propA = grid.getCellDisplayValue(rowA, col);
-          propB = grid.getCellDisplayValue(rowB, col);
-        } else {
-          propA = grid.getCellValue(rowA, col);
-          propB = grid.getCellValue(rowB, col);
-        }
-
-        tem = sortFn(propA, propB, rowA, rowB, direction, col);
+        // Webpack's compress will hoist and combine propA, propB into one var and break sorting functionality
+        // Wrapping in IIFE prevents that unexpected behavior
+        (function () {
+          var propA, propB;
+  
+          if ( col.sortCellFiltered ){
+            propA = grid.getCellDisplayValue(rowA, col);
+            propB = grid.getCellDisplayValue(rowB, col);
+          } else {
+            propA = grid.getCellValue(rowA, col);
+            propB = grid.getCellValue(rowB, col);
+          }
+  
+          tem = sortFn(propA, propB, rowA, rowB, direction, col);
+        })();
 
         idx++;
       }


### PR DESCRIPTION
When using this module with Webpack and UglifyJs, utilizing the compress with all default options will result in the sorting functionality breaking due to it hoisting and collapsing the propA and propB variables in the rowSortFn method. One simple solution to this issue is to wrap that content in an IIFE to prevent that hosting/collapsing behavior.

