### PR TITLE
fix(i18n): improve Swedish translations

### DIFF
--- a/packages/i18n/src/js/sv.js
+++ b/packages/i18n/src/js/sv.js
@@ -16,7 +16,7 @@
           filterLabel: "Filter för kolumn: "
         },
         aggregate: {
-          label: 'Artiklar'
+          label: 'Poster'
         },
         groupPanel: {
           description: 'Dra en kolumnrubrik hit och släpp den för att gruppera efter den kolumnen.'
@@ -27,9 +27,9 @@
             notSelected: 'Rad är inte vald'
           },
           placeholder: 'Sök...',
-          showingItems: 'Visar artiklar:',
-          selectedItems: 'Valda artiklar:',
-          totalItems: 'Antal artiklar:',
+          showingItems: 'Visar:',
+          selectedItems: 'Valda:',
+          totalItems: 'Antal:',
           size: 'Sidstorlek:',
           first: 'Första sidan',
           next: 'Nästa sida',
@@ -95,8 +95,8 @@
             pageForward: 'Gå en sida framåt',
             pageToLast: 'Gå till sista sidan'
           },
-          sizes: 'Artiklar per sida',
-          totalItems: 'Artiklar',
+          sizes: 'Poster per sida',
+          totalItems: 'Poster',
           through: 'genom',
           of: 'av'
         },


### PR DESCRIPTION
Swedish translation of 'Items' is too specific. Change it to a more general translation.