### PR TITLE
fix: 4457 Find or Select by Row Entity's 'ID'

### DIFF
--- a/packages/core/src/js/factories/Grid.js
+++ b/packages/core/src/js/factories/Grid.js
@@ -1105,11 +1105,15 @@ angular.module('ui.grid')
    * looks in grid.rows
    */
   Grid.prototype.getRowsByKey = function getRowsByKey(isInEntity, key, comparator, lookInRows) {
+    if ( key == void 0 ) {
+      return null;
+    }
+
     lookInRows = lookInRows == void 0 ? this.rows : lookInRows;
     var func = isInEntity ? function (row) {
-      return row.entity != void 0 && row.entity[key] === comparator;
+      return row.entity != void 0 && row.entity.hasOwnProperty(key) && row.entity[key] === comparator;
     } : function (row) {
-      return row[key] === comparator;
+      return row.hasOwnProperty(key) && row[key] === comparator;
     }
 
     return lookInRows.filter(func);
@@ -1127,23 +1131,25 @@ angular.module('ui.grid')
    * looks in grid.rows
    */
   Grid.prototype.findRowByKey = function findRowByKey(isInEntity, key, comparator, lookInRows) {
-    lookInRows = lookInRows == void 0 ? this.rows : lookInRows;
     var result = null;
-    var func = isInEntity ? function (row) {
-      if ( row.entity != void 0 && row.entity[key] === comparator ) {
-        result = row;
-        return false;
+    if ( key != void 0 ) {
+      lookInRows = lookInRows == void 0 ? this.rows : lookInRows;
+      var func = isInEntity ? function (row) {
+        if ( row.entity != void 0 && row.entity.hasOwnProperty(key) && row.entity[key] === comparator ) {
+          result = row;
+          return false;
+        }
+        return true;
+      } : function (row) {
+        if ( row.hasOwnProperty(key) && row[key] === comparator ) {
+          result = row;
+          return false;
+        }
+        return true;
       }
-      return true;
-    } : function (row) {
-      if ( row[key] === comparator ) {
-        result = row;
-        return false;
-      }
-      return true;
-    }
 
-    lookInRows.every(func);
+      lookInRows.every(func);
+    }
     return result
   };
 

--- a/packages/core/src/js/factories/Grid.js
+++ b/packages/core/src/js/factories/Grid.js
@@ -1128,14 +1128,23 @@ angular.module('ui.grid')
    */
   Grid.prototype.findRowByKey = function findRowByKey(isInEntity, key, comparator, lookInRows) {
     lookInRows = lookInRows == void 0 ? this.rows : lookInRows;
+    var result = null;
     var func = isInEntity ? function (row) {
-      return row.entity != void 0 && row.entity[key] === comparator;
+      if ( row.entity != void 0 && row.entity[key] === comparator ) {
+        result = row;
+        return false;
+      }
+      return true;
     } : function (row) {
-      return row[key] === comparator;
+      if ( row[key] === comparator ) {
+        result = row;
+        return false;
+      }
+      return true;
     }
 
-    rows = lookInRows.filter(func);
-    return rows.length > 0 ? rows[0] : null;
+    lookInRows.every(func);
+    return result
   };
 
   /**

--- a/packages/core/src/js/factories/Grid.js
+++ b/packages/core/src/js/factories/Grid.js
@@ -1093,6 +1093,50 @@ angular.module('ui.grid')
     return rows.length > 0 ? rows[0] : null;
   };
 
+  /**
+   * @ngdoc function
+   * @name getRowsByKey
+   * @methodOf ui.grid.class:Grid
+   * @description returns the GridRows who have an key that is equal to comparator
+   * @param {boolean} isInEntity if true then key is in entity else it's directly in row
+   * @param {(string|number)} key the key to look for
+   * @param {any} comparator the value that key should have
+   * @param {array} lookInRows [optional] the rows to look in - if not provided then
+   * looks in grid.rows
+   */
+  Grid.prototype.getRowsByKey = function getRowsByKey(isInEntity, key, comparator, lookInRows) {
+    lookInRows = lookInRows == void 0 ? this.rows : lookInRows;
+    var func = isInEntity ? function (row) {
+      return row.entity != void 0 && row.entity[key] === comparator;
+    } : function (row) {
+      return row[key] === comparator;
+    }
+
+    return lookInRows.filter(func);
+  };
+
+  /**
+   * @ngdoc function
+   * @name findRowByKey
+   * @methodOf ui.grid.class:Grid
+   * @description returns the first GridRow which has an key that is equal to comparator
+   * @param {boolean} isInEntity if true then key is in entity else it's directly in row
+   * @param {(string|number)} key the key to look for
+   * @param {any} comparator the value that key should have
+   * @param {array} lookInRows [optional] the rows to look in - if not provided then
+   * looks in grid.rows
+   */
+  Grid.prototype.findRowByKey = function findRowByKey(isInEntity, key, comparator, lookInRows) {
+    lookInRows = lookInRows == void 0 ? this.rows : lookInRows;
+    var func = isInEntity ? function (row) {
+      return row.entity != void 0 && row.entity[key] === comparator;
+    } : function (row) {
+      return row[key] === comparator;
+    }
+
+    rows = lookInRows.filter(func);
+    return rows.length > 0 ? rows[0] : null;
+  };
 
   /**
    * @ngdoc function

--- a/packages/core/test/core/factories/Grid.spec.js
+++ b/packages/core/test/core/factories/Grid.spec.js
@@ -324,14 +324,14 @@ describe('Grid factory', function() {
 		});
 	});
 
-	describe('getting Rows', function(){
-		it('should get Rows', function(){
+	describe('getting Rows', function() {
+		it('should get Rows', function() {
 			expect(grid.getRow()).toBe(null);
 			expect(grid.getRows(grid.rows[0].entity)).toBe(grid.rows[0]);
 			expect(grid.getRows(grid.rows[0].entity), [grid.rows[0]]).toBe(grid.rows[0]);
 		});
 
-		it('should get Rows by key', function(){
+		it('should get Rows by key', function() {
 			grid.rows[0].entity = {str: 'abc', num: 123, nll: null, multi: true};
 			grid.rows[1].entity = {multi: true};
 			grid.rows[0].str = 'abc';
@@ -356,7 +356,7 @@ describe('Grid factory', function() {
 			expect(grid.getRowsByKey(true, "innerMulti", false).length).toBe(2);
 		});
 
-		it('should find first Row by key', function(){
+		it('should find first Row by key', function() {
 			grid.rows[0].entity = {str: 'abc', num: 123, nll: null, multi: true};
 			grid.rows[1].entity = {multi: true};
 			grid.rows[0].str = 'abc';

--- a/packages/core/test/core/factories/Grid.spec.js
+++ b/packages/core/test/core/factories/Grid.spec.js
@@ -324,6 +324,64 @@ describe('Grid factory', function() {
 		});
 	});
 
+	describe('getting Rows', function(){
+		it('should get Rows', function(){
+			expect(grid.getRow()).toBe(null);
+			expect(grid.getRows(grid.rows[0].entity)).toBe(grid.rows[0]);
+			expect(grid.getRows(grid.rows[0].entity), [grid.rows[0]]).toBe(grid.rows[0]);
+		});
+
+		it('should get Rows by key', function(){
+			grid.rows[0].entity = {str: 'abc', num: 123, nll: null, multi: true};
+			grid.rows[1].entity = {multi: true};
+			grid.rows[0].str = 'abc';
+			grid.rows[0].num = 123;
+			grid.rows[0].nll = null;
+			grid.rows[0].innerMulti = false;
+			grid.rows[1].innerMulti = false;
+
+			expect(grid.getRowsByKey()).toBe(null);
+			expect(grid.getRowsByKey(true, "test")).toBe(null);
+			expect(grid.getRowsByKey(true, "str", "abc")).toBe([grid.rows[0]]);
+			expect(grid.getRowsByKey(true, "str", "def")).toBe(null);
+			expect(grid.getRowsByKey(true, "num", 123)).toBe([grid.rows[0]]);
+			expect(grid.getRowsByKey(true, "nll", null)).toBe([grid.rows[0]]);
+			expect(grid.getRowsByKey(true, "multi", true).length).toBe(2);
+
+			expect(grid.getRowsByKey(false, "test")).toBe(null);
+			expect(grid.getRowsByKey(false, "str", "abc")).toBe([grid.rows[0]]);
+			expect(grid.getRowsByKey(false, "str", "def")).toBe(null);
+			expect(grid.getRowsByKey(false, "num", 123)).toBe([grid.rows[0]]);
+			expect(grid.getRowsByKey(false, "nll", null)).toBe([grid.rows[0]]);
+			expect(grid.getRowsByKey(true, "innerMulti", false).length).toBe(2);
+		});
+
+		it('should find first Row by key', function(){
+			grid.rows[0].entity = {str: 'abc', num: 123, nll: null, multi: true};
+			grid.rows[1].entity = {multi: true};
+			grid.rows[0].str = 'abc';
+			grid.rows[0].num = 123;
+			grid.rows[0].nll = null;
+			grid.rows[0].innerMulti = false;
+			grid.rows[1].innerMulti = false;
+
+			expect(grid.findRowByKey()).toBe(null);
+			expect(grid.findRowByKey(true, "test")).toBe(null);
+			expect(grid.findRowByKey(true, "str", "abc")).toBe([grid.rows[0]]);
+			expect(grid.findRowByKey(true, "str", "def")).toBe(null);
+			expect(grid.findRowByKey(true, "num", 123)).toBe([grid.rows[0]]);
+			expect(grid.findRowByKey(true, "nll", null)).toBe([grid.rows[0]]);
+			expect(grid.findRowByKey(true, "multi", true).length).toBe(1);
+
+			expect(grid.findRowByKey(false, "test")).toBe(null);
+			expect(grid.findRowByKey(false, "str", "abc")).toBe([grid.rows[0]]);
+			expect(grid.findRowByKey(false, "str", "def")).toBe(null);
+			expect(grid.findRowByKey(false, "num", 123)).toBe([grid.rows[0]]);
+			expect(grid.findRowByKey(false, "nll", null)).toBe([grid.rows[0]]);
+			expect(grid.findRowByKey(true, "innerMulti", false).length).toBe(1);
+		});
+	})
+
 	describe('buildColumns', function() {
 		it('guess correct column types when not specified', function() {
 			var dataRow = {str: 'abc', num: 123, dat: new Date(), bool: true, obj: {}, nll: null, negNum: -1, posNum: +1};

--- a/packages/core/test/core/factories/Grid.spec.js
+++ b/packages/core/test/core/factories/Grid.spec.js
@@ -327,8 +327,8 @@ describe('Grid factory', function() {
 	describe('getting Rows', function() {
 		it('should get Rows', function() {
 			expect(grid.getRow()).toBe(null);
-			expect(grid.getRows(grid.rows[0].entity)).toBe(grid.rows[0]);
-			expect(grid.getRows(grid.rows[0].entity), [grid.rows[0]]).toBe(grid.rows[0]);
+			expect(grid.getRow(grid.rows[0].entity)).toBe(grid.rows[0]);
+			expect(grid.getRow(grid.rows[0].entity), [grid.rows[0]]).toBe(grid.rows[0]);
 		});
 
 		it('should get Rows by key', function() {
@@ -341,19 +341,19 @@ describe('Grid factory', function() {
 			grid.rows[1].innerMulti = false;
 
 			expect(grid.getRowsByKey()).toBe(null);
-			expect(grid.getRowsByKey(true, "test")).toBe(null);
-			expect(grid.getRowsByKey(true, "str", "abc")).toBe([grid.rows[0]]);
-			expect(grid.getRowsByKey(true, "str", "def")).toBe(null);
-			expect(grid.getRowsByKey(true, "num", 123)).toBe([grid.rows[0]]);
-			expect(grid.getRowsByKey(true, "nll", null)).toBe([grid.rows[0]]);
+			expect(grid.getRowsByKey(true, "test")).toEqual([]);
+			expect(grid.getRowsByKey(true, "str", "abc")[0].entity).toBe(grid.rows[0].entity);
+			expect(grid.getRowsByKey(true, "str", "def")).toEqual([]);
+			expect(grid.getRowsByKey(true, "num", 123)[0].entity).toBe(grid.rows[0].entity);
+			expect(grid.getRowsByKey(true, "nll", null)[0].entity).toBe(grid.rows[0].entity);
 			expect(grid.getRowsByKey(true, "multi", true).length).toBe(2);
 
-			expect(grid.getRowsByKey(false, "test")).toBe(null);
-			expect(grid.getRowsByKey(false, "str", "abc")).toBe([grid.rows[0]]);
-			expect(grid.getRowsByKey(false, "str", "def")).toBe(null);
-			expect(grid.getRowsByKey(false, "num", 123)).toBe([grid.rows[0]]);
-			expect(grid.getRowsByKey(false, "nll", null)).toBe([grid.rows[0]]);
-			expect(grid.getRowsByKey(true, "innerMulti", false).length).toBe(2);
+			expect(grid.getRowsByKey(false, "test")).toEqual([]);
+			expect(grid.getRowsByKey(false, "str", "abc")).toEqual([grid.rows[0]]);
+			expect(grid.getRowsByKey(false, "str", "def")).toEqual([]);
+			expect(grid.getRowsByKey(false, "num", 123)).toEqual([grid.rows[0]]);
+			expect(grid.getRowsByKey(false, "nll", null)).toEqual([grid.rows[0]]);
+			expect(grid.getRowsByKey(false, "innerMulti", false).length).toBe(2);
 		});
 
 		it('should find first Row by key', function() {
@@ -367,18 +367,18 @@ describe('Grid factory', function() {
 
 			expect(grid.findRowByKey()).toBe(null);
 			expect(grid.findRowByKey(true, "test")).toBe(null);
-			expect(grid.findRowByKey(true, "str", "abc")).toBe([grid.rows[0]]);
+			expect(grid.findRowByKey(true, "str", "abc").entity).toBe(grid.rows[0].entity);
 			expect(grid.findRowByKey(true, "str", "def")).toBe(null);
-			expect(grid.findRowByKey(true, "num", 123)).toBe([grid.rows[0]]);
-			expect(grid.findRowByKey(true, "nll", null)).toBe([grid.rows[0]]);
-			expect(grid.findRowByKey(true, "multi", true).length).toBe(1);
+			expect(grid.findRowByKey(true, "num", 123).entity).toBe(grid.rows[0].entity);
+			expect(grid.findRowByKey(true, "nll", null).entity).toBe(grid.rows[0].entity);
+			expect(grid.findRowByKey(true, "multi", true).entity).toBe(grid.rows[0].entity);
 
 			expect(grid.findRowByKey(false, "test")).toBe(null);
-			expect(grid.findRowByKey(false, "str", "abc")).toBe([grid.rows[0]]);
+			expect(grid.findRowByKey(false, "str", "abc")).toBe(grid.rows[0]);
 			expect(grid.findRowByKey(false, "str", "def")).toBe(null);
-			expect(grid.findRowByKey(false, "num", 123)).toBe([grid.rows[0]]);
-			expect(grid.findRowByKey(false, "nll", null)).toBe([grid.rows[0]]);
-			expect(grid.findRowByKey(true, "innerMulti", false).length).toBe(1);
+			expect(grid.findRowByKey(false, "num", 123)).toBe(grid.rows[0]);
+			expect(grid.findRowByKey(false, "nll", null)).toBe(grid.rows[0]);
+			expect(grid.findRowByKey(false, "innerMulti", false).entity).toBe(grid.rows[0].entity);
 		});
 	})
 

--- a/packages/selection/src/js/selection.js
+++ b/packages/selection/src/js/selection.js
@@ -233,7 +233,7 @@
                 selectRowByVisibleIndex: function (rowNum, evt) {
                   var row = grid.renderContainers.body.visibleRowCache[rowNum];
                   if (row != void 0 && row !== null && typeof (row) !== 'undefined' && !row.isSelected) {
-                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect, false));
+                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect, false);
                   }
                 },
                 /**

--- a/packages/selection/src/js/selection.js
+++ b/packages/selection/src/js/selection.js
@@ -201,7 +201,7 @@
                  */
                 toggleRowSelection: function (rowEntity, evt) {
                   var row = grid.getRow(rowEntity);
-                  if (row !== null) {
+                  if (row != void 0) {
                     service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
                   }
                 },
@@ -215,7 +215,7 @@
                  */
                 selectRow: function (rowEntity, evt) {
                   var row = grid.getRow(rowEntity);
-                  if (row !== null && !row.isSelected) {
+                  if (row != void 0 && !row.isSelected) {
                     service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
                   }
                 },
@@ -232,7 +232,7 @@
                  */
                 selectRowByVisibleIndex: function (rowNum, evt) {
                   var row = grid.renderContainers.body.visibleRowCache[rowNum];
-                  if (row !== null && typeof (row) !== 'undefined' && !row.isSelected) {
+                  if (row != void 0 && !row.isSelected) {
                     service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
                   }
                 },
@@ -249,7 +249,7 @@
                 */
                 selectRowByKey: function (isInEntity, key, comparator, evt, lookInRows) {
                   var row = grid.findRowByKey(isInEntity, key, comparator, lookInRows);
-                  if (row !== null && !row.isSelected) {
+                  if (row != void 0 && !row.isSelected) {
                     service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
                   }
                 },
@@ -263,7 +263,7 @@
                  */
                 unSelectRow: function (rowEntity, evt) {
                   var row = grid.getRow(rowEntity);
-                  if (row !== null && row.isSelected) {
+                  if (row != void 0 && row.isSelected) {
                     service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
                   }
                 },
@@ -280,7 +280,7 @@
                  */
                 unSelectRowByVisibleIndex: function (rowNum, evt) {
                   var row = grid.renderContainers.body.visibleRowCache[rowNum];
-                  if (row !== null && typeof (row) !== 'undefined' && row.isSelected) {
+                  if (row != void 0 && row.isSelected) {
                     service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
                   }
                 },
@@ -297,7 +297,7 @@
                 */
                 unSelectRowByKey: function (isInEntity, key, comparator, evt, lookInRows) {
                   var row = grid.findRowByKey(isInEntity, key, comparator, lookInRows);
-                  if (row !== null && !row.isSelected) {
+                  if (row != void 0 && row.isSelected) {
                     service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
                   }
                 },

--- a/packages/selection/src/js/selection.js
+++ b/packages/selection/src/js/selection.js
@@ -238,6 +238,23 @@
                 },
                 /**
                  * @ngdoc function
+                 * @name selectRowByKey
+                 * @methodOf  ui.grid.selection.api:PublicApi
+                 * @description Select the data row
+                 * @param {boolean} isInEntity if true then key is in entity else it's directly in row
+                 * @param {Symbol} key the key to look for
+                 * @param {any} comparator the value that key should have
+                 * @param {Event} evt object if raised from an event
+                 * @param {array} lookInRows [optional] the rows to look in - if not provided then looks in grid.rows
+                */
+                selectRowByKey: function (isInEntity, key, comparator, evt, lookInRows) {
+                  var row = grid.findRowByKey(isInEntity, key, comparator, lookInRows);
+                  if (row !== null && !row.isSelected) {
+                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
+                  }
+                },
+                /**
+                 * @ngdoc function
                  * @name unSelectRow
                  * @methodOf  ui.grid.selection.api:PublicApi
                  * @description UnSelect the data row
@@ -264,6 +281,23 @@
                 unSelectRowByVisibleIndex: function (rowNum, evt) {
                   var row = grid.renderContainers.body.visibleRowCache[rowNum];
                   if (row !== null && typeof (row) !== 'undefined' && row.isSelected) {
+                    service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
+                  }
+                },
+                /**
+                 * @ngdoc function
+                 * @name unSelectRowByKey
+                 * @methodOf  ui.grid.selection.api:PublicApi
+                 * @description Select the data row
+                 * @param {boolean} isInEntity if true then key is in entity else it's directly in row
+                 * @param {(string|number)} key the key to look for
+                 * @param {any} comparator the value that key should have
+                 * @param {Event} evt object if raised from an event
+                 * @param {array} lookInRows [optional] the rows to look in - if not provided then looks in grid.rows
+                */
+                unSelectRowByKey: function (isInEntity, key, comparator, evt, lookInRows) {
+                  var row = grid.findRowByKey(isInEntity, key, comparator, lookInRows);
+                  if (row !== null && !row.isSelected) {
                     service.toggleRowSelection(grid, row, evt, grid.options.multiSelect, grid.options.noUnselect);
                   }
                 },

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -197,6 +197,68 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 			grid.api.selection.selectRow(grid.rows[4].entity);
 			expect(grid.rows[4].isSelected).toBe(false);
 		});
+
+		it('select by key then unselect rows by key in entity, including selecting rows already selected and unselecting rows not selected', function() {
+			grid.rows[4].entity = {str: 'abc'};
+			grid.rows[6].entity = {str: 'def'};
+			grid.api.selection.selectRowByKey(true, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(true);
+
+			grid.api.selection.selectRowByKey(true, "str", "def");
+			expect(grid.rows[4].isSelected).toBe(true);
+			expect(grid.rows[6].isSelected).toBe(true);
+
+			grid.api.selection.selectRowByKey(true, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(true);
+			expect(grid.rows[6].isSelected).toBe(true);
+
+			grid.api.selection.unSelectRowByKey(true, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(false);
+			expect(grid.rows[6].isSelected).toBe(true);
+
+			grid.api.selection.unSelectRowByKey(true, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(false);
+			expect(grid.rows[6].isSelected).toBe(true);
+
+			grid.api.selection.unSelectRowByKey(true, "str", "def");
+			expect(grid.rows[4].isSelected).toBe(false);
+			expect(grid.rows[6].isSelected).toBe(false);
+
+			grid.rows[4].enableSelection = false;
+			grid.api.selection.selectRowByKey(true, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(false);
+		});
+
+		it('select by key then unselect rows by key outside entity, including selecting rows already selected and unselecting rows not selected', function() {
+			grid.rows[4] = {str: 'abc'};
+			grid.rows[6] = {str: 'def'};
+			grid.api.selection.selectRowByKey(false, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(true);
+
+			grid.api.selection.selectRowByKey(false, "str", "def");
+			expect(grid.rows[4].isSelected).toBe(true);
+			expect(grid.rows[6].isSelected).toBe(true);
+
+			grid.api.selection.selectRowByKey(false, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(true);
+			expect(grid.rows[6].isSelected).toBe(true);
+
+			grid.api.selection.unSelectRowByKey(false, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(false);
+			expect(grid.rows[6].isSelected).toBe(true);
+
+			grid.api.selection.unSelectRowByKey(false, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(false);
+			expect(grid.rows[6].isSelected).toBe(true);
+
+			grid.api.selection.unSelectRowByKey(false, "str", "def");
+			expect(grid.rows[4].isSelected).toBe(false);
+			expect(grid.rows[6].isSelected).toBe(false);
+
+			grid.rows[4].enableSelection = false;
+			grid.api.selection.selectRowByKey(false, "str", "abc");
+			expect(grid.rows[4].isSelected).toBe(false);
+		});
 	});
 
 	describe('setSelected function', function() {

--- a/packages/selection/test/uiGridSelectionService.spec.js
+++ b/packages/selection/test/uiGridSelectionService.spec.js
@@ -230,8 +230,9 @@ describe('ui.grid.selection uiGridSelectionService', function() {
 		});
 
 		it('select by key then unselect rows by key outside entity, including selecting rows already selected and unselecting rows not selected', function() {
-			grid.rows[4] = {str: 'abc'};
-			grid.rows[6] = {str: 'def'};
+			grid.rows[4].str = 'abc';
+			grid.rows[6].str = 'def';
+
 			grid.api.selection.selectRowByKey(false, "str", "abc");
 			expect(grid.rows[4].isSelected).toBe(true);
 


### PR DESCRIPTION
- fixes #4457
- I added find and select
- not just in entity but also in row object itself
- I can't guess what the id field of the user really is written, so after all keys can be searched
- new getter functions: _getRowsByKey_ and _findRowByKey_ (find returns only the first row which is more performant, User is responsible that this field is unique)
- new selector functions: _selectRowByKey_ and _unSelectRowByKey_, they both use findRowByKey
- all of them need following arguments: 
  - isInEntity(boolean) toggles between row and entity object
  - key(string or number) the specific key to the value
  - comparator(any) the specific value, can be anything
  - lookInRows(Array)(optional) same as in getRow(), search this instead of grid.rows