### PR TITLE
fix(exporter): remove extra double quotes in excel export

### DIFF
--- a/packages/exporter/src/js/exporter.js
+++ b/packages/exporter/src/js/exporter.js
@@ -1558,9 +1558,8 @@
          * @ngdoc function
          * @name formatFieldAsExcel
          * @methodOf  ui.grid.exporter.service:uiGridExporterService
-         * @description Renders a single field as a csv field, including
-         * quotes around the value
-         * @param {field} field the field to be turned into a csv string,
+         * @description Renders a single field as a excel-ified field
+         * @param {field} field the field to be excel-ified,
          * may be of any type
          * @returns {string} a excel-ified version of the field
          */
@@ -1568,14 +1567,11 @@
           if (field.value == null) { // we want to catch anything null-ish, hence just == not ===
             return '';
           }
-          if (typeof(field.value) === 'number') {
+          if ((typeof(field.value) === 'number') || (typeof(field.value) === 'string')) {
             return field.value;
           }
           if (typeof(field.value) === 'boolean') {
             return (field.value ? 'TRUE' : 'FALSE') ;
-          }
-          if (typeof(field.value) === 'string') {
-            return field.value.replace(/"/g,'""');
           }
 
           return JSON.stringify(field.value);

--- a/packages/exporter/test/exporter.spec.js
+++ b/packages/exporter/test/exporter.spec.js
@@ -1255,8 +1255,8 @@ describe('ui.grid.exporter', function() {
       it('should "FALSE" when the type of the field value is boolean', function() {
         expect(uiGridExporterService.formatFieldAsExcel({value: false})).toEqual('FALSE');
       });
-      it('should double the amount of double quotes when the type of the field value is string', function() {
-        expect(uiGridExporterService.formatFieldAsExcel({value: '"test"'})).toEqual('""test""');
+      it('should not double the amount of double quotes when the type of the field value is string', function() {
+        expect(uiGridExporterService.formatFieldAsExcel({value: '"test"'})).toEqual('"test"');
       });
       it('should transform the field value into a string when the type of the field value is anything else', function() {
         expect(uiGridExporterService.formatFieldAsExcel({value: {foo: 'bar'}})).toEqual('{"foo":"bar"}');


### PR DESCRIPTION
Remove code that is adding a duplicate double quote for each double quote it sees in a string value when exporting from excel. Also change test file to reflect this change. The motivation is that it does not seem like normal behavior to add extra double quotes for excel exports and these extra double quotes become confusing for the end user.