### PR TITLE
fix: 6418 Selected groupings selects all of that column value no matter if filter is applied

### DIFF
--- a/packages/selection/src/js/selection.js
+++ b/packages/selection/src/js/selection.js
@@ -202,7 +202,7 @@
                 toggleRowSelection: function (rowEntity, evt) {
                   var row = grid.getRow(rowEntity);
                   if (row !== null) {
-                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
+                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect, true);
                   }
                 },
                 /**
@@ -216,7 +216,7 @@
                 selectRow: function (rowEntity, evt) {
                   var row = grid.getRow(rowEntity);
                   if (row !== null && !row.isSelected) {
-                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
+                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect, true);
                   }
                 },
                 /**
@@ -233,7 +233,7 @@
                 selectRowByVisibleIndex: function (rowNum, evt) {
                   var row = grid.renderContainers.body.visibleRowCache[rowNum];
                   if (row !== null && typeof (row) !== 'undefined' && !row.isSelected) {
-                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
+                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect, false);
                   }
                 },
                 /**
@@ -247,7 +247,7 @@
                 unSelectRow: function (rowEntity, evt) {
                   var row = grid.getRow(rowEntity);
                   if (row !== null && row.isSelected) {
-                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
+                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect, true);
                   }
                 },
                 /**
@@ -264,7 +264,7 @@
                 unSelectRowByVisibleIndex: function (rowNum, evt) {
                   var row = grid.renderContainers.body.visibleRowCache[rowNum];
                   if (row !== null && typeof (row) !== 'undefined' && row.isSelected) {
-                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
+                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect, false);
                   }
                 },
                 /**
@@ -531,38 +531,37 @@
          * @param {Event} evt object if resulting from event
          * @param {bool} multiSelect if false, only one row at time can be selected
          * @param {bool} noUnselect if true then rows cannot be unselected
+         * @param {bool} [canBeInvisible=true] if false, row can only be selected when it's (theoretically) visible
          */
-        toggleRowSelection: function (grid, row, evt, multiSelect, noUnselect) {
+         toggleRowSelection: function (grid, row, evt, multiSelect, noUnselect, canBeInvisible) {
           if ( row.enableSelection === false ) {
             return;
           }
 
-          var selected = row.isSelected,
-            selectedRows;
+          if (canBeInvisible === void 0) {
+            canBeInvisible = true;
+          }
+
+          var selected = row.isSelected;
 
           if (!multiSelect) {
             if (!selected) {
               service.clearSelectedRows(grid, evt);
             }
-            else {
-              selectedRows = service.getSelectedRows(grid);
-              if (selectedRows.length > 1) {
-                selected = false; // Enable reselect of the row
-                service.clearSelectedRows(grid, evt);
-              }
+            else if (service.getSelectedRows(grid).length > 1) {
+              selected = false; // Enable reselect of the row
+              service.clearSelectedRows(grid, evt);
             }
           }
 
           // only select row in this case
-          if (!(selected && noUnselect)) {
+          if (!(selected && noUnselect) && (canBeInvisible || row.visible)) {
             row.setSelected(!selected);
             if (row.isSelected === true) {
               grid.selection.lastSelectedRow = row;
             }
 
-            selectedRows = service.getSelectedRows(grid);
-            grid.selection.selectAll = grid.rows.length === selectedRows.length;
-
+            grid.selection.selectAll = grid.rows.length === service.getSelectedRows(grid).length;
             grid.api.selection.raise.rowSelectionChanged(row, evt);
           }
         },
@@ -802,17 +801,17 @@
             }
             else if (evt.ctrlKey || evt.metaKey) {
               uiGridSelectionService.toggleRowSelection(self, row, evt,
-                self.options.multiSelect, self.options.noUnselect);
+                self.options.multiSelect, self.options.noUnselect, false);
             }
             else if (row.groupHeader) {
-              uiGridSelectionService.toggleRowSelection(self, row, evt, self.options.multiSelect, self.options.noUnselect);
+              uiGridSelectionService.toggleRowSelection(self, row, evt, self.options.multiSelect, self.options.noUnselect, false);
               for (var i = 0; i < row.treeNode.children.length; i++) {
-                uiGridSelectionService.toggleRowSelection(self, row.treeNode.children[i].row, evt, self.options.multiSelect, self.options.noUnselect);
+                uiGridSelectionService.toggleRowSelection(self, row.treeNode.children[i].row, evt, self.options.multiSelect, self.options.noUnselect, false);
               }
             }
             else {
               uiGridSelectionService.toggleRowSelection(self, row, evt,
-                (self.options.multiSelect && !self.options.modifierKeysToMultiSelect), self.options.noUnselect);
+                (self.options.multiSelect && !self.options.modifierKeysToMultiSelect), self.options.noUnselect, false);
             }
             self.options.enableFocusRowOnRowHeaderClick && row.setFocused(!row.isFocused) && self.api.selection.raise.rowFocusChanged(row, evt);
           }
