### PR TITLE
fix(pinning): blank space between pinnedRight column and last unpinned column

### DIFF
--- a/packages/core/src/js/factories/GridRenderContainer.js
+++ b/packages/core/src/js/factories/GridRenderContainer.js
@@ -601,12 +601,12 @@ angular.module('ui.grid')
       // Skip hidden columns
       if (!column.visible) { return; }
 
-      if (pinRightColumn) {
-        availableWidth += self.grid.scrollbarWidth;
-      }
-
       if (!pinRightColumn && column.colDef.pinnedRight) {
         pinRightColumn = true;
+      }
+
+      if (pinRightColumn) {
+        availableWidth += self.grid.scrollbarWidth;
       }
 
       if (angular.isNumber(column.width)) {


### PR DESCRIPTION
Change the order of conditionals to remove blank space between the last unpinned column and the pinned right column in order to fix the availableWidth behavior

#4949