### PR TITLE
fix: 4396 Using .text() to set uiGridStyle is inefficient when using JQuery

### DIFF
--- a/packages/core/src/js/directives/ui-grid-style.js
+++ b/packages/core/src/js/directives/ui-grid-style.js
@@ -45,7 +45,9 @@
 
         if (interpolateFn) {
           $scope.$watch(interpolateFn, function(value) {
-            $elm.text(value);
+            for (let i = 0; i < $elm.length; i++) {
+              $elm[i].textContent = value;
+            }
           });
         }
       }

--- a/packages/core/src/js/directives/ui-grid-style.js
+++ b/packages/core/src/js/directives/ui-grid-style.js
@@ -45,7 +45,7 @@
 
         if (interpolateFn) {
           $scope.$watch(interpolateFn, function(value) {
-            for (let i = 0; i < $elm.length; i++) {
+            for (var i = 0; i < $elm.length; i++) {
               $elm[i].textContent = value;
             }
           });


### PR DESCRIPTION
 - exchanged jquery's .text() function with more efficient direct assignment
 - jquery btw also uses textContent: https://github.com/jquery/jquery/blob/de5398a6ad088dc006b46c6a870a2a053f4cd663/src/manipulation.js#L292
 - fixes #4396