### PR TITLE
fix: 4446 exporter file name setters now accept functions

### DIFF
--- a/packages/exporter/src/js/exporter.js
+++ b/packages/exporter/src/js/exporter.js
@@ -247,6 +247,13 @@
            * @propertyOf  ui.grid.exporter.api:GridOptions
            * @description The default filename to use when saving the downloaded pdf, only used in IE (other browsers open pdfs in a new window)
            * <br/>Defaults to 'download.pdf'
+           * <pre>
+           *   gridOptions.exporterPdfFilename = "rows.pdf"
+           * </pre>
+           * <br/>Or a function returning a string:
+           * <pre>
+           *   gridOptions.exporterPdfFilename = function(grid, rowTypes, colTypes) { return "rows" + rowTypes + ".pdf" };
+           * </pre>
            */
           gridOptions.exporterPdfFilename = gridOptions.exporterPdfFilename ? gridOptions.exporterPdfFilename : 'download.pdf';
           /**
@@ -1276,7 +1283,8 @@
               docDefinition = self.prepareAsPdf(grid, exportColumnHeaders, exportData);
 
             if (self.isIE() || navigator.appVersion.indexOf('Edge') !== -1) {
-              self.downloadPDF(grid.options.exporterPdfFilename, docDefinition);
+              var fileName = angular.isFunction(grid.options.exporterPdfFilename) ? grid.options.exporterPdfFilename(grid, rowTypes, colTypes) : grid.options.exporterPdfFilename;
+              self.downloadPDF(fileName, docDefinition);
             } else {
               pdfMake.createPdf(docDefinition).open();
             }

--- a/packages/exporter/src/js/exporter.js
+++ b/packages/exporter/src/js/exporter.js
@@ -262,6 +262,13 @@
            * @propertyOf  ui.grid.exporter.api:GridOptions
            * @description The default filename to use when saving the downloaded excel, only used in IE (other browsers open excels in a new window)
            * <br/>Defaults to 'download.xlsx'
+           * <pre>
+           *   gridOptions.exporterExcelFilename = "rows.xlsx"
+           * </pre>
+           * <br/>Or a function returning a string:
+           * <pre>
+           *   gridOptions.exporterExcelFilename = function(grid, rowTypes, colTypes) { return "rows" + rowTypes + ".xlsx" };
+           * </pre>
            */
           gridOptions.exporterExcelFilename = gridOptions.exporterExcelFilename ? gridOptions.exporterExcelFilename : 'download.xlsx';
 
@@ -271,6 +278,13 @@
            * @propertyOf  ui.grid.exporter.api:GridOptions
            * @description The default sheetname to use when saving the downloaded to excel
            * <br/>Defaults to 'Sheet1'
+           * <pre>
+           *   gridOptions.exporterExcelSheetName = "HitListSheet"
+           * </pre>
+           * <br/>Or a function returning a string:
+           * <pre>
+           *   gridOptions.exporterExcelSheetName = function(grid, rowTypes, colTypes) { return "HitListSheet" + rowTypes };
+           * </pre>
            */
           gridOptions.exporterExcelSheetName = gridOptions.exporterExcelSheetName ? gridOptions.exporterExcelSheetName : 'Sheet1';
 
@@ -1624,9 +1638,13 @@
           this.loadAllDataIfNeeded(grid, rowTypes, colTypes).then(function() {
             var exportColumnHeaders = grid.options.showHeader ? self.getColumnHeaders(grid, colTypes) : [];
 
-            var workbook = new ExcelBuilder.Workbook();
-            var aName = grid.options.exporterExcelSheetName ? grid.options.exporterExcelSheetName : 'Sheet1';
+            var aName = 'Sheet1';
+            if (grid.options.exporterExcelSheetName) {
+              aName = angular.isFunction(grid.options.exporterExcelSheetName) ? grid.options.exporterExcelSheetName(grid, rowTypes, colTypes) : grid.options.exporterExcelSheetName;
+            }
+
             var sheet = new ExcelBuilder.Worksheet({name: aName});
+            var workbook = new ExcelBuilder.Workbook();
             workbook.addWorksheet(sheet);
             var docDefinition = self.prepareAsExcel(grid, workbook, sheet);
 
@@ -1649,8 +1667,8 @@
             sheet.setData(sheet.data.concat(excelContent));
 
             ExcelBuilder.Builder.createFile(workbook, {type: 'blob'}).then(function(result) {
-              self.downloadFile (grid.options.exporterExcelFilename, result, grid.options.exporterCsvColumnSeparator,
-                grid.options.exporterOlderExcelCompatibility);
+              var fileName = angular.isFunction(grid.options.exporterExcelFilename) ? grid.options.exporterExcelFilename(grid, rowTypes, colTypes) : grid.options.exporterExcelFilename;
+              self.downloadFile(fileName, result, grid.options.exporterCsvColumnSeparator, grid.options.exporterOlderExcelCompatibility);
             });
           });
         }

--- a/packages/exporter/src/js/exporter.js
+++ b/packages/exporter/src/js/exporter.js
@@ -232,6 +232,13 @@
            * @description The default filename to use when saving the downloaded csv.
            * This will only work in some browsers.
            * <br/>Defaults to 'download.csv'
+           * <pre>
+           *   gridOptions.exporterCsvFilename = "rows.csv"
+           * </pre>
+           * <br/>Or a function returning a string:
+           * <pre>
+           *   gridOptions.exporterCsvFilename = function(grid, rowTypes, colTypes) { return "rows" + rowTypes + ".csv" };
+           * </pre>
            */
           gridOptions.exporterCsvFilename = gridOptions.exporterCsvFilename ? gridOptions.exporterCsvFilename : 'download.csv';
           /**
@@ -831,7 +838,8 @@
             var exportData = self.getData(grid, rowTypes, colTypes);
             var csvContent = self.formatAsCsv(exportColumnHeaders, exportData, grid.options.exporterCsvColumnSeparator);
 
-            self.downloadFile (grid.options.exporterCsvFilename, csvContent, grid.options.exporterCsvColumnSeparator, grid.options.exporterOlderExcelCompatibility, grid.options.exporterIsExcelCompatible);
+            var fileName = angular.isFunction(grid.options.exporterCsvFilename) ? grid.options.exporterCsvFilename(grid, rowTypes, colTypes) : grid.options.exporterCsvFilename;
+            self.downloadFile(fileName, csvContent, grid.options.exporterCsvColumnSeparator, grid.options.exporterOlderExcelCompatibility, grid.options.exporterIsExcelCompatible);
           });
         },
 

--- a/packages/exporter/test/exporter.spec.js
+++ b/packages/exporter/test/exporter.spec.js
@@ -1059,10 +1059,9 @@ describe('ui.grid.exporter', function() {
         uiGridExporterService.pdfExport(grid, uiGridExporterConstants.ALL);
         expect(uiGridExporterService.loadAllDataIfNeeded).toHaveBeenCalled();
       });
-      
       it('calls exporterPdfFilename', function() {
         spyOn(uiGridExporterService, 'exporterPdfFilename');
-        grid.options.exporterCsvFilename = function(grid, rowTypes, colTypes) {
+        grid.options.exporterPdfFilename = function(grid, rowTypes, colTypes) {
           if (!grid) {
             throw Error("got erroneous Parameter: no grid");
           }
@@ -1076,9 +1075,8 @@ describe('ui.grid.exporter', function() {
         }
 
         uiGridExporterService.pdfExport(grid, uiGridExporterConstants.ALL);
-        expect(uiGridExporterService.exporterCsvFilename).toHaveBeenCalled();
+        expect(uiGridExporterService.exporterPdfFilename).toHaveBeenCalled();
       });
-      
     });
 
     describe('prepareAsPdf', function() {
@@ -1379,7 +1377,6 @@ describe('ui.grid.exporter', function() {
         uiGridExporterService.excelExport(grid, uiGridExporterConstants.ALL);
         expect(uiGridExporterService.exporterExcelFilename).toHaveBeenCalled();
       });
-      
       it('calls exporterExcelSheetName', function() {
         spyOn(uiGridExporterService, 'exporterExcelSheetName');
         grid.options.exporterExcelSheetName = function(grid, rowTypes, colTypes) {

--- a/packages/exporter/test/exporter.spec.js
+++ b/packages/exporter/test/exporter.spec.js
@@ -738,19 +738,6 @@ describe('ui.grid.exporter', function() {
             callback();
           }
         });
-        spyOn(uiGridExporterService, 'exporterCsvFilename');
-        grid.options.exporterCsvFilename = function(grid, rowTypes, colTypes) {
-          if (!grid) {
-            throw Error("got erroneous Parameter: no grid");
-          }
-          if (rowTypes != uiGridExporterConstants.VISIBLE) {
-            throw Error("got erroneous Parameter: rowTypes != uiGridExporterConstants.VISIBLE");
-          }
-          if (colTypes != uiGridExporterConstants.VISIBLE) {
-            throw Error("got erroneous Parameter: colTypes != uiGridExporterConstants.VISIBLE");
-          }
-          return "test";
-        }
         uiGridExporterService.csvExport(grid, uiGridExporterConstants.VISIBLE, uiGridExporterConstants.VISIBLE);
       });
       afterEach(function() {
@@ -762,9 +749,6 @@ describe('ui.grid.exporter', function() {
       });
       it('calls downloadFile', function() {
         expect(uiGridExporterService.downloadFile).toHaveBeenCalled();
-      });
-      it('calls exporterCsvFilename', function() {
-        expect(uiGridExporterService.exporterCsvFilename).toHaveBeenCalled();
       });
     });
 
@@ -789,7 +773,7 @@ describe('ui.grid.exporter', function() {
         it('calls exporterAllDataFn', function() {
           expect(grid.options.exporterAllDataFn).toHaveBeenCalled();
         });
-        it('calls exporterAllDataFn', function() {
+        it('calls modifyRows', function() {
           expect(grid.modifyRows).toHaveBeenCalled();
         });
       });
@@ -1058,24 +1042,6 @@ describe('ui.grid.exporter', function() {
         });
         uiGridExporterService.pdfExport(grid, uiGridExporterConstants.ALL);
         expect(uiGridExporterService.loadAllDataIfNeeded).toHaveBeenCalled();
-      });
-      it('calls exporterPdfFilename', function() {
-        spyOn(uiGridExporterService, 'exporterPdfFilename');
-        grid.options.exporterPdfFilename = function(grid, rowTypes, colTypes) {
-          if (!grid) {
-            throw Error("got erroneous Parameter: no grid");
-          }
-          if (rowTypes != uiGridExporterConstants.VISIBLE) {
-            throw Error("got erroneous Parameter: rowTypes != uiGridExporterConstants.VISIBLE");
-          }
-          if (colTypes != uiGridExporterConstants.VISIBLE) {
-            throw Error("got erroneous Parameter: colTypes != uiGridExporterConstants.VISIBLE");
-          }
-          return "test";
-        }
-
-        uiGridExporterService.pdfExport(grid, uiGridExporterConstants.ALL);
-        expect(uiGridExporterService.exporterPdfFilename).toHaveBeenCalled();
       });
     });
 
@@ -1357,43 +1323,6 @@ describe('ui.grid.exporter', function() {
         });
         uiGridExporterService.excelExport(grid, uiGridExporterConstants.ALL);
         expect(uiGridExporterService.loadAllDataIfNeeded).toHaveBeenCalled();
-      });
-      
-      it('calls exporterExcelFilename', function() {
-        spyOn(uiGridExporterService, 'exporterExcelFilename');
-        grid.options.exporterExcelFilename = function(grid, rowTypes, colTypes) {
-          if (!grid) {
-            throw Error("got erroneous Parameter: no grid");
-          }
-          if (rowTypes != uiGridExporterConstants.VISIBLE) {
-            throw Error("got erroneous Parameter: rowTypes != uiGridExporterConstants.VISIBLE");
-          }
-          if (colTypes != uiGridExporterConstants.VISIBLE) {
-            throw Error("got erroneous Parameter: colTypes != uiGridExporterConstants.VISIBLE");
-          }
-          return "test";
-        }
-
-        uiGridExporterService.excelExport(grid, uiGridExporterConstants.ALL);
-        expect(uiGridExporterService.exporterExcelFilename).toHaveBeenCalled();
-      });
-      it('calls exporterExcelSheetName', function() {
-        spyOn(uiGridExporterService, 'exporterExcelSheetName');
-        grid.options.exporterExcelSheetName = function(grid, rowTypes, colTypes) {
-          if (!grid) {
-            throw Error("got erroneous Parameter: no grid");
-          }
-          if (rowTypes != uiGridExporterConstants.VISIBLE) {
-            throw Error("got erroneous Parameter: rowTypes != uiGridExporterConstants.VISIBLE");
-          }
-          if (colTypes != uiGridExporterConstants.VISIBLE) {
-            throw Error("got erroneous Parameter: colTypes != uiGridExporterConstants.VISIBLE");
-          }
-          return "test";
-        }
-
-        uiGridExporterService.excelExport(grid, uiGridExporterConstants.ALL);
-        expect(uiGridExporterService.exporterExcelSheetName).toHaveBeenCalled();
       });
     });
   });

--- a/packages/exporter/test/exporter.spec.js
+++ b/packages/exporter/test/exporter.spec.js
@@ -738,6 +738,19 @@ describe('ui.grid.exporter', function() {
             callback();
           }
         });
+        spyOn(uiGridExporterService, 'exporterCsvFilename');
+        grid.options.exporterCsvFilename = function(grid, rowTypes, colTypes) {
+          if (!grid) {
+            throw Error("got erroneous Parameter: no grid");
+          }
+          if (rowTypes != uiGridExporterConstants.VISIBLE) {
+            throw Error("got erroneous Parameter: rowTypes != uiGridExporterConstants.VISIBLE");
+          }
+          if (colTypes != uiGridExporterConstants.VISIBLE) {
+            throw Error("got erroneous Parameter: colTypes != uiGridExporterConstants.VISIBLE");
+          }
+          return "test";
+        }
         uiGridExporterService.csvExport(grid, uiGridExporterConstants.VISIBLE, uiGridExporterConstants.VISIBLE);
       });
       afterEach(function() {
@@ -749,6 +762,9 @@ describe('ui.grid.exporter', function() {
       });
       it('calls downloadFile', function() {
         expect(uiGridExporterService.downloadFile).toHaveBeenCalled();
+      });
+      it('calls exporterCsvFilename', function() {
+        expect(uiGridExporterService.exporterCsvFilename).toHaveBeenCalled();
       });
     });
 
@@ -1043,6 +1059,26 @@ describe('ui.grid.exporter', function() {
         uiGridExporterService.pdfExport(grid, uiGridExporterConstants.ALL);
         expect(uiGridExporterService.loadAllDataIfNeeded).toHaveBeenCalled();
       });
+      
+      it('calls exporterPdfFilename', function() {
+        spyOn(uiGridExporterService, 'exporterPdfFilename');
+        grid.options.exporterCsvFilename = function(grid, rowTypes, colTypes) {
+          if (!grid) {
+            throw Error("got erroneous Parameter: no grid");
+          }
+          if (rowTypes != uiGridExporterConstants.VISIBLE) {
+            throw Error("got erroneous Parameter: rowTypes != uiGridExporterConstants.VISIBLE");
+          }
+          if (colTypes != uiGridExporterConstants.VISIBLE) {
+            throw Error("got erroneous Parameter: colTypes != uiGridExporterConstants.VISIBLE");
+          }
+          return "test";
+        }
+
+        uiGridExporterService.pdfExport(grid, uiGridExporterConstants.ALL);
+        expect(uiGridExporterService.exporterCsvFilename).toHaveBeenCalled();
+      });
+      
     });
 
     describe('prepareAsPdf', function() {
@@ -1323,6 +1359,44 @@ describe('ui.grid.exporter', function() {
         });
         uiGridExporterService.excelExport(grid, uiGridExporterConstants.ALL);
         expect(uiGridExporterService.loadAllDataIfNeeded).toHaveBeenCalled();
+      });
+      
+      it('calls exporterExcelFilename', function() {
+        spyOn(uiGridExporterService, 'exporterExcelFilename');
+        grid.options.exporterExcelFilename = function(grid, rowTypes, colTypes) {
+          if (!grid) {
+            throw Error("got erroneous Parameter: no grid");
+          }
+          if (rowTypes != uiGridExporterConstants.VISIBLE) {
+            throw Error("got erroneous Parameter: rowTypes != uiGridExporterConstants.VISIBLE");
+          }
+          if (colTypes != uiGridExporterConstants.VISIBLE) {
+            throw Error("got erroneous Parameter: colTypes != uiGridExporterConstants.VISIBLE");
+          }
+          return "test";
+        }
+
+        uiGridExporterService.excelExport(grid, uiGridExporterConstants.ALL);
+        expect(uiGridExporterService.exporterExcelFilename).toHaveBeenCalled();
+      });
+      
+      it('calls exporterExcelSheetName', function() {
+        spyOn(uiGridExporterService, 'exporterExcelSheetName');
+        grid.options.exporterExcelSheetName = function(grid, rowTypes, colTypes) {
+          if (!grid) {
+            throw Error("got erroneous Parameter: no grid");
+          }
+          if (rowTypes != uiGridExporterConstants.VISIBLE) {
+            throw Error("got erroneous Parameter: rowTypes != uiGridExporterConstants.VISIBLE");
+          }
+          if (colTypes != uiGridExporterConstants.VISIBLE) {
+            throw Error("got erroneous Parameter: colTypes != uiGridExporterConstants.VISIBLE");
+          }
+          return "test";
+        }
+
+        uiGridExporterService.excelExport(grid, uiGridExporterConstants.ALL);
+        expect(uiGridExporterService.exporterExcelSheetName).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
exporterCsvFilename, exporterPdfFilename, exporterExcelFilename and exporterExcelSheetName can now be functions.
They get the parameters grid, rowTypes and colTypes and should return the filename string.
This fixes #4446 