### PR TITLE
docs(tutorial): fix tag for CSS files on tutorial

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -777,7 +777,7 @@
     },
     "bootstrap": {
       "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+      "resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E=",
       "dev": true
     },
@@ -5296,9 +5296,9 @@
       }
     },
     "grunt-uidocs-generator": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-uidocs-generator/-/grunt-uidocs-generator-0.6.0.tgz",
-      "integrity": "sha512-qftNHLdP5omWdlOI9tWMXerczYQ4JBS73XP9fOqA1dprZdryCdYd4Pq7Ren/vUjJbvGQuDM+UqV3/4s9S+M2tw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-uidocs-generator/-/grunt-uidocs-generator-0.6.1.tgz",
+      "integrity": "sha512-+oSlrEVr4b7IINc0iTp+LBTSwd+FDGhLgMw5OmZ59Kwzts80epGhOaiJrQiRUuPcmDl1xweeqtkSl0kaUrX6Ew==",
       "dev": true,
       "requires": {
         "bootstrap": "3.3.7",
@@ -5306,25 +5306,6 @@
         "marked": "0.4.0",
         "shelljs": "0.8.2",
         "upath": "1.1.0"
-      },
-      "dependencies": {
-        "marked": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-          "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
-          "dev": true
-        },
-        "shelljs": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
-          "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
-          "dev": true,
-          "requires": {
-            "glob": "7.0.6",
-            "interpret": "1.1.0",
-            "rechoir": "0.6.2"
-          }
-        }
       }
     },
     "gzip-size": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "grunt-newer": "^1.3.0",
     "grunt-protractor-runner": "^5.0.0",
     "grunt-shell-spawn": "~0.3.10",
-    "grunt-uidocs-generator": "^0.6.0",
+    "grunt-uidocs-generator": "^0.6.1",
     "hoek": "^5.0.3",
     "husky": "^0.14.3",
     "jasmine-core": "^2.4.1",


### PR DESCRIPTION
upgrade version of grunt-uidocs-generator

fix #6855