### PR TITLE
fix(core): prevent uiGrid styles breaking, columns collapsing

### DIFF
--- a/packages/core/src/js/directives/ui-grid.js
+++ b/packages/core/src/js/directives/ui-grid.js
@@ -338,6 +338,9 @@ function uiGridDirective($window, gridUtil, uiGridConstants) {
 
           // Resize the grid on window resize events
           function gridResize() {
+            if (!$elm.is(':visible')) {
+              return;
+            }
             grid.gridWidth = $scope.gridWidth = gridUtil.elementWidth($elm);
             grid.gridHeight = $scope.gridHeight = gridUtil.elementHeight($elm);
 


### PR DESCRIPTION
Prevent uiGrid styles breaking(columns collapsing) for those cases when some uiGrids are invisible on page (in some hidden dialogs or tabs).
We don't need to do gridResize() when grid is not visible.