### PR TITLE
fix: 7206 double click column header doesn't make column wide enough

### DIFF
--- a/packages/resize-columns/src/js/ui-grid-column-resizer.js
+++ b/packages/resize-columns/src/js/ui-grid-column-resizer.js
@@ -525,7 +525,7 @@
                 var e = angular.element(newElm);
                 e.attr('style', 'float: left');
 
-                var width = gridUtil.elementWidth(e);
+                var width = gridUtil.elementWidth(e) + 2;
 
                 if (menuButton) {
                   var menuButtonWidth = gridUtil.elementWidth(menuButton);


### PR DESCRIPTION
 - width gets adjusted so that ellipses aren't shown
#7206