### PR TITLE
update(ui-grid-header): added role attribute to UI-Grid-Header.html

### DIFF
--- a/packages/core/src/templates/ui-grid/ui-grid-header.html
+++ b/packages/core/src/templates/ui-grid/ui-grid-header.html
@@ -14,6 +14,7 @@
             role="row"
             class="ui-grid-header-cell-row">
             <div
+              role="columnheader"
               class="ui-grid-header-cell ui-grid-clearfix"
               ng-repeat="col in colContainer.renderedColumns track by col.uid"
               ui-grid-header-cell


### PR DESCRIPTION
**Issue Description:** Certain ARIA roles must contain particular children (.ui-grid-header-cell-row[role="row"]).This accessibility issue was found using [Accessibility Insights for Web 2.4.1](http://aka.ms/AccessibilityInsights) (axe-core 3.2.2), a tool that helps find and fix accessibility issues. I am using grouping in my project. I verified same on tutorial page. 

**Element path:**
.ui-grid-header.ng-scope[role="rowgroup"] > .ui-grid-top-panel > .ui-grid-header-viewport > .ui-grid-header-canvas > .ui-grid-header-cell-wrapper > .ui-grid-header-cell-row[role="row"]

**Environment:** Chrome version 74.0.3729.169 

**Fix Description:** Added role="columnheader" in children div element of row div.

**Before Changes: Required ARIA children role not present: cell columnheader rowheader gridcell**
![1](https://user-images.githubusercontent.com/53933688/63838748-892c3380-c99b-11e9-93ba-70ddf3eb44a3.png)
**After Changes(Verified Locally):** 
![AfterChanges](https://user-images.githubusercontent.com/53933688/63913083-7e7da700-ca4c-11e9-8083-73b8103832c7.png)

**Testing Details:**
Unit tests - PASS
Manual testing - PASS
E2E tests - Unable to run them locally as execution stops with below error message. 
![E2ETestCases](https://user-images.githubusercontent.com/53933688/63914125-e2ee3580-ca4f-11e9-8bc5-4bc1ca1b6208.PNG)

**Note:** CI seems to be broken. Failing for all open PRs.