### PR TITLE
update(ui-grid): changed sequence of right and left container div elements

### DIFF
--- a/packages/core/src/templates/ui-grid/ui-grid.html
+++ b/packages/core/src/templates/ui-grid/ui-grid.html
@@ -28,7 +28,8 @@
   <div class="ui-grid-contents-wrapper" role="grid">
     <div ui-grid-menu-button ng-if="grid.options.enableGridMenu"></div>
 
-    <div ng-if="grid.hasLeftContainer()" style="width: 0" ui-grid-pinned-container="'left'"></div>
+    <div ng-if="grid.hasRightContainer()" style="width: 0" ui-grid-pinned-container="'right'"></div>
+    
 
     <div ui-grid-render-container
       container-id="'body'"
@@ -40,7 +41,7 @@
       enable-vertical-scrollbar="grid.options.enableVerticalScrollbar">
     </div>
 
-    <div ng-if="grid.hasRightContainer()" style="width: 0" ui-grid-pinned-container="'right'"></div>
+    <div ng-if="grid.hasLeftContainer()" style="width: 0" ui-grid-pinned-container="'left'"></div>
 
 
     <div ui-grid-grid-footer ng-if="grid.options.showGridFooter"></div>


### PR DESCRIPTION
**Issue Description :** NVDA is reading random row no while focus comes to first header cell when grouping  grid data.

**Root Cause:** As expand all controls of grouping is part of left container in ui-grid.html, it's div aligned first and then header cell div. Somehow  Narrator is also reading no of grouped row along with header cell row. 

**Proposed Fix:**  Updated right and left container div sequence in ui-grid.html file.

**Before Changes:** 
![BeforeChanges](https://user-images.githubusercontent.com/53933688/66714638-ad6e9300-edd6-11e9-809f-3723c8623244.png)
[BeforeChanges_NVDA.zip](https://github.com/angular-ui/ui-grid/files/3721649/BeforeChanges_NVDA.zip)

**After Changes:**
[AfterChange_NVDA.zip](https://github.com/angular-ui/ui-grid/files/3721650/AfterChange_NVDA.zip)

**Testing Details:**
Unit tests - PASS
Manual testing - PASS
E2E tests - Unable to run locally.