### PR TITLE
fix(translation): change translation in in i18n nl.js for clearAllFilters

### DIFF
--- a/packages/i18n/src/js/nl.js
+++ b/packages/i18n/src/js/nl.js
@@ -54,7 +54,7 @@
           exporterAllAsExcel: 'Exporteer alle data als excel',
           exporterVisibleAsExcel: 'Exporteer zichtbare data als excel',
           exporterSelectedAsExcel: 'Exporteer alle data als excel',
-          clearAllFilters: 'Reinig alle filters'
+          clearAllFilters: 'Alle filters wissen'
         },
         importer: {
           noHeaders: 'Kolomnamen kunnen niet worden afgeleid. Heeft het bestand een header?',


### PR DESCRIPTION
The right translation of clearAllFilters in nl.js should be 'Alle filters wissen'. [#6738]