### PR TITLE
fix(ui-grid-filter): reset filterable on restored columns

### DIFF
--- a/packages/core/src/js/directives/ui-grid-filter.js
+++ b/packages/core/src/js/directives/ui-grid-filter.js
@@ -26,6 +26,7 @@
             };
 
             $scope.$on( '$destroy', function() {
+              delete $scope.col.filterable;
               delete $scope.col.updateFilters;
             });
           },


### PR DESCRIPTION
Tested this code locally (I was having the same issue as the original poster for issue #6969). It works like a charm.

https://github.com/angular-ui/ui-grid/issues/6969