### PR TITLE
update(ui-grid-header-cell): enable sorting on grid header cell for enter & space-bar keys

### DIFF
--- a/packages/core/src/js/directives/ui-grid-header-cell.js
+++ b/packages/core/src/js/directives/ui-grid-header-cell.js
@@ -161,8 +161,9 @@
             };
 
             $scope.handleKeyDown = function(event) {
-              if (event.keyCode === 32) {
+              if (event.keyCode === 32 || event.keyCode === 13) {
                 event.preventDefault();
+                $scope.handleClick(event);
               }
             };
 


### PR DESCRIPTION
**Issue Description:** User is unable to perform sorting actions using keyboard keys on Grid Column Header cell. We have to enable Column Header Menu to perform sorting through Menu option.

**Proposed Fix:** Updated **handleKeyDown** method to perform sorting on Enter and Spacebar keys in **ui-grid-header-cell.js** file.

**After Changes :** 
![AfterChanges_SortingWithKeyBoard_GIF](https://user-images.githubusercontent.com/53933688/66310914-f207b380-e92a-11e9-8c48-bdc0dcf5a930.gif)
[AfterChanges_SortingWithKeyBoard.zip](https://github.com/angular-ui/ui-grid/files/3697168/AfterChanges_SortingWithKeyBoard.zip)

**Testing Details:** (Verified Locally)
Unit tests - PASS
Manual testing - PASS
E2E testing -  PASS
![E2ETestResult](https://user-images.githubusercontent.com/53933688/66311249-a6093e80-e92b-11e9-95f4-c99fb05bd736.PNG)

**Note:** CI build seems to be broken.