### PR TITLE
fix: 🐛 don't call needLoadMoreData on last row with cellNav

### DIFF
--- a/packages/infinite-scroll/src/js/infinite-scroll.js
+++ b/packages/infinite-scroll/src/js/infinite-scroll.js
@@ -333,11 +333,14 @@
         grid.infiniteScroll.direction = grid.scrollDirection;
         delete grid.infiniteScroll.prevScrollTop;
 
-        if (grid.scrollDirection === uiGridConstants.scrollDirection.UP && grid.infiniteScroll.scrollUp ) {
+        if (grid.scrollDirection === uiGridConstants.scrollDirection.UP && grid.infiniteScroll.scrollUp) {
           grid.infiniteScroll.dataLoading = true;
           grid.api.infiniteScroll.raise.needLoadMoreDataTop();
         }
-        else if (grid.scrollDirection === uiGridConstants.scrollDirection.DOWN && grid.infiniteScroll.scrollDown ) {
+        else if (grid.scrollDirection === uiGridConstants.scrollDirection.DOWN && grid.infiniteScroll.scrollDown) {
+          if (grid.cellNav && grid.cellNav.lastRowCol && grid.cellNav.lastRowCol.row.index === grid.infiniteScroll.previousVisibleRows - 1) {
+            return;
+          }
           grid.infiniteScroll.dataLoading = true;
           grid.api.infiniteScroll.raise.needLoadMoreData();
         }

--- a/packages/infinite-scroll/test/infiniteScroll.spec.js
+++ b/packages/infinite-scroll/test/infiniteScroll.spec.js
@@ -345,6 +345,45 @@
           expect(grid.api.infiniteScroll.raise.needLoadMoreData).not.toHaveBeenCalled();
         });
       });
+      describe('cellNav and loadData', function() {
+        var arrayOf50 = [];
+        var VisibleRowCount = 50;
+        var lastRowIndex = 49;
+        beforeEach(function() {
+          grid.infiniteScroll = undefined;
+          uiGridInfiniteScrollService.initializeGrid(grid, $scope);
+          spyOn(grid, 'getVisibleRowCount').and.returnValue(VisibleRowCount);
+          spyOn(grid.api.infiniteScroll.raise, 'needLoadMoreData');
+          spyOn(grid.api.infiniteScroll.raise, 'needLoadMoreDataTop');
+          for ( var i = 0; i < VisibleRowCount; i++ ) {
+            arrayOf50.push(i);
+          }
+          grid.cellNav = {
+            lastRowCol: {
+              row: {
+                index: 0
+              }
+            }
+          };
+          grid.renderContainers = { body: { visibleRowCache: arrayOf50}};
+        });
+        afterEach(function() {
+          grid.api.infiniteScroll.raise.needLoadMoreData.calls.reset();
+          grid.api.infiniteScroll.raise.needLoadMoreDataTop.calls.reset();
+        });
+        it('scroll down and last row is currently selected', function() {
+          grid.scrollDirection = uiGridConstants.scrollDirection.DOWN;
+          grid.infiniteScroll.scrollDown = true;
+          grid.cellNav.lastRowCol.row.index = lastRowIndex;
+
+          uiGridInfiniteScrollService.loadData(grid);
+
+          expect(grid.infiniteScroll.previousVisibleRows).toEqual(grid.getVisibleRowCount());
+          expect(grid.api.infiniteScroll.raise.needLoadMoreData).not.toHaveBeenCalled();
+          expect(grid.infiniteScroll.direction).toEqual(uiGridConstants.scrollDirection.DOWN);
+        });
+      });
+
       describe('handleScroll', function() {
         describe('when the source is the even "ui.grid.adjustInfiniteScrollPosition"', function() {
           beforeEach(function() {


### PR DESCRIPTION
This change will prevent needLoadMoreData from being called on lastRow when cellNav is present. I did this because I was unable to edit the last row if both cellNav and infiniteScroll were present (caused infinte refresh loop with scrollDown).
