### PR TITLE
fix: 3527 Columns to the right disappear while Horizontally Scrolling

### DIFF
--- a/packages/core/src/js/factories/Grid.js
+++ b/packages/core/src/js/factories/Grid.js
@@ -2250,13 +2250,12 @@ angular.module('ui.grid')
       var container = self.renderContainers[i],
         prevScrollTop = getPrevScrollValue(rowsAdded, container.prevScrollTop),
         prevScrollLeft = getPrevScrollValue(rowsAdded, container.prevScrollLeft),
-        prevScrolltopPercentage = rowsAdded || prevScrollTop > 0 ? null : container.prevScrolltopPercentage,
-        prevScrollleftPercentage = rowsAdded || prevScrollLeft > 0 ? null : container.prevScrollleftPercentage;
+        prevScrolltopPercentage = rowsAdded || prevScrollTop > 0 ? null : container.prevScrolltopPercentage;
 
       // gridUtil.logDebug('redrawing container', i);
 
       container.adjustRows(prevScrollTop, prevScrolltopPercentage);
-      container.adjustColumns(prevScrollLeft, prevScrollleftPercentage);
+      container.adjustColumns(prevScrollLeft);
     }
   };
 

--- a/packages/core/src/js/factories/GridRenderContainer.js
+++ b/packages/core/src/js/factories/GridRenderContainer.js
@@ -401,7 +401,7 @@ angular.module('ui.grid')
       scrollLeft = (this.getCanvasWidth() - this.getViewportWidth()) * scrollPercentage;
     }
 
-    this.adjustColumns(scrollLeft, scrollPercentage);
+    this.adjustColumns(scrollLeft);
 
     this.prevScrollLeft = scrollLeft;
     this.prevScrollleftPercentage = scrollPercentage;
@@ -458,7 +458,7 @@ angular.module('ui.grid')
     self.prevRowScrollIndex = rowIndex;
   };
 
-  GridRenderContainer.prototype.adjustColumns = function adjustColumns(scrollLeft, scrollPercentage) {
+  GridRenderContainer.prototype.adjustColumns = function adjustColumns(scrollLeft) {
     var self = this;
 
     var minCols = self.minColumnsToRender();
@@ -466,17 +466,7 @@ angular.module('ui.grid')
     var columnCache = self.visibleColumnCache;
     var maxColumnIndex = columnCache.length - minCols;
 
-    // Calculate the scroll percentage according to the scrollLeft location, if no percentage was provided
-    if ((typeof(scrollPercentage) === 'undefined' || scrollPercentage === null) && scrollLeft) {
-      scrollPercentage = scrollLeft / self.getHorizontalScrollLength();
-    }
-
-    var colIndex = Math.ceil(Math.min(maxColumnIndex, maxColumnIndex * scrollPercentage));
-
-    // Define a max row index that we can't scroll past
-    if (colIndex > maxColumnIndex) {
-      colIndex = maxColumnIndex;
-    }
+    var colIndex = Math.min(maxColumnIndex, self.getLeftIndex(scrollLeft));
 
     var newRange = [];
     if (columnCache.length > self.grid.options.columnVirtualizationThreshold && self.getCanvasWidth() > self.getViewportWidth()) {
@@ -495,6 +485,20 @@ angular.module('ui.grid')
 
     self.prevColumnScrollIndex = colIndex;
   };
+
+  GridRenderContainer.prototype.getLeftIndex = function getLeftIndex(scrollLeft) {
+    var wholeLeftWidth = 0;
+    var index = 0
+    for (index; index < this.visibleColumnCache.length; index++) {
+      if(this.visibleColumnCache[index] && this.visibleColumnCache[index].visible){
+        //accumulate the whole width of columns on the left side, till the point of visibility is surpassed, this is our wanted index
+        wholeLeftWidth += this.visibleColumnCache[index].drawnWidth;
+        if(wholeLeftWidth >= scrollLeft)
+          break;
+      }
+    }
+    return index;
+  }
 
   // Method for updating the visible rows
   GridRenderContainer.prototype.updateViewableRowRange = function updateViewableRowRange(renderedRange) {


### PR DESCRIPTION
 - adjustColumns now calculates the colIndex instead of guessing it with scrollpercentage
 - this is fixing #3527 

Use Case: grid has 100 columns, the first column is enlarged to 50% of grid width, it is scrolled to the middle(50%)

previously: assumes that all columns have the same width; 50% of 100 columns is 50 -> colIndex is set to 50; if excessColumns isn't high enough(default is 4) the cached Columns begin at Index 46

now: accumulates the drawnWidth of all columns till 50%(or whatever left position it has) and returns the index of the column which reached the treshold -> colIndex is set to 0; the cached Columns begin at Index 0 