### PR TITLE
Wrap rowSortFn while innards in function to prevent sorting bug

### DIFF
--- a/src/js/core/services/rowSorter.js
+++ b/src/js/core/services/rowSorter.js
@@ -456,16 +456,11 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
 
         sortFn = rowSorter.getSortFn(grid, col, r);
 
-        var propA, propB;
-
-        if ( col.sortCellFiltered ) {
-          propA = grid.getCellDisplayValue(rowA, col);
-          propB = grid.getCellDisplayValue(rowB, col);
-        } else {
-          propA = grid.getCellValue(rowA, col);
-          propB = grid.getCellValue(rowB, col);
-        }
-
+        // Webpack's compress will hoist and combine propA, propB into one var and break sorting functionality
+        // Wrapping in function prevents that unexpected behavior
+        var props = getCellValues(grid, rowA, rowB, col);
+        var propA = props[0];
+        var propB = props[1];
         tem = sortFn(propA, propB, rowA, rowB, direction, col);
 
         idx++;
@@ -497,6 +492,20 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
 
     return newRows;
   };
+
+  function getCellValues(grid, rowA, rowB, col) {
+    var propA, propB;
+
+    if ( col.sortCellFiltered ) {
+      propA = grid.getCellDisplayValue(rowA, col);
+      propB = grid.getCellDisplayValue(rowB, col);
+    } else {
+      propA = grid.getCellValue(rowA, col);
+      propB = grid.getCellValue(rowB, col);
+    }
+
+    return [propA, propB];
+  }
 
   return rowSorter;
 }]);


### PR DESCRIPTION
When using this module with Webpack and UglifyJs, utilizing the compress with all default options will result in the sorting functionality breaking due to it hoisting and collapsing the propA and propB variables in the rowSortFn method. One simple solution to this issue is to wrap that content in an IIFE to prevent that hosting/collapsing behavior.

