### PR TITLE
fix: clearSelectedRows should respect enableSelection 

### DIFF
--- a/packages/selection/src/js/selection.js
+++ b/packages/selection/src/js/selection.js
@@ -627,7 +627,7 @@
         clearSelectedRows: function (grid, evt) {
           var changedRows = [];
           service.getSelectedRows(grid).forEach(function (row) {
-            if (row.isSelected) {
+            if (row.isSelected && row.enableSelection !== false && grid.options.isRowSelectable(row) !== false) {
               row.setSelected(false);
               service.decideRaiseSelectionEvent(grid, row, changedRows, evt);
             }


### PR DESCRIPTION
The issue we had was that we have rows that are selected, but also have `enableSelection: false`. We expected select all to behave similarly when selecting and unselecting all rows in that select all does not touch disabled rows. But unselect all does touch disabled rows.

This fixes the above issue by using the same check that is used during select all behavior in `clearSelectedRows`.