### PR TITLE
fix: 6388 RowSorter doesn't sort numberStr in scientific notation correctly

### DIFF
--- a/packages/core/src/js/services/rowSorter.js
+++ b/packages/core/src/js/services/rowSorter.js
@@ -135,6 +135,14 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
   };
 
 
+  function parseNumStr(numStr) {
+    if (/^\s*-?Infinity\s*$/.test(numStr)) {//check for positive or negative Infinity and return that
+      return parseFloat(numStr);
+    }
+    return parseFloat(numStr.replace(/[^0-9.eE-]/g, ''));
+  }
+
+
   /**
    * @ngdoc method
    * @methodOf ui.grid.class:rowSorter
@@ -156,7 +164,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
           badB = false;
 
       // Try to parse 'a' to a float
-      numA = parseFloat(a.replace(/[^0-9.-]/g, ''));
+      numA = parseNumStr(a);
 
       // If 'a' couldn't be parsed to float, flag it as bad
       if (isNaN(numA)) {
@@ -164,7 +172,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
       }
 
       // Try to parse 'b' to a float
-      numB = parseFloat(b.replace(/[^0-9.-]/g, ''));
+      numB = parseNumStr(b);
 
       // If 'b' couldn't be parsed to float, flag it as bad
       if (isNaN(numB)) {

--- a/packages/core/src/js/services/rowSorter.js
+++ b/packages/core/src/js/services/rowSorter.js
@@ -122,7 +122,7 @@ module.service('rowSorter', ['uiGridConstants', function (uiGridConstants) {
 
 
   function parseNumStr(numStr) {
-    if (/^\s*-?Infinity\s*$/.test(numStr)) {//check for positive or negative Infinity and return that
+    if (/^\s*-?Infinity\s*$/.test(numStr)) { //check for positive or negative Infinity and return that
       return parseFloat(numStr);
     }
     return parseFloat(numStr.replace(/[^0-9.eE-]/g, ''));

--- a/packages/core/src/js/services/rowSorter.js
+++ b/packages/core/src/js/services/rowSorter.js
@@ -122,7 +122,7 @@ module.service('rowSorter', ['uiGridConstants', function (uiGridConstants) {
 
 
   function parseNumStr(numStr) {
-    if (/^\s*-?Infinity\s*$/.test(numStr)) { //check for positive or negative Infinity and return that
+    if (/^\s*-?Infinity\s*$/.test(numStr)) { // check for positive or negative Infinity and return that
       return parseFloat(numStr);
     }
     return parseFloat(numStr.replace(/[^0-9.eE-]/g, ''));


### PR DESCRIPTION
  - scientific notation now also gets parsed to number on sort number string, including e, Infinity and -Infinity
  - fixes #6388