### PR TITLE
fix(sort): add an extra check for sort data

### DIFF
--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -43,7 +43,7 @@
             };
             $scope.isSortPriorityVisible = function() {
               // show sort priority if column is sorted and there is at least one other sorted column
-              return angular.isNumber($scope.col.sort.priority) && $scope.grid.columns.some(function(element, index) {
+              return $scope.col && $scope.col.sort && angular.isNumber($scope.col.sort.priority) && $scope.grid.columns.some(function(element, index) {
                   return angular.isNumber(element.sort.priority) && element !== $scope.col;
                 });
             };
@@ -52,7 +52,7 @@
               // Trying to recreate this sort of thing but it was getting messy having it in the template.
               // Sort direction {{col.sort.direction == asc ? 'ascending' : ( col.sort.direction == desc ? 'descending': 'none')}}.
               // {{col.sort.priority ? {{columnPriorityText}} {{col.sort.priority}} : ''}
-              var label = col.sort.direction === uiGridConstants.ASC ? $scope.i18n.sort.ascending : ( col.sort.direction === uiGridConstants.DESC ? $scope.i18n.sort.descending : $scope.i18n.sort.none);
+              var label = col.sort && col.sort.direction === uiGridConstants.ASC ? $scope.i18n.sort.ascending : ( col.sort && col.sort.direction === uiGridConstants.DESC ? $scope.i18n.sort.descending : $scope.i18n.sort.none);
 
               if ($scope.isSortPriorityVisible()) {
                 label = label + '. ' + $scope.i18n.headerCell.priority + ' ' + (col.sort.priority + 1);

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1969,7 +1969,7 @@ angular.module('ui.grid')
 
     if (!direction) {
       // Find the current position in the cycle (or -1).
-      var i = column.sortDirectionCycle.indexOf(column.sort.direction ? column.sort.direction : null);
+      var i = column.sortDirectionCycle.indexOf(column.sort && column.sort.direction ? column.sort.direction : null);
       // Proceed to the next position in the cycle (or start at the beginning).
       i = (i+1) % column.sortDirectionCycle.length;
       // If suppressRemoveSort is set, and the next position in the cycle would

--- a/src/js/core/services/rowSorter.js
+++ b/src/js/core/services/rowSorter.js
@@ -343,7 +343,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
    */
   rowSorter.prioritySort = function (a, b) {
     // Both columns have a sort priority
-    if (a.sort.priority !== undefined && b.sort.priority !== undefined) {
+    if (a.sort && a.sort.priority !== undefined && b.sort && b.sort.priority !== undefined) {
       // A is higher priority
       if (a.sort.priority < b.sort.priority) {
         return -1;
@@ -358,11 +358,11 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
       }
     }
     // Only A has a priority
-    else if (a.sort.priority !== undefined) {
+    else if (a.sort && a.sort.priority !== undefined) {
       return -1;
     }
     // Only B has a priority
-    else if (b.sort.priority !== undefined) {
+    else if (b.sort && b.sort.priority !== undefined) {
       return 1;
     }
     // Neither has a priority


### PR DESCRIPTION
When doing a restore as part of saveState, it is possible to trigger the sort logic without having a
sort object, which causes failures.