### PR TITLE
fix: 6898 when filtering makes Data empty, the scroll is disabled and the column disappears

### DIFF
--- a/packages/core/less/body.less
+++ b/packages/core/less/body.less
@@ -27,6 +27,7 @@
 .ui-grid-canvas {
   position: relative;
   padding-top: 1px; // to prevent canvas from absorbing the 1st rendered row's margin
+  min-height: 1px; // so that it's rendered, even if it has no data
 }
 
 .ui-grid-row {


### PR DESCRIPTION
 - canvas now has a minimum height of 1px, which renders it even if it has no data and therefore preserving scrollability
 - fixes #6898 