### PR TITLE
fix: 🐛 update the index accordingly when modifying existing rows

### DIFF
--- a/packages/core/src/js/factories/Grid.js
+++ b/packages/core/src/js/factories/Grid.js
@@ -1235,6 +1235,9 @@ angular.module('ui.grid')
       if ( oldRow ) {
         newRow = oldRow;
         newRow.entity = newEntity;
+        if (newRow.index !== i) {
+          newRow.index = i;
+        }
       }
 
       // if we didn't find the row, it must be new, so create it

--- a/packages/core/test/core/factories/Grid.spec.js
+++ b/packages/core/test/core/factories/Grid.spec.js
@@ -731,6 +731,18 @@ describe('Grid factory', function() {
 			expect(grid.rows[1].entity.str).toBe('xyz');
 			expect(grid.rows[2].entity.str).toBe('bac');
 		});
+
+		it('should delete and insert new in the middle', function() {
+			dataRows.splice(2, 0, {str: 'wwe'});
+			grid.modifyRows(dataRows);
+
+			expect(grid.getRow).not.toHaveBeenCalled();
+			expect(grid.rows.length).toBe(4);
+			expect(grid.rows[0].index).toBe(0);
+			expect(grid.rows[2].entity.str).toBe('wwe');
+      expect(grid.rows[3].entity.str).toBe('bac');
+			expect(grid.rows[3].index).toBe(3);
+		});
 	});
 
 	describe('binding', function() {


### PR DESCRIPTION
This change will update the index accordingly when newRow is added in modifyRows. I did this because index of row wasn't being updated properly when

- New row was added in the middle of rows
- More than two new rows were added

This fix resolves all the issues above.