### PR TITLE
fix(uiGridColumMenu): Check column visibility before trying to focus …

### DIFF
--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -381,7 +381,8 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
 
           if ($scope.col && $scope.col.visible) {
             // Focus on the menu button
-            gridUtil.focus.bySelector($document, '.ui-grid-header-cell.' + $scope.col.getColClass()+ ' .ui-grid-column-menu-button', $scope.col.grid, false);
+            gridUtil.focus.bySelector($document, '.ui-grid-header-cell.' + $scope.col.getColClass()+ ' .ui-grid-column-menu-button', $scope.col.grid, false)
+                .catch(angular.noop);
           }
         }
 
@@ -403,7 +404,8 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
 
           // automatically set the focus to the first button element in the now open menu.
           if (hasVisibleMenuItems) {
-            gridUtil.focus.bySelector($document, '.ui-grid-menu-items .ui-grid-menu-item:not(.ng-hide)', true);
+            gridUtil.focus.bySelector($document, '.ui-grid-menu-items .ui-grid-menu-item:not(.ng-hide)', true)
+                .catch(angular.noop);
           }
 
           delete $scope.colElementPosition;

--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -379,7 +379,7 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
         } else {
           $scope.hideMenu( true );
 
-          if ($scope.col) {
+          if ($scope.col && $scope.col.visible) {
             // Focus on the menu button
             gridUtil.focus.bySelector($document, '.ui-grid-header-cell.' + $scope.col.getColClass()+ ' .ui-grid-column-menu-button', $scope.col.grid, false);
           }

--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -397,8 +397,15 @@ function ($timeout, gridUtil, uiGridConstants, uiGridColumnMenuService, $documen
         $timeout(function() {
           uiGridColumnMenuService.repositionMenu( $scope, $scope.col, $scope.colElementPosition, $elm, $scope.colElement );
 
+          var hasVisibleMenuItems = $scope.menuItems.some(function (menuItem) {
+              return menuItem.shown();
+          });
+
           // automatically set the focus to the first button element in the now open menu.
-          gridUtil.focus.bySelector($document, '.ui-grid-menu-items .ui-grid-menu-item:not(.ng-hide)', true);
+          if (hasVisibleMenuItems) {
+            gridUtil.focus.bySelector($document, '.ui-grid-menu-items .ui-grid-menu-item:not(.ng-hide)', true);
+          }
+
           delete $scope.colElementPosition;
           delete $scope.columnElement;
           addKeydownHandlersToMenu();


### PR DESCRIPTION
…it in the menu-hidden callback

Fixes #6871.

> it's trying to focus on the column even though $scope.col.visible is false (and therefore the column is not rendered and not focusable).
> Skipping the column focus will be fine because setFocusOnHideColumn will handle focussing of the visible columns.