### PR TITLE
chore(core): remove upper limit for angular dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
     "less-min": "lessc -rp=\"../\" --compress -x ./less/main.less dist/ui-grid.core.min.css"
   },
   "dependencies": {
-    "angular": ">=1.4.0 1.8.x"
+    "angular": ">=1.4.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The upper limit for `angular` prevents the [long-term support version of AngularJS](https://xlts.dev/angularjs) from being used. The current version there is 1.9.3.

This PR removes the upper limit.