### PR TITLE
fix(core): use allowFloatWidth property to allow float calculations for widths

### DIFF
--- a/packages/core/src/js/factories/GridColumn.js
+++ b/packages/core/src/js/factories/GridColumn.js
@@ -260,6 +260,18 @@ angular.module('ui.grid')
 
   /**
    * @ngdoc property
+   * @name allowFloatWidth
+   * @propertyOf ui.grid.class:GridOptions.columnDef
+   * @description Allows float number in column width calculation
+   * @example
+   * <pre>  $scope.gridOptions.columnDefs = [ { field: 'field1', width: 50.5, allowFloatWidth: true},
+   *                                          { field: 'field2', width: '20%', allowFloatWidth: true},
+   *                                          { field: 'field3', width: '*', allowFloatWidth: true }]; </pre>
+   *
+   */
+
+  /**
+   * @ngdoc property
    * @name minWidth
    * @propertyOf ui.grid.class:GridOptions.columnDef
    * @description Sets the minimum column width.  Should be a number.

--- a/packages/core/src/js/factories/GridRenderContainer.js
+++ b/packages/core/src/js/factories/GridRenderContainer.js
@@ -606,7 +606,7 @@ angular.module('ui.grid')
 
       if (angular.isNumber(column.width)) {
         // pixel width, set to this value
-        if(column.colDef.allowFloatWidth) {
+        if (column.colDef.allowFloatWidth) {
           width = parseFloat(column.width);
         } else {
           width = parseInt(column.width, 10);
@@ -620,7 +620,7 @@ angular.module('ui.grid')
         // percentage width, set to percentage of the viewport
         // round down to int - some browsers don't play nice with float maxWidth
         var percentageIntegerValue = parseInt(column.width.replace(/%/g, ''), 10);
-        if(column.colDef.allowFloatWidth) {
+        if (column.colDef.allowFloatWidth) {
           width = parseFloat(percentageIntegerValue / 100 * availableWidth);
         } else {
           width = parseInt(percentageIntegerValue / 100 * availableWidth, 10);
@@ -657,7 +657,7 @@ angular.module('ui.grid')
       asterisksArray.forEach(function (column) {
         var width = parseInt(column.width.length * asteriskVal, 10);
 
-        if(column.colDef.allowFloatWidth) {
+        if (column.colDef.allowFloatWidth) {
           width = parseFloat(column.width.length * asteriskVal);
         }
 

--- a/packages/core/src/js/factories/GridRenderContainer.js
+++ b/packages/core/src/js/factories/GridRenderContainer.js
@@ -606,7 +606,12 @@ angular.module('ui.grid')
 
       if (angular.isNumber(column.width)) {
         // pixel width, set to this value
-        width = parseInt(column.width, 10);
+        if(column.colDef.allowFloatWidth) {
+          width = parseFloat(column.width);
+        } else {
+          width = parseInt(column.width, 10);
+        }
+
         usedWidthSum = usedWidthSum + width;
         column.drawnWidth = width;
 
@@ -615,7 +620,12 @@ angular.module('ui.grid')
         // percentage width, set to percentage of the viewport
         // round down to int - some browsers don't play nice with float maxWidth
         var percentageIntegerValue = parseInt(column.width.replace(/%/g, ''), 10);
-        width = parseInt(percentageIntegerValue / 100 * availableWidth);
+        if(column.colDef.allowFloatWidth) {
+          width = parseFloat(percentageIntegerValue / 100 * availableWidth);
+        } else {
+          width = parseInt(percentageIntegerValue / 100 * availableWidth, 10);
+        }
+
 
         if (width > column.maxWidth) {
           width = column.maxWidth;
@@ -646,6 +656,11 @@ angular.module('ui.grid')
 
       asterisksArray.forEach(function (column) {
         var width = parseInt(column.width.length * asteriskVal, 10);
+
+        if(column.colDef.allowFloatWidth) {
+          width = parseFloat(column.width.length * asteriskVal);
+        }
+
 
         if (width > column.maxWidth) {
             width = column.maxWidth;


### PR DESCRIPTION
This PR allows width calculations to be float numbers instead of just integers. It allows for a more uniform distribution of columns and alignment with other grids.