### PR TITLE
fix: 6360 error when entering *+ combination in the column filter

### DIFF
--- a/packages/core/src/js/services/rowSearcher.js
+++ b/packages/core/src/js/services/rowSearcher.js
@@ -84,7 +84,7 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     if (/\*/.test(term)) {//this would check only start and end -> /^\*|\*$/
       var regexpFlags = (!filter.flags || !filter.flags.caseSensitive) ? 'i' : '';
       term = escapeRegExp(term);
-      var reText = term.replace(/\\\*/g, '.*');//this would check only start and end -> /^\\\*|\\\*$/g
+      var reText = term.replace(/\\\*/g, '.*?');//this would check only start and end -> /^\\\*|\\\*$/g
       return new RegExp('^' + reText + '$', regexpFlags);
     }
     // Otherwise default to default condition


### PR DESCRIPTION
 - updated escapeRegExp according to https://github.com/sindresorhus/escape-string-regexp (where it was originally probably taken from)
 - now escapes term first, before changing *
 - changed * replacement from "[\s\S]*?" to ".*?": [\s\S] == .
 - fixes #7159 , #6335 and #5301