@@ -933,7 +932,7 @@
                   evt.preventDefault();
                   uiGridSelectionService.toggleRowSelection($scope.grid, $scope.row, evt,
                     ($scope.grid.options.multiSelect && !$scope.grid.options.modifierKeysToMultiSelect),
-                    $scope.grid.options.noUnselect);
+                    $scope.grid.options.noUnselect, false);
                   $scope.$apply();
                 }
               });
@@ -953,12 +952,12 @@
               }
               else if (evt.ctrlKey || evt.metaKey) {
                 uiGridSelectionService.toggleRowSelection($scope.grid, $scope.row, evt,
-                  $scope.grid.options.multiSelect, $scope.grid.options.noUnselect);
+                  $scope.grid.options.multiSelect, $scope.grid.options.noUnselect, false);
               }
               else if ($scope.grid.options.enableSelectRowOnFocus) {
                 uiGridSelectionService.toggleRowSelection($scope.grid, $scope.row, evt,
                   ($scope.grid.options.multiSelect && !$scope.grid.options.modifierKeysToMultiSelect),
-                  $scope.grid.options.noUnselect);
+                  $scope.grid.options.noUnselect, false);
               }
               $scope.row.setFocused(!$scope.row.isFocused);
               $scope.grid.api.selection.raise.rowFocusChanged($scope.row, evt);

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -81,14 +81,14 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[0].visible = true;
 			grid.rows[1].visible = false;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false);
 			expect(grid.rows[1].isSelected).toBe(true);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
 			expect(grid.rows[0].isSelected).toBe(false);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false);
 			expect(grid.rows[1].isSelected).toBe(false);
 		});
 
@@ -96,14 +96,14 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[0].visible = true;
 			grid.rows[1].visible = false;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false, true);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false, true);
 			expect(grid.rows[1].isSelected).toBe(true);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false, true);
 			expect(grid.rows[0].isSelected).toBe(false);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false, true);
 			expect(grid.rows[1].isSelected).toBe(false);
 		});
 
@@ -113,15 +113,15 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[2].visible = false;
 			grid.rows[2].isSelected = true;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false, false);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false, false);
 			expect(grid.rows[1].isSelected).toBe(false);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false, false);
 			expect(grid.rows[0].isSelected).toBe(false);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[2], true, false, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[2], null, true, false, false);
 			expect(grid.rows[2].isSelected).toBe(true);
 		});
 

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -110,6 +110,8 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 		it('should toggle selected with visible rows', function() {
 			grid.rows[0].visible = true;
 			grid.rows[1].visible = false;
+			grid.rows[2].visible = false;
+			grid.rows[2].isSelected = true;
 
 			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
 			expect(grid.rows[0].isSelected).toBe(true);
@@ -118,9 +120,9 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 
 			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
 			expect(grid.rows[0].isSelected).toBe(false);
-			grid.rows[1].isSelected = true;
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false);
-			expect(grid.rows[1].isSelected).toBe(true);
+			
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[2], null, true, false);
+			expect(grid.rows[2].isSelected).toBe(true);
 		});
 
 		it('should not toggle selected with enableSelection: false', function() {

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -120,7 +120,7 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 
 			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
 			expect(grid.rows[0].isSelected).toBe(false);
-			
+
 			uiGridSelectionService.toggleRowSelection(grid, grid.rows[2], null, true, false);
 			expect(grid.rows[2].isSelected).toBe(true);
 		});

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -81,14 +81,14 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[0].visible = true;
 			grid.rows[1].visible = false;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true);
 			expect(grid.rows[1].isSelected).toBe(true);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true);
 			expect(grid.rows[0].isSelected).toBe(false);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true);
 			expect(grid.rows[1].isSelected).toBe(false);
 		});
 
