### PR TITLE
fix: change $scope.$parent to appScope where applicable

### DIFF
--- a/packages/core/src/js/directives/ui-grid.js
+++ b/packages/core/src/js/directives/ui-grid.js
@@ -44,8 +44,8 @@
       if (self.grid.options.fastWatch) {
         self.uiGrid = $scope.uiGrid;
         if (angular.isString($scope.uiGrid.data)) {
-          deregFunctions.push( $scope.$parent.$watch($scope.uiGrid.data, dataWatchFunction) );
-          deregFunctions.push( $scope.$parent.$watch(function() {
+          deregFunctions.push( self.grid.appScope.$watch($scope.uiGrid.data, dataWatchFunction) );
+          deregFunctions.push( self.grid.appScope.$watch(function() {
             if ( self.grid.appScope[$scope.uiGrid.data] ) {
               return self.grid.appScope[$scope.uiGrid.data].length;
             } else {
@@ -53,18 +53,18 @@
             }
           }, dataWatchFunction) );
         } else {
-          deregFunctions.push( $scope.$parent.$watch(function() { return $scope.uiGrid.data; }, dataWatchFunction) );
-          deregFunctions.push( $scope.$parent.$watch(function() { return getSize($scope.uiGrid.data); }, function() { dataWatchFunction($scope.uiGrid.data); }) );
+          deregFunctions.push( self.grid.appScope.$watch(function() { return $scope.uiGrid.data; }, dataWatchFunction) );
+          deregFunctions.push( self.grid.appScope.$watch(function() { return getSize($scope.uiGrid.data); }, function() { dataWatchFunction($scope.uiGrid.data); }) );
         }
-        deregFunctions.push( $scope.$parent.$watch(function() { return $scope.uiGrid.columnDefs; }, columnDefsWatchFunction) );
-        deregFunctions.push( $scope.$parent.$watch(function() { return getSize($scope.uiGrid.columnDefs); }, function() { columnDefsWatchFunction($scope.uiGrid.columnDefs); }) );
+        deregFunctions.push( self.grid.appScope.$watch(function() { return $scope.uiGrid.columnDefs; }, columnDefsWatchFunction) );
+        deregFunctions.push( self.grid.appScope.$watch(function() { return getSize($scope.uiGrid.columnDefs); }, function() { columnDefsWatchFunction($scope.uiGrid.columnDefs); }) );
       } else {
         if (angular.isString($scope.uiGrid.data)) {
-          deregFunctions.push( $scope.$parent.$watchCollection($scope.uiGrid.data, dataWatchFunction) );
+          deregFunctions.push( self.grid.appScope.$watchCollection($scope.uiGrid.data, dataWatchFunction) );
         } else {
-          deregFunctions.push( $scope.$parent.$watchCollection(function() { return $scope.uiGrid.data; }, dataWatchFunction) );
+          deregFunctions.push( self.grid.appScope.$watchCollection(function() { return $scope.uiGrid.data; }, dataWatchFunction) );
         }
-        deregFunctions.push( $scope.$parent.$watchCollection(function() { return $scope.uiGrid.columnDefs; }, columnDefsWatchFunction) );
+        deregFunctions.push( self.grid.appScope.$watchCollection(function() { return $scope.uiGrid.columnDefs; }, columnDefsWatchFunction) );
       }
 
 

--- a/packages/core/src/js/directives/ui-grid.js
+++ b/packages/core/src/js/directives/ui-grid.js
@@ -40,12 +40,14 @@
         return array ? array.length : 0;
       }
 
-      // if fastWatch is set we watch only the length and the reference, not every individual object
+      
+      const watchScope = (self.grid.appScope instanceof $scope.constructor) ? self.grid.appScope : $scope.$parent;
+      // if fastWatch is set we watch only the length and the reference, not every individual object                  
       if (self.grid.options.fastWatch) {
         self.uiGrid = $scope.uiGrid;
         if (angular.isString($scope.uiGrid.data)) {
-          deregFunctions.push( self.grid.appScope.$watch($scope.uiGrid.data, dataWatchFunction) );
-          deregFunctions.push( self.grid.appScope.$watch(function() {
+          deregFunctions.push( watchScope.$watch($scope.uiGrid.data, dataWatchFunction) );
+          deregFunctions.push( watchScope.$watch(function() {
             if ( self.grid.appScope[$scope.uiGrid.data] ) {
               return self.grid.appScope[$scope.uiGrid.data].length;
             } else {
@@ -53,18 +55,18 @@
             }
           }, dataWatchFunction) );
         } else {
-          deregFunctions.push( self.grid.appScope.$watch(function() { return $scope.uiGrid.data; }, dataWatchFunction) );
-          deregFunctions.push( self.grid.appScope.$watch(function() { return getSize($scope.uiGrid.data); }, function() { dataWatchFunction($scope.uiGrid.data); }) );
+          deregFunctions.push( watchScope.$watch(function() { return $scope.uiGrid.data; }, dataWatchFunction) );
+          deregFunctions.push( watchScope.$watch(function() { return getSize($scope.uiGrid.data); }, function() { dataWatchFunction($scope.uiGrid.data); }) );
         }
-        deregFunctions.push( self.grid.appScope.$watch(function() { return $scope.uiGrid.columnDefs; }, columnDefsWatchFunction) );
-        deregFunctions.push( self.grid.appScope.$watch(function() { return getSize($scope.uiGrid.columnDefs); }, function() { columnDefsWatchFunction($scope.uiGrid.columnDefs); }) );
+        deregFunctions.push( watchScope.$watch(function() { return $scope.uiGrid.columnDefs; }, columnDefsWatchFunction) );
+        deregFunctions.push( watchScope.$watch(function() { return getSize($scope.uiGrid.columnDefs); }, function() { columnDefsWatchFunction($scope.uiGrid.columnDefs); }) );
       } else {
         if (angular.isString($scope.uiGrid.data)) {
-          deregFunctions.push( self.grid.appScope.$watchCollection($scope.uiGrid.data, dataWatchFunction) );
+          deregFunctions.push( watchScope.$watchCollection($scope.uiGrid.data, dataWatchFunction) );
         } else {
-          deregFunctions.push( self.grid.appScope.$watchCollection(function() { return $scope.uiGrid.data; }, dataWatchFunction) );
+          deregFunctions.push( watchScope.$watchCollection(function() { return $scope.uiGrid.data; }, dataWatchFunction) );
         }
-        deregFunctions.push( self.grid.appScope.$watchCollection(function() { return $scope.uiGrid.columnDefs; }, columnDefsWatchFunction) );
+        deregFunctions.push( watchScope.$watchCollection(function() { return $scope.uiGrid.columnDefs; }, columnDefsWatchFunction) );
       }
 
 


### PR DESCRIPTION
This change prevents an issue where combining a string uiGrid.data and wrapping ui-grid with another component causes data not to be watched and evaluated correctly.
Seems to me we'd want to watch the variable on appScope, not necessarily ui-grid's direct parent.

Otherwise, when using a wrapped uigrid, we'll have to pass '$parent.data' instead of 'data', which is a leaky abstraction at best.