### PR TITLE
feat(filterChanged): pass the changed column as first argument to filterChanged function

### DIFF
--- a/packages/core/src/js/directives/ui-grid-header-cell.js
+++ b/packages/core/src/js/directives/ui-grid-header-cell.js
@@ -237,7 +237,7 @@
                   $scope.col.filters.forEach( function(filter, i) {
                     filterDeregisters.push($scope.$watch('col.filters[' + i + '].term', function(n, o) {
                       if (n !== o) {
-                        uiGridCtrl.grid.api.core.raise.filterChanged();
+                        uiGridCtrl.grid.api.core.raise.filterChanged( $scope.col );
                         uiGridCtrl.grid.api.core.notifyDataChange( uiGridConstants.dataChange.COLUMN );
                         uiGridCtrl.grid.queueGridRefresh();
                       }

--- a/packages/saveState/src/js/saveState.js
+++ b/packages/saveState/src/js/saveState.js
@@ -587,7 +587,7 @@
                     delete currentCol.filters[index].term;
                   }
                 });
-                grid.api.core.raise.filterChanged();
+                grid.api.core.raise.filterChanged( currentCol );
               }
 
               if ( !!grid.api.pinning && grid.options.savePinning && currentCol.renderContainer !== columnState.pinned ) {


### PR DESCRIPTION
When using the filterChanged function, it's now possible to use the first argument - `column` - to simply do `column.filters[0].term` to retreive the search term for the column being filtered. This is especially useful if using external filtering.

I do not see a simple way to determine the column being changed without this.

Closes #4775.