### PR TITLE
fix: clear selection function

### DIFF
--- a/packages/selection/src/js/selection.js
+++ b/packages/selection/src/js/selection.js
@@ -708,7 +708,7 @@
         clearSelectedRows: function (grid, evt) {
           var changedRows = [];
           service.getSelectedRows(grid).forEach(function (row) {
-            if (row.isSelected && row.enableSelection !== false && grid.options.isRowSelectable(row) !== false) {
+            if (row.isSelected && row.enableSelection !== false) {
               row.setSelected(false);
               service.decideRaiseSelectionEvent(grid, row, changedRows, evt);
             }


### PR DESCRIPTION
fix: issue when you clear the selected rows

I think is not necessary know if the row is selectable or not, I'm having on issue related to it. Imagine you have a select dropdown with actions to perform to the rows selected, you select some rows but then you change the action to perform and this new action is not allowed to some of the rows previously selected, the function is not going to clear up those rows because they are selected and then they are not selectables.