### PR TITLE
fix(grouping): adds aggregationLabel to aggregateColumn call to match public API

### DIFF
--- a/packages/grouping/src/js/grouping.js
+++ b/packages/grouping/src/js/grouping.js
@@ -747,8 +747,9 @@
        * @param {Grid} grid grid object
        * @param {GridColumn} column the column we want to aggregate
        * @param {string} aggregationType of the recognised types from uiGridGroupingConstants or one of the custom aggregations from gridOptions
+       * @param {string} aggregationLabel to be used instead of the default label. If empty string is passed, label is omitted
        */
-      aggregateColumn: function( grid, column, aggregationType) {
+      aggregateColumn: function( grid, column, aggregationType, aggregationLabel ) {
         if (typeof(column.grouping) !== 'undefined' && typeof(column.grouping.groupPriority) !== 'undefined' && column.grouping.groupPriority >= 0) {
           service.ungroupColumn( grid, column );
         }
@@ -761,7 +762,12 @@
           aggregationDef = uiGridTreeBaseService.nativeAggregations()[aggregationType];
         }
 
-        column.treeAggregation = { type: aggregationType, label:  i18nService.get().aggregation[aggregationDef.label] || aggregationDef.label };
+        column.treeAggregation = {
+          type: aggregationType,
+          label: ( typeof aggregationLabel === 'string') ?
+            aggregationLabel :
+            i18nService.get().aggregation[aggregationDef.label] || aggregationDef.label
+        };
         column.treeAggregationFn = aggregationDef.aggregationFn;
         column.treeAggregationFinalizerFn = aggregationDef.finalizerFn;
 


### PR DESCRIPTION
I believe this is a bug. The public API has a parameter that can be passed called 'aggregationLabel', but in the public API call, it is not used.

This pull request adds a check to the service to see if that aggregation label is a string and uses that as a label instead, as I believe it was intended.

Public API: 
![image](https://user-images.githubusercontent.com/44622077/67431940-e6fb8700-f5aa-11e9-8bec-e41312c32d91.png)