@@ -96,14 +96,14 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[0].visible = true;
 			grid.rows[1].visible = false;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, true);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, true);
 			expect(grid.rows[1].isSelected).toBe(true);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, true);
 			expect(grid.rows[0].isSelected).toBe(false);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, true);
 			expect(grid.rows[1].isSelected).toBe(false);
 		});
 
@@ -111,13 +111,16 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[0].visible = true;
 			grid.rows[1].visible = false;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false);
 			expect(grid.rows[1].isSelected).toBe(false);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
 			expect(grid.rows[0].isSelected).toBe(false);
+			grid.rows[1].isSelected = true;
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false);
+			expect(grid.rows[1].isSelected).toBe(true);
 		});
 
 		it('should not toggle selected with enableSelection: false', function() {

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -115,7 +115,7 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			expect(grid.rows[0].isSelected).toBe(true);
 			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false, false);
 			expect(grid.rows[1].isSelected).toBe(false);
-			
+
 			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, false);
 			expect(grid.rows[0].isSelected).toBe(false);
 		});

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -81,14 +81,14 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[0].visible = true;
 			grid.rows[1].visible = false;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false);
 			expect(grid.rows[1].isSelected).toBe(true);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false);
 			expect(grid.rows[0].isSelected).toBe(false);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false);
 			expect(grid.rows[1].isSelected).toBe(false);
 		});
 
@@ -96,14 +96,14 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[0].visible = true;
 			grid.rows[1].visible = false;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false, true);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false, true);
 			expect(grid.rows[1].isSelected).toBe(true);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false, true);
 			expect(grid.rows[0].isSelected).toBe(false);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false, true);
 			expect(grid.rows[1].isSelected).toBe(false);
 		});
 
@@ -113,15 +113,15 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.rows[2].visible = false;
 			grid.rows[2].isSelected = true;
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false, false);
 			expect(grid.rows[0].isSelected).toBe(true);
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, true, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], true, false, false);
 			expect(grid.rows[1].isSelected).toBe(false);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], true, false, false);
 			expect(grid.rows[0].isSelected).toBe(false);
 
-			uiGridSelectionService.toggleRowSelection(grid, grid.rows[2], null, true, false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[2], true, false, false);
 			expect(grid.rows[2].isSelected).toBe(true);
 		});
 

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -77,6 +77,49 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			expect(grid.rows[1].isSelected).toBe(true);
 		});
 
+		it('should toggle selected with invisible rows using default', function() {
+			grid.rows[0].visible = true;
+			grid.rows[1].visible = false;
+
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false);
+			expect(grid.rows[0].isSelected).toBe(true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false);
+			expect(grid.rows[1].isSelected).toBe(true);
+
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false);
+			expect(grid.rows[0].isSelected).toBe(false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false);
+			expect(grid.rows[1].isSelected).toBe(false);
+		});
+
+		it('should toggle selected with invisible rows but not using default', function() {
+			grid.rows[0].visible = true;
+			grid.rows[1].visible = false;
+
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, true);
+			expect(grid.rows[0].isSelected).toBe(true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false, true);
+			expect(grid.rows[1].isSelected).toBe(true);
+
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, true);
+			expect(grid.rows[0].isSelected).toBe(false);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false, true);
+			expect(grid.rows[1].isSelected).toBe(false);
+		});
+
+		it('should toggle selected with visible rows', function() {
+			grid.rows[0].visible = true;
+			grid.rows[1].visible = false;
+
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, false);
+			expect(grid.rows[0].isSelected).toBe(true);
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[1], null, false, false);
+			expect(grid.rows[1].isSelected).toBe(false);
+			
+			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, false, false);
+			expect(grid.rows[0].isSelected).toBe(false);
+		});
+
 		it('should not toggle selected with enableSelection: false', function() {
 			grid.rows[0].enableSelection = false;
 			uiGridSelectionService.toggleRowSelection(grid, grid.rows[0], null, true);


### PR DESCRIPTION
Added parameter canBeInvisible to function toggleRowSelection which defaults to true, then it doesn't change the behaviour(so the user don't need to change anything).
When set to false, invisible rows won't get selected.
I also sat according unit tests.
this fixes #6418 