### PR TITLE
Scrolling - column footers misaligned with data #6909

### DIFF
--- a/packages/core/less/footer.less
+++ b/packages/core/less/footer.less
@@ -29,8 +29,6 @@
 
 .ui-grid-footer-viewport,
 .ui-grid-footer-canvas {
-  display: flex;
-  flex: 1 1 auto;
   height: 100%;
 }
 


### PR DESCRIPTION
From the version 4.4.4 we can observe an issue in the footer scroll (watch https://github.com/angular-ui/ui-grid/issues/6909).
To resolve the issue https://github.com/angular-ui/ui-grid/issues/6630 or https://github.com/angular-ui/ui-grid/issues/3416, it was added on footer.less some css styling (`
.ui-grid-footer-viewport,
.ui-grid-footer-canvas {
  display: flex;
  flex: 1 1 auto;
  height: 100%;
}
` ). Actually you don't need to use flex properties to fix the upper issue, it's enough to add only just `height: 100%` and it will works fine. If you add the flex properties, you will produce the https://github.com/angular-ui/ui-grid/issues/6909, because the flex will modify the grid footer cell properties and the length of the footer will be longer then the grid content itself. 


