### PR TITLE
fix: 5502 Column filter treat NULL as a string, so "n," "u," and "l" don't filter rows

### DIFF
--- a/packages/core/src/js/services/rowSearcher.js
+++ b/packages/core/src/js/services/rowSearcher.js
@@ -179,7 +179,7 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
 
     // Get the column value for this row
     var value = column.filterCellFiltered ? grid.getCellDisplayValue(row, column) : grid.getCellValue(row, column);
-    if (value == void 0){
+    if (value == void 0) {
       value = "";
     }
 

--- a/packages/core/src/js/services/rowSearcher.js
+++ b/packages/core/src/js/services/rowSearcher.js
@@ -182,7 +182,6 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     if(value == void 0)
       value = "";
 
-
     // If the filter's condition is a RegExp, then use it
     if (filter.condition instanceof RegExp) {
       return filter.condition.test(value);

--- a/packages/core/src/js/services/rowSearcher.js
+++ b/packages/core/src/js/services/rowSearcher.js
@@ -326,7 +326,7 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
       return hasTerm;
     };
 
-    for (var i = 0; i < cols.length; i++) {
+    for (var i = 0; i < columns.length; i++) {
       var col = columns[i];
 
       if (typeof(col.filters) !== 'undefined' && hasTerm(col.filters) ) {

--- a/packages/core/src/js/services/rowSearcher.js
+++ b/packages/core/src/js/services/rowSearcher.js
@@ -144,7 +144,7 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
             break;
           case uiGridConstants.filter.EXACT:
             newFilter.exactRE = new RegExp('^' + newFilter.term + '$', regexpFlags);
-            break; 
+            break;
           case uiGridConstants.filter.CONTAINS:
             newFilter.containsRE = new RegExp(newFilter.term, regexpFlags);
             break;
@@ -179,8 +179,9 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
 
     // Get the column value for this row
     var value = column.filterCellFiltered ? grid.getCellDisplayValue(row, column) : grid.getCellValue(row, column);
-    if(value == void 0)
+    if (value == void 0){
       value = "";
+    }
 
     // If the filter's condition is a RegExp, then use it
     if (filter.condition instanceof RegExp) {


### PR DESCRIPTION
 - null in filter is now changed to ''
 - cleaned code
 - **BREAKING CHANGE**: custom regex and filter may not work anymore. If thats a problem, then lines 182 and 183 could be moved 10 lines lower, below custom regex and filter call

this fixes #5502