### PR TITLE
Fix scrollToIfNecessary not working with custom rowHeight on downward scrolls

### DIFF
--- a/packages/core/src/js/factories/Grid.js
+++ b/packages/core/src/js/factories/Grid.js
@@ -2332,8 +2332,8 @@ angular.module('ui.grid')
 
       /*-- Get the top, left, right, and bottom "scrolled" edges of the grid --*/
 
-      // The top boundary is the current Y scroll position PLUS the header height, because the header can obscure rows when the grid is scrolled downwards
-      var topBound = self.renderContainers.body.prevScrollTop + self.headerHeight;
+      // The top boundary is the current Y scroll position
+      var topBound = self.renderContainers.body.prevScrollTop;
 
       // Don't the let top boundary be less than 0
       topBound = (topBound < 0) ? 0 : topBound;
@@ -2372,7 +2372,7 @@ angular.module('ui.grid')
         // }
 
         // This is the minimum amount of pixels we need to scroll vertical in order to see this row.
-        var pixelsToSeeRow = (seekRowIndex * self.options.rowHeight + self.headerHeight);
+        var pixelsToSeeRow = (seekRowIndex * self.options.rowHeight);
 
         // Don't let the pixels required to see the row be less than zero
         pixelsToSeeRow = (pixelsToSeeRow < 0) ? 0 : pixelsToSeeRow;
@@ -2399,7 +2399,8 @@ angular.module('ui.grid')
           //   to get the full position we need
           scrollPixels = pixelsToSeeRow - bottomBound + self.renderContainers.body.prevScrollTop;
 
-          scrollEvent.y = getScrollY(scrollPixels, scrollLength,self.renderContainers.body.prevScrolltopPercentage);
+          // Scroll to full position plus the height of one row since scrollPixels points to the top pixel of the row
+          scrollEvent.y = getScrollY(scrollPixels + self.options.rowHeight, scrollLength, self.renderContainers.body.prevScrolltopPercentage);
         }
       }
 


### PR DESCRIPTION
### Issue Description:

When using custom `rowHeight` values, `scrollToIfNecessary()` works correctly going 'up' but not 'down'. On downward scrolls only the first 30px of the specified row is shown.

### Fix Description:

As far as I can tell, because the header isn't part of the `body` renderContainer then `headerHeight` should be removed from the `scrollToIfNecessary()` math. (Maybe the header used to be absolutely positioned within the render container?)

This also seems to be the case for `footerHeight` on 'upward' `scrollToIfNecessary()` scrolls but I haven't yet included a fix for this.

Am I misunderstanding something about the scroll containers or is this logic correct?

### Replication Steps: 

* Edit [this tutorial page](http://ui-grid.info/docs/#!/tutorial/Tutorial:%20202%20Cell%20Navigation) in Plunkr
* Set `gridOptions.rowHeight` to `80`
* Press 'Scroll to Row 20' button
* Observe only top 30px of row is visible

### Testing for this changeset: 
* Unit tests - PASS
* Manual testing - PASS
* e2e tests - UNKNOWN (I'm unable to run them locally and CI appears to be broken